### PR TITLE
fix(claw): update tool initialization to use Workspace type

### DIFF
--- a/claw/cmd/aiclaw/main.go
+++ b/claw/cmd/aiclaw/main.go
@@ -185,13 +185,14 @@ func main() {
 	}
 
 	// Create tool registry and register tools
-	// For claw (chat bot), we use clawDir as working directory since it's not tied to a specific project
+	// For claw (chat bot), we create a workspace with clawDir as working directory since it's not tied to a specific project
+	workspace := tools.MustNewWorkspace(clawDir)
 	toolRegistry := tools.NewRegistry()
-	toolRegistry.Register(tools.NewReadTool(clawDir))
-	toolRegistry.Register(tools.NewBashTool(clawDir))
-	toolRegistry.Register(tools.NewWriteTool(clawDir))
-	toolRegistry.Register(tools.NewGrepTool(clawDir))
-	toolRegistry.Register(tools.NewEditTool(clawDir))
+	toolRegistry.Register(tools.NewReadTool(workspace))
+	toolRegistry.Register(tools.NewBashTool(workspace))
+	toolRegistry.Register(tools.NewWriteTool(workspace))
+	toolRegistry.Register(tools.NewGrepTool(workspace))
+	toolRegistry.Register(tools.NewEditTool(workspace))
 
 	agentConfig := &adapter.Config{
 		Model:           cfg.Model.ID,


### PR DESCRIPTION
## Summary

Fix compilation error in `claw/cmd/aiclaw` by updating tool initialization to use the new `Workspace` type.

## Problem

After the refactoring in PR #2, the tool API changed to expect `*tools.Workspace` instead of `string` for the working directory parameter. This caused compilation errors:

```
cmd/aiclaw/main.go:190:42: cannot use clawDir (variable of type string) as *tools.Workspace value
cmd/aiclaw/main.go:191:42: cannot use clawDir (variable of type string) as *tools.Workspace value
...
```

## Changes

- Create a `Workspace` object using `tools.MustNewWorkspace(clawDir)`
- Update all tool registrations to use the workspace object instead of string
- Updated tools:
  - ReadTool
  - BashTool
  - WriteTool
  - GrepTool
  - EditTool

## Testing

```bash
cd claw
go build -o bin/aiclaw ./cmd/aiclaw
# Success: binary created (13,238,386 bytes)
```

## Compatibility

- Maintains backward compatibility with existing tool behavior
- The `Workspace` abstraction allows for dynamic directory changes (e.g., git worktrees)
- For claw, the working directory remains `~/.aiclaw`