### PR TITLE
fix: avoid stale env key after model-select for glm-5

### DIFF
--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -35,26 +35,58 @@ func ResolveAPIKey(provider string) (string, error) {
 	}
 
 	envVar := strings.ToUpper(providerKey) + "_API_KEY"
-	if value := strings.TrimSpace(os.Getenv(envVar)); value != "" {
-		return value, nil
+	envValue := strings.TrimSpace(os.Getenv(envVar))
+
+	authValue, authPath, authErr := resolveAPIKeyFromAuth(providerKey)
+	preferEnv := strings.EqualFold(strings.TrimSpace(os.Getenv("AI_API_KEY_SOURCE")), "env")
+
+	// Default to auth-first to avoid stale shell env overriding managed auth.json.
+	if preferEnv {
+		if envValue != "" {
+			return envValue, nil
+		}
+		if authValue != "" {
+			return authValue, nil
+		}
+	} else {
+		if authValue != "" {
+			return authValue, nil
+		}
+		if envValue != "" {
+			return envValue, nil
+		}
 	}
 
+	if authErr != nil {
+		return "", authErr
+	}
+	if authPath == "" {
+		var err error
+		authPath, err = GetDefaultAuthPath()
+		if err != nil {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("set %s or add %s", envVar, authPath)
+}
+
+func resolveAPIKeyFromAuth(providerKey string) (string, string, error) {
 	authPath, err := GetDefaultAuthPath()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	data, err := os.ReadFile(authPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("set %s or add %s", envVar, authPath)
+			return "", authPath, nil
 		}
-		return "", fmt.Errorf("failed to read auth file: %w", err)
+		return "", authPath, fmt.Errorf("failed to read auth file: %w", err)
 	}
 
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return "", fmt.Errorf("failed to parse auth file: %w", err)
+		return "", authPath, fmt.Errorf("failed to parse auth file: %w", err)
 	}
 
 	entryRaw, ok := raw[providerKey]
@@ -68,30 +100,30 @@ func ResolveAPIKey(provider string) (string, error) {
 		}
 	}
 	if !ok {
-		return "", fmt.Errorf("no credentials for %q in %s", providerKey, authPath)
+		return "", authPath, nil
 	}
 
 	var key string
 	if err := json.Unmarshal(entryRaw, &key); err == nil {
 		key = strings.TrimSpace(key)
 		if key != "" {
-			return key, nil
+			return key, authPath, nil
 		}
 	}
 
 	var entry AuthEntry
 	if err := json.Unmarshal(entryRaw, &entry); err != nil {
-		return "", fmt.Errorf("invalid auth entry for %q in %s", providerKey, authPath)
+		return "", authPath, fmt.Errorf("invalid auth entry for %q in %s", providerKey, authPath)
 	}
 	if entry.APIKey != "" {
-		return entry.APIKey, nil
+		return strings.TrimSpace(entry.APIKey), authPath, nil
 	}
 	if entry.Key != "" {
-		return entry.Key, nil
+		return strings.TrimSpace(entry.Key), authPath, nil
 	}
 	if entry.Token != "" {
-		return entry.Token, nil
+		return strings.TrimSpace(entry.Token), authPath, nil
 	}
 
-	return "", fmt.Errorf("empty credentials for %q in %s", providerKey, authPath)
+	return "", authPath, fmt.Errorf("empty credentials for %q in %s", providerKey, authPath)
 }

--- a/pkg/config/auth_test.go
+++ b/pkg/config/auth_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAPIKey_PrefersAuthByDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ZAI_API_KEY", "env-key")
+	t.Setenv("AI_API_KEY_SOURCE", "")
+
+	authPath := filepath.Join(home, ".ai", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0755); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	if err := os.WriteFile(authPath, []byte(`{"zai":{"key":"auth-key"}}`), 0644); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	key, err := ResolveAPIKey("zai")
+	if err != nil {
+		t.Fatalf("ResolveAPIKey returned error: %v", err)
+	}
+	if key != "auth-key" {
+		t.Fatalf("expected auth key, got %q", key)
+	}
+}
+
+func TestResolveAPIKey_PreferEnvWhenConfigured(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ZAI_API_KEY", "env-key")
+	t.Setenv("AI_API_KEY_SOURCE", "env")
+
+	authPath := filepath.Join(home, ".ai", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0755); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	if err := os.WriteFile(authPath, []byte(`{"zai":{"key":"auth-key"}}`), 0644); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	key, err := ResolveAPIKey("zai")
+	if err != nil {
+		t.Fatalf("ResolveAPIKey returned error: %v", err)
+	}
+	if key != "env-key" {
+		t.Fatalf("expected env key, got %q", key)
+	}
+}
+
+func TestResolveAPIKey_FallsBackToEnvWhenAuthMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MINIMAX_API_KEY", "minimax-env-key")
+	t.Setenv("AI_API_KEY_SOURCE", "")
+
+	key, err := ResolveAPIKey("minimax")
+	if err != nil {
+		t.Fatalf("ResolveAPIKey returned error: %v", err)
+	}
+	if key != "minimax-env-key" {
+		t.Fatalf("expected env fallback key, got %q", key)
+	}
+}
+
+func TestResolveAPIKey_FallsBackToAuthWhenEnvMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("AI_API_KEY_SOURCE", "")
+
+	authPath := filepath.Join(home, ".ai", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0755); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	if err := os.WriteFile(authPath, []byte(`{"openrouter":{"apiKey":"or-auth-key"}}`), 0644); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	key, err := ResolveAPIKey("openrouter")
+	if err != nil {
+		t.Fatalf("ResolveAPIKey returned error: %v", err)
+	}
+	if key != "or-auth-key" {
+		t.Fatalf("expected auth fallback key, got %q", key)
+	}
+}


### PR DESCRIPTION
## Summary
- fix API key resolution precedence to prefer `~/.ai/auth.json` by default
- keep env override available via `AI_API_KEY_SOURCE=env`
- add tests for auth/env precedence and fallback behavior

## Why
`/model-select` switching to `zai/glm-5` could be affected by stale `ZAI_API_KEY` in process env. This makes key source deterministic and avoids accidental 401 from outdated shell env.

Closes #14
