### PR TITLE
Fix llm_context_decision: skip already truncated tool outputs

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -737,11 +737,14 @@ func streamAssistantResponse(
 	// Inject decision reminder if LLM updated overview but didn't call llm_context_decision tool
 	// This is separate from overview update reminder - it triggers when decision is needed but not made
 	if agentCtx.LLMContext != nil && agentCtx.LLMContext.NeedsDecisionReminder() {
-		// Get stale count for reminder
+		// Get stale count and available tool IDs for reminder
 		staleCount, _ := collectStaleToolOutputStats(agentCtx.Messages, recentToolResultsNoMetadata)
 		agentCtx.LLMContext.SetStaleToolCount(staleCount)
 
-		decisionReminderContent := agentCtx.LLMContext.GetDecisionReminderMessage()
+		// Get available (non-truncated) tool IDs to include in reminder example
+		_, availableToolIDs := buildToolOutputsSummaryWithIDs(agentCtx.Messages)
+
+		decisionReminderContent := agentCtx.LLMContext.GetDecisionReminderMessage(availableToolIDs)
 		decisionReminderMsg := llm.LLMMessage{
 			Role:    "user",
 			Content: decisionReminderContent,

--- a/pkg/agent/tool_metadata.go
+++ b/pkg/agent/tool_metadata.go
@@ -141,3 +141,75 @@ func buildToolOutputsSummary(messages []agentctx.AgentMessage) string {
 
 	return fmt.Sprintf("%d stale outputs (%s), consider TRUNCATE", staleCount, strings.Join(parts, ", "))
 }
+
+// buildToolOutputsSummaryWithIDs returns summary and list of tool call IDs that can be truncated.
+// It excludes already truncated tool outputs.
+func buildToolOutputsSummaryWithIDs(messages []agentctx.AgentMessage) (string, []string) {
+	staleCount, byTool := collectStaleToolOutputStats(messages, recentToolResultsNoMetadata)
+	if staleCount == 0 || len(byTool) == 0 {
+		return "none", nil
+	}
+
+	// Collect tool call IDs for each tool type
+	toolIDsByTool := make(map[string][]string)
+	lastUserIndex := findLastVisibleUserIndex(messages)
+	protected := protectedRecentToolResultIndexes(messages, recentToolResultsNoMetadata)
+
+	for i, msg := range messages {
+		if !msg.IsAgentVisible() || msg.Role != "toolResult" {
+			continue
+		}
+		if i >= lastUserIndex {
+			continue
+		}
+		if _, ok := protected[i]; ok {
+			continue
+		}
+		if isTruncatedAgentToolTag(msg.ExtractText()) {
+			continue
+		}
+
+		name := strings.TrimSpace(msg.ToolName)
+		if name == "" {
+			name = "unknown"
+		}
+		toolIDsByTool[name] = append(toolIDsByTool[name], msg.ToolCallID)
+	}
+
+	// Build summary text
+	type pair struct {
+		name  string
+		count int
+	}
+	pairs := make([]pair, 0, len(byTool))
+	for name, count := range byTool {
+		pairs = append(pairs, pair{name: name, count: count})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].count == pairs[j].count {
+			return pairs[i].name < pairs[j].name
+		}
+		return pairs[i].count > pairs[j].count
+	})
+
+	limit := toolOutputSummaryTypeLimit
+	if len(pairs) < limit {
+		limit = len(pairs)
+	}
+	parts := make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		parts = append(parts, fmt.Sprintf("%d %s", pairs[i].count, pairs[i].name))
+	}
+	if len(pairs) > limit {
+		parts = append(parts, "...")
+	}
+
+	// Flatten all tool call IDs
+	var allIDs []string
+	for _, ids := range toolIDsByTool {
+		allIDs = append(allIDs, ids...)
+	}
+
+	summary := fmt.Sprintf("%d stale outputs (%s), consider TRUNCATE", staleCount, strings.Join(parts, ", "))
+	return summary, allIDs
+}

--- a/pkg/context/llm_context.go
+++ b/pkg/context/llm_context.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -719,9 +720,29 @@ func (wm *LLMContext) GetStaleToolCount() int {
 }
 
 // GetDecisionReminderMessage returns a user message reminder for llm_context_decision.
