### PR TITLE
[WF] Fix deadlock in ai -win when sending large text (>64KB)

### DIFF
--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -347,6 +347,9 @@ func (s *Server) Run() error {
 // This method blocks until an error occurs or the reader is closed.
 func (s *Server) RunWithIO(reader io.Reader, writer io.Writer) error {
 	scanner := bufio.NewScanner(reader)
+	// Set larger buffer: 4MB initial, 16MB max to handle large JSON commands (>64KB)
+	buf := make([]byte, 0, 4*1024*1024) // 4MB
+	scanner.Buffer(buf, 16*1024*1024)   // 16MB max
 	s.setOutput(writer)
 
 	for scanner.Scan() {


### PR DESCRIPTION
Fixes #28

## Changes
- Fix RPC scanner buffer deadlock for large commands (>64KB)
- Set scanner buffer to 4MB initial, 16MB max in pkg/rpc/server.go
- Matches the pattern used in internal/winai/interpreter.go

## Problem
The scanner's default buffer size of 64KB causes a deadlock when ai -win receives large JSON-RPC commands (e.g., 180KB files sent via ;;).

## Solution
This fixes the issue by setting the scanner buffer to 4MB initial and 16MB max, ensuring that large single-line JSON commands can be read without deadlock.