### PR TITLE
fix(compact): ensure tool_call/tool_result pairing after compaction

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -826,7 +826,7 @@ func extractText(msg agentctx.AgentMessage) string {
 
 // ensureToolCallPairing ensures that tool_call and tool_result messages remain paired.
 // If a tool_result is in recentMessages but its corresponding tool_call is in oldMessages,
-// move the tool_result to oldMessages (it will be summarized).
+// the tool_result must be hidden (archived) so the API doesn't see a mismatch.
 // This prevents "tool call and result not match" errors after compaction.
 func ensureToolCallPairing(oldMessages, recentMessages []agentctx.AgentMessage) []agentctx.AgentMessage {
 	if len(recentMessages) == 0 {
@@ -849,39 +849,27 @@ func ensureToolCallPairing(oldMessages, recentMessages []agentctx.AgentMessage) 
 	}
 
 	// Find tool_results in recentMessages whose tool_call is in oldMessages
-	// These need to be moved to oldMessages
+	// These need to be hidden (archived) because their tool_calls will be summarized
 	keptMessages := make([]agentctx.AgentMessage, 0, len(recentMessages))
-	movedToOld := make([]agentctx.AgentMessage, 0)
+	archivedCount := 0
 
 	for _, msg := range recentMessages {
 		if msg.Role == "toolResult" && msg.ToolCallID != "" {
 			if oldToolCallIDs[msg.ToolCallID] {
-				// This tool_result's call is in oldMessages, move it there
-				movedToOld = append(movedToOld, msg)
+				// This tool_result's call is in oldMessages - hide it to prevent mismatch
+				archivedMsg := msg.WithVisibility(false, msg.IsUserVisible()).WithKind("tool_result_archived")
+				keptMessages = append(keptMessages, archivedMsg)
+				archivedCount++
 				continue
 			}
 		}
 		keptMessages = append(keptMessages, msg)
 	}
 
-	if len(movedToOld) > 0 {
+	if archivedCount > 0 {
 		slog.Info("[Compact] Fixed tool_call/tool_result pairing",
-			"moved_to_old", len(movedToOld),
-			"kept_in_recent", len(keptMessages))
-		// Note: We can't actually modify oldMessages here, but we log the issue
-		// The tool_result will be hidden from the LLM but still present
-		// This prevents the "not match" error while keeping the summary context
-
-		// Alternative: mark these as archived instead of removing
-		// This way they're not visible to LLM but API can still match them
-		for i := range keptMessages {
-			msg := &keptMessages[i]
-			if msg.Role == "toolResult" && msg.ToolCallID != "" {
-				if oldToolCallIDs[msg.ToolCallID] {
-					*msg = msg.WithVisibility(false, msg.IsUserVisible()).WithKind("tool_result_archived")
-				}
-			}
-		}
+			"archived", archivedCount,
+			"kept", len(keptMessages))
 	}
 
 	return keptMessages

--- a/pkg/compact/compact_tool_pairing_test.go
+++ b/pkg/compact/compact_tool_pairing_test.go
@@ -1,0 +1,200 @@
+package compact
+
+import (
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"testing"
+
+	"github.com/tiancaiamao/ai/pkg/llm"
+)
+
+// TestEnsureToolCallPairing_Bug demonstrates the bug where tool_call is in oldMessages
+// but its tool_result is visible in recentMessages, causing "tool call and result not match"
+func TestEnsureToolCallPairing_Bug(t *testing.T) {
+	// Scenario: tool_call in oldMessages, tool_result in recentMessages
+	// The tool_call will be summarized (not visible), so tool_result should also be hidden
+	
+	oldMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call-123",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/test.txt"},
+				},
+			},
+		},
+	}
+
+	recentMessages := []agentctx.AgentMessage{
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-123",
+			ToolName:   "read",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "file content here"},
+			},
+		},
+		agentctx.NewUserMessage("next user message"),
+	}
+
+	result := ensureToolCallPairing(oldMessages, recentMessages)
+
+	// After fix: tool_result should be hidden because its tool_call is in oldMessages (will be summarized)
+	// The bug was that tool_result remained visible, causing "tool call and result not match"
+	
+	// Check that tool_result is hidden
+	toolResultFound := false
+	for _, msg := range result {
+		if msg.Role == "toolResult" && msg.ToolCallID == "call-123" {
+			toolResultFound = true
+			if msg.IsAgentVisible() {
+				t.Error("BUG: tool_result should be hidden when its tool_call is in oldMessages (will be summarized)")
+			}
+		}
+	}
+	
+	if !toolResultFound {
+		t.Error("tool_result should still be present in messages (just hidden)")
+	}
+}
+
+// TestEnsureToolCallPairing_CorrectPairing tests that correctly paired messages stay visible
+func TestEnsureToolCallPairing_CorrectPairing(t *testing.T) {
+	// Scenario: both tool_call and tool_result in recentMessages - should stay visible
+	recentMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call-456",
+					Type: "toolCall",
+					Name: "write",
+					Arguments: map[string]any{"path": "/test.txt", "content": "hello"},
+				},
+			},
+		},
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-456",
+			ToolName:   "write",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "ok"},
+			},
+		},
+	}
+
+	// Empty oldMessages - no tool_calls to be summarized
+	oldMessages := []agentctx.AgentMessage{}
+	
+	result := ensureToolCallPairing(oldMessages, recentMessages)
+
+	// Both should remain visible
+	if len(result) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(result))
+	}
+	
+	for _, msg := range result {
+		if !msg.IsAgentVisible() {
+			t.Error("messages with tool_call in recentMessages should stay visible")
+		}
+	}
+}
+
+// TestEnsureToolCallPairing_NoToolCallsInOldMessages tests edge case
+func TestEnsureToolCallPairing_NoToolCallsInOldMessages(t *testing.T) {
+	// Scenario: oldMessages has no tool_calls, recentMessages has tool_result
+	oldMessages := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("some old message"),
+	}
+
+	recentMessages := []agentctx.AgentMessage{
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-789",
+			ToolName:   "read",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "result"},
+			},
+		},
+	}
+
+	result := ensureToolCallPairing(oldMessages, recentMessages)
+
+	// Tool_result should stay visible (its call might be in an even older message, 
+	// or it's orphaned - either way it's not being summarized)
+	if len(result) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result))
+	}
+	
+	if !result[0].IsAgentVisible() {
+		t.Error("tool_result should stay visible when oldMessages has no tool_calls")
+	}
+}
+
+// TestFullCompactPreservesPairing tests the full compaction flow preserves tool_call/tool_result pairing
+func TestFullCompactPreservesPairing(t *testing.T) {
+	config := &Config{
+		MaxMessages:        10,
+		MaxTokens:          1000,
+		KeepRecent:         2,
+		KeepRecentTokens:   100,
+		AutoCompact:        true,
+	}
+
+	compactor := NewCompactor(config, llm.Model{}, "", "", 0)
+
+	// Create messages: 1 user + tool_call + tool_result + 1 user
+	// The tool_call and tool_result should end up in the same visibility state after compaction
+	messages := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("first message"),
+		// tool_call
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call-full-1",
+					Type: "toolCall",
+					Name: "bash",
+					Arguments: map[string]any{"command": "ls"},
+				},
+			},
+		},
+		// tool_result
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-full-1",
+			ToolName:   "bash",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "file1\nfile2\nfile3"},
+			},
+		},
+		agentctx.NewUserMessage("last message"),
+	}
+
+	result, err := compactor.Compact(messages, "")
+	if err != nil {
+		t.Fatalf("Compact failed: %v", err)
+	}
+
+	// After compaction, check that all tool_results have their corresponding tool_calls visible
+	// Collect all visible tool_call IDs
+	visibleToolCalls := make(map[string]bool)
+	for _, msg := range result.Messages {
+		if msg.Role == "assistant" && msg.IsAgentVisible() {
+			for _, tc := range msg.ExtractToolCalls() {
+				visibleToolCalls[tc.ID] = true
+			}
+		}
+	}
+
+	// Check all visible tool_results have their tool_calls visible
+	for _, msg := range result.Messages {
+		if msg.Role == "toolResult" && msg.IsAgentVisible() {
+			if !visibleToolCalls[msg.ToolCallID] {
+				t.Errorf("BUG: tool_result with id %s is visible but its tool_call is not visible", msg.ToolCallID)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes issue #10 - 'tool call and result not match (2013)' error after auto-compaction.

## Root Cause

The  function in  had a bug:
1. It used  to skip adding tool_results to , effectively removing them from the message list
2. A subsequent loop tried to mark remaining messages as hidden, but the tool_results were already gone
3. After compaction, visible tool_results remained without their corresponding tool_calls (which were summarized), causing the API error

## Fix

Rewrote  to properly archive tool_results:
- When a tool_result's corresponding tool_call is in oldMessages (to be summarized), create a hidden copy with 
- The tool_result remains in the message list but is hidden from the LLM
- This prevents the API from seeing a mismatch while preserving the message structure

## Changes

- : Fixed  function
- : Added comprehensive tests

## Tests Added

- : Verifies tool_results are properly hidden when their tool_calls are in oldMessages
- : Verifies correctly paired messages stay visible
- : Edge case test
- : End-to-end test for the full compaction flow

## Acceptance Criteria

- [x] No 'tool call and result not match' error after auto-compaction
- [x] tool_call and tool_result messages remain correctly paired after compaction