-func (wm *LLMContext) GetDecisionReminderMessage() string {
+func (wm *LLMContext) GetDecisionReminderMessage(availableToolIDs []string) string {
 	meta := wm.GetMeta()
 	staleCount := wm.GetStaleToolCount()
+
+	// Build truncate_ids example from available (non-truncated) tool IDs
+	var truncateIDsExample string
+	if len(availableToolIDs) > 0 {
+		// Show first few IDs as example, limit to 5 to avoid overwhelming
+		limit := 5
+		if len(availableToolIDs) < limit {
+			limit = len(availableToolIDs)
+		}
+		exampleIDs := make([]string, limit)
+		for i := 0; i < limit; i++ {
+			exampleIDs[i] = fmt.Sprintf(`"%s"`, availableToolIDs[i])
+		}
+		if len(availableToolIDs) > limit {
+			truncateIDsExample = fmt.Sprintf(`["%s", ...%d more IDs available in tool outputs]`,
+				strings.Join(exampleIDs, `", "`), len(availableToolIDs)-limit)
+		} else {
+			truncateIDsExample = fmt.Sprintf(`[%s]`, strings.Join(exampleIDs, ", "))
+		}
+	}
 
 	return fmt.Sprintf(`[system message by agent, not from real user]
 
@@ -742,13 +763,13 @@ HOW TO TRUNCATE (IMPORTANT):
 3. Pass them as truncate_ids array
 
 EXAMPLE (copy and modify):
-{"decision": "truncate", "reasoning": "Cleaning up %d stale tool outputs to free space", "truncate_ids": ["call_xxx1", "call_xxx2", "call_xxx3", ...50-100 IDs...]}
+{"decision": "truncate", "reasoning": "Cleaning up %d stale tool outputs to free space", "truncate_ids": %s}
 
 If you don't know IDs, use decision="skip" instead.`,
 		int(meta.TokensPercent), staleCount,
 		meta.TokensUsed, meta.TokensMax, meta.TokensPercent, meta.MessagesInHistory,
 		getSuggestedAction(meta.TokensPercent, staleCount),
-		staleCount)
+		staleCount, truncateIDsExample)
 }
 
 // getSuggestedAction returns suggested action based on token usage and stale outputs.

--- a/pkg/tools/llm_context_decision.go
+++ b/pkg/tools/llm_context_decision.go
@@ -354,3 +354,65 @@ func (t *LLMContextDecisionTool) shouldTruncate(toolCallID string, idsToTruncate
 	}
 	return false
 }
+
+// filterAlreadyTruncated filters out already truncated tool call IDs from the provided IDs.
+// This prevents LLM from trying to truncate the same tool output multiple times.
+func (t *LLMContextDecisionTool) filterAlreadyTruncated(ctx context.Context, agentCtx *agentctx.AgentContext, rawIDs any) []string {
+	if rawIDs == nil {
+		return nil
+	}
+
+	// Parse IDs from the input
+	var idsToFilter []string
+
+	// Handle string (comma-separated)
+	if idsStr, ok := rawIDs.(string); ok && idsStr != "" {
+		parts := strings.Split(idsStr, ",")
+		for _, part := range parts {
+			id := strings.TrimSpace(part)
+			if id != "" {
+				idsToFilter = append(idsToFilter, id)
+			}
+		}
+	}
+
+	// Handle array
+	if idsArray, ok := rawIDs.([]any); ok && len(idsArray) > 0 {
+		for _, id := range idsArray {
+			if idStr, ok := id.(string); ok && idStr != "" {
+				idsToFilter = append(idsToFilter, idStr)
+			}
+		}
+	}
+
+	if len(idsToFilter) == 0 {
+		return nil
+	}
+
+	// Filter out IDs that are already truncated
+	var filteredIDs []string
+	for _, id := range idsToFilter {
+		// Check if this tool output exists and is already truncated
+		alreadyTruncated := false
+		for _, msg := range agentCtx.Messages {
+			if msg.Role != "toolResult" {
+				continue
+			}
+			if strings.EqualFold(msg.ToolCallID, id) {
+				// Found the tool output, check if it's already truncated
+				if agentctx.IsTruncatedAgentToolTag(msg.ExtractText()) {
+					alreadyTruncated = true
+					slog.Debug("[LLMContextDecision] Skipping already truncated ID",
+						"tool_call_id", id)
+				}
+				break
+			}
+		}
+
+		if !alreadyTruncated {
+			filteredIDs = append(filteredIDs, id)
+		}
+	}
+
+	return filteredIDs
+}

