### PR TITLE
feat: headless mode session info output

### DIFF
--- a/cmd/ai/headless_mode.go
+++ b/cmd/ai/headless_mode.go
@@ -357,6 +357,14 @@ Be concise and focused on the task at hand.`
 		args string
 	}
 
+	// Output session info at the start
+	fmt.Fprintf(output, "=== Session Info ===\n")
+	fmt.Fprintf(output, "Session ID: %s\n", sessionID)
+	if !noSession {
+		fmt.Fprintf(output, "Session file: %s\n", sess.GetPath())
+	}
+	fmt.Fprintln(output)
+
 	// Subscribe to events and output turn-by-turn
 	eventEmitterDone := make(chan struct{})
 	shutdownEmitter := make(chan struct{})


### PR DESCRIPTION
## Summary
- 在 ai --mode headless 运行时打印 Session ID 和 Session file 路径
- ai --mode headless --no-session 时不打印 Session file 路径

Closes #23