--- a/pkg/tools/llm_context_decision_test.go
+++ b/pkg/tools/llm_context_decision_test.go
@@ -1,0 +1,88 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+func TestLLMContextDecisionFiltersAlreadyTruncated(t *testing.T) {
+	// Create test messages
+	messages := []agentctx.AgentMessage{
+		// Regular tool output (not truncated)
+		agentctx.NewToolResultMessage("call_1", "read", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "large content 1"},
+		}, false),
+
+		// Already truncated tool output
+		agentctx.NewToolResultMessage("call_2", "read", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: `<agent:tool id="call_2" name="read" chars="1000" truncated="true" />`},
+		}, false),
+
+		// Another regular tool output
+		agentctx.NewToolResultMessage("call_3", "grep", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "large content 3"},
+		}, false),
+
+		// Another already truncated tool output
+		agentctx.NewToolResultMessage("call_4", "bash", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: `<agent:tool id="call_4" name="bash" chars="2000" truncated="true" />`},
+		}, false),
+	}
+
+	tool := NewLLMContextDecisionTool(nil)
+
+	// Try to truncate all four tool outputs
+	ctx := context.Background()
+	agentCtx := &agentctx.AgentContext{
+		Messages:          messages,
+		ContextMgmtState:  agentctx.DefaultContextMgmtState(),
+		LLMContext:        nil,
+	}
+
+	params := map[string]any{
+		"decision":     "truncate",
+		"reasoning":    "Test filtering of already truncated outputs",
+		"truncate_ids": "call_1,call_2,call_3,call_4", // Include already truncated IDs
+	}
+
+	resultBlocks, err := tool.Execute(ctx, params)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	// Check result
+	if len(resultBlocks) == 0 {
+		t.Fatal("Expected result blocks, got none")
+	}
+
+	// Extract text from content block
+	resultText := ""
+	if tc, ok := resultBlocks[0].(agentctx.TextContent); ok {
+		resultText = tc.Text
+	}
+	t.Logf("Result: %s", resultText)
+
+	// Only call_1 and call_3 should be truncated (they weren't truncated yet)
+	// call_2 and call_4 should be skipped (already truncated)
+	for _, msg := range agentCtx.Messages {
+		if msg.Role != "toolResult" {
+			continue
+		}
+
+		content := msg.ExtractText()
+		switch msg.ToolCallID {
+		case "call_1", "call_3":
+			// Should be truncated now
+			if !agentctx.IsTruncatedAgentToolTag(content) {
+				t.Errorf("Message %s should be truncated but is not: %s", msg.ToolCallID, content)
+			}
+		case "call_2", "call_4":
+			// Were already truncated, should still be truncated
+			if !agentctx.IsTruncatedAgentToolTag(content) {
+				t.Errorf("Message %s should still be truncated but is not: %s", msg.ToolCallID, content)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 修复 llm_context_decision 重复 truncate 已 truncated 的工具输出

### 问题描述
llm_context_decision 调用时，发现已经 truncate 过的工具输出重复 truncate。

LLM 发送的 llm_context_decision 请求参数中，decision=truncate，truncate_ids 包含了很多已经被 truncated 的 tool outputs。这些工具输出的 metadata 中已经标记了 truncated="true"。

### 解决方案
1. 添加  函数，过滤掉已经 truncated 的工具输出 ID
2. 修改  显示可用（非 truncated）的工具 ID
3. 添加  辅助函数检查 truncated 状态

### 验收
- 已 truncated 的工具输出不再出现在 truncate_ids 中

Closes #18