### PR TITLE
Refactor prompt wiring and clean up prompt builder

### DIFF
--- a/cmd/ai/headless_mode.go
+++ b/cmd/ai/headless_mode.go
@@ -221,7 +221,7 @@ func runHeadless(sessionPath string, noSession bool, maxTurns int, allowedTools 
 		compactorConfig,
 		model,
 		apiKey,
-		"You are a helpful coding assistant.",
+		prompt.CompactorBasePrompt(),
 		currentContextWindow,
 	)
 	registerHeadlessTools(registry, ws, compactor)
@@ -241,18 +241,8 @@ func runHeadless(sessionPath string, noSession bool, maxTurns int, allowedTools 
 		IncludeDefaults: true,
 	})
 
-	// Create agent with skills using structured prompt builder
-	basePrompt := `You are a helpful coding assistant.
-When you need to inspect files or run commands, call the tools. Do not write tool markup like <read_file> in plain text.
-Do not include chain-of-thought or <thinking> tags in your output.`
-
-	// Use focused subagent prompt if running as subagent
-	if isSubagent {
-		basePrompt = `You are a focused subagent executing a specific task.
-Complete the task efficiently and report your findings.
-Do not include chain-of-thought or <thinking> tags in your output.
-Be concise and focused on the task at hand.`
-	}
+	// Create agent with skills using structured prompt builder.
+	basePrompt := prompt.HeadlessBasePrompt(isSubagent)
 
 	// Build the full system prompt
 	// Use workspace to get dynamic cwd for each prompt build

--- a/cmd/ai/json_mode.go
+++ b/cmd/ai/json_mode.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"encoding/json"
 	"fmt"
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"io"
 	"os"
 	"path/filepath"
@@ -163,7 +163,7 @@ func runJSON(sessionPath string, debugAddr string, prompts []string, output io.W
 		compactorConfig,
 		model,
 		apiKey,
-		"You are a helpful coding assistant.",
+		prompt.CompactorBasePrompt(),
 		currentContextWindow,
 	)
 
@@ -182,10 +182,8 @@ func runJSON(sessionPath string, debugAddr string, prompts []string, output io.W
 		IncludeDefaults: true,
 	})
 
-	// Create agent with skills using structured prompt builder
-	basePrompt := `You are a helpful coding assistant.
-When you need to inspect files or run commands, call the tools. Do not write tool markup like <read_file> in plain text.
-Do not include chain-of-thought or <thinking> tags in your output.`
+	// Create agent with skills using structured prompt builder.
+	basePrompt := prompt.JSONModeBasePrompt()
 
 	// Build the full system prompt
 	// Use workspace to get dynamic cwd for each prompt build

--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -183,7 +183,7 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 		compactorConfig,
 		model,
 		apiKey,
-		"You are a helpful coding assistant.",
+		prompt.CompactorBasePrompt(),
 		currentContextWindow,
 	)
 
@@ -232,15 +232,8 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 		slog.Info("Skill", "name", s.Name, "description", s.Description)
 	}
 
-	// Create agent with skills using structured prompt builder
-
-	// - Always output JSON objects as specified by the task schema.
-	// - Never output free text or markdown explanations.
-
-	basePrompt := `You are a helpful AI coding assistant.
-- If you cannot answer the request, return an empty JSON with error field.
-- Do not hallucinate or add unnecessary commentary.
-- Respect facts and be critical in your thinking. Don't simply agree with everything the user says.`
+	// Create agent with skills using structured prompt builder.
+	basePrompt := prompt.RPCBasePrompt()
 
 	// Build the full system prompt (used for agent and compactor)
 	buildSystemPrompt := func(currentSess *session.Session) string {
@@ -625,7 +618,7 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 		}
 
 		// Get workspace and current directory info
-		startupPath := cfg.Workspace // This is the initial working directory (git root or cwd at startup)
+		startupPath := cfg.Workspace  // This is the initial working directory (git root or cwd at startup)
 		currentWorkdir := ws.GetCWD() // This is the current working directory
 
 		result := make([]any, len(sessions))

--- a/pkg/prompt/builder.go
+++ b/pkg/prompt/builder.go
@@ -29,7 +29,7 @@ type Builder struct {
 	base string
 
 	// Working directory (can be static or dynamic via workspace)
-	cwd      string
+	cwd       string
 	workspace *tools.Workspace
 
 	// Minimal mode (excludes optional sections like skills, project context)
@@ -247,9 +247,8 @@ Treat it as the source of truth between turns.
 1. Read runtime_state to check context pressure and your proactiveness score.
 2. If context_management.action_required is not "none", call llm_context_decision tool.
    - Available decisions: "truncate", "compact", "both", "skip"
-   - Use decision="skip" with appropriate skip_turns (1-30) when context pressure is low.
-   - Higher skip_turns (15-30) indicate you promise to be proactive; this increases trust.
-   - Lower skip_turns (1-5) are for uncertain situations; reminders will come more frequently.
+   - Use decision="skip" with skip_turns (1-30) only when pressure is low and risk is understood.
+   - Use smaller skip_turns when uncertainty is high.
 3. If task state changed, update overview.md.
 4. Then answer the user.
 
@@ -297,6 +296,13 @@ func (b *Builder) buildToolingSection() string {
 	lines = append(lines, "")
 	lines = append(lines, "**IMPORTANT**: Only use the tools listed above.")
 	lines = append(lines, "Do NOT assume you have access to any other tools.")
+
+	// Tool usage guidance
+	lines = append(lines, "")
+	lines = append(lines, "### Tool Usage")
+	lines = append(lines, "- Analyze tool errors before retrying.")
+	lines = append(lines, "- If stuck, report blockers with actionable context.")
+	lines = append(lines, "- If a tool appears missing, check available Skills.")
 
 	// Skills hint
 	if !b.minimal && len(b.skills) > 0 {

--- a/pkg/prompt/builder_test.go
+++ b/pkg/prompt/builder_test.go
@@ -103,6 +103,10 @@ func TestBuilderWithTools(t *testing.T) {
 	if !contains(result, "Only use the tools listed above") {
 		t.Error("agentctx.Tool limitation warning missing")
 	}
+
+	if !contains(result, "### Tool Usage") {
+		t.Error("tool usage guidance missing")
+	}
 }
 
 func TestBuilderWithSkills(t *testing.T) {
@@ -153,6 +157,29 @@ func TestBuilderMinimalMode(t *testing.T) {
 
 	if !contains(result, "## Workspace") {
 		t.Error("Workspace section missing in minimal mode")
+	}
+}
+
+func TestBuilderSkillsRendering(t *testing.T) {
+	base := "You are an AI assistant."
+	cwd := "/workspace"
+	skills := []skill.Skill{
+		{Name: "wf-issue", Description: "issue workflow", FilePath: "/tmp/wf-issue/SKILL.md"},
+		{Name: "subagent", Description: "subagent workflow", FilePath: "/tmp/subagent/SKILL.md"},
+	}
+
+	b := NewBuilder(base, cwd)
+	b.SetSkills(skills)
+	result := b.Build()
+
+	if !contains(result, "## Skills") {
+		t.Error("skills header missing")
+	}
+	if !contains(result, "- **wf-issue**: issue workflow (/tmp/wf-issue/SKILL.md)") {
+		t.Error("full skill entry missing")
+	}
+	if !contains(result, "- **subagent**: subagent workflow (/tmp/subagent/SKILL.md)") {
+		t.Error("full skill entry missing")
 	}
 }
 

--- a/pkg/prompt/system.go
+++ b/pkg/prompt/system.go
@@ -1,0 +1,42 @@
+package prompt
+
+import "strings"
+
+// CompactorBasePrompt returns the baseline prompt used by compactor requests.
+func CompactorBasePrompt() string {
+	return "You are a helpful coding assistant."
+}
+
+// RPCBasePrompt returns the base system prompt for interactive RPC mode.
+func RPCBasePrompt() string {
+	return strings.TrimSpace(`You are a pragmatic AI coding assistant.
+- Be accurate and concise. Avoid unnecessary commentary.
+- Do not hallucinate tools, file contents, command outputs, or capabilities.
+- Respect facts and critically evaluate user assumptions; do not blindly agree.
+- Use tools for file/system operations; never pretend a tool was executed.
+- Analyze tool errors before retrying; do not loop blindly.
+- For normal conversation, respond in natural language.
+- If the user explicitly requires a JSON schema, output valid JSON only.`)
+}
+
+// HeadlessBasePrompt returns the base system prompt for headless mode.
+func HeadlessBasePrompt(isSubagent bool) string {
+	if isSubagent {
+		return strings.TrimSpace(`You are a focused subagent executing a specific task.
+Complete the task efficiently and report your findings.
+- Be concise and focused.
+- Analyze errors before retrying.
+- Report blockers clearly with next-step suggestions.`)
+	}
+
+	return strings.TrimSpace(`You are a pragmatic coding assistant.
+- Use tools for file operations and shell commands.
+- Do not write tool markup in plain text.
+- Analyze errors before retrying; do not loop blindly.
+- Report failures with concise, actionable context.`)
+}
+
+// JSONModeBasePrompt returns the base system prompt for JSON mode.
+func JSONModeBasePrompt() string {
+	return HeadlessBasePrompt(false)
+}

--- a/pkg/prompt/system_test.go
+++ b/pkg/prompt/system_test.go
@@ -1,0 +1,88 @@
+package prompt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/tiancaiamao/ai/pkg/skill"
+	"github.com/tiancaiamao/ai/pkg/truncate"
+)
+
+type abTool struct {
+	name string
+	desc string
+}
+
+func (t abTool) Name() string        { return t.name }
+func (t abTool) Description() string { return t.desc }
+
+func TestBasePromptsAreDefined(t *testing.T) {
+	if strings.TrimSpace(CompactorBasePrompt()) == "" {
+		t.Fatal("CompactorBasePrompt should not be empty")
+	}
+	if strings.TrimSpace(RPCBasePrompt()) == "" {
+		t.Fatal("RPCBasePrompt should not be empty")
+	}
+	if strings.TrimSpace(HeadlessBasePrompt(false)) == "" {
+		t.Fatal("HeadlessBasePrompt(false) should not be empty")
+	}
+	if strings.TrimSpace(HeadlessBasePrompt(true)) == "" {
+		t.Fatal("HeadlessBasePrompt(true) should not be empty")
+	}
+	if strings.TrimSpace(JSONModeBasePrompt()) == "" {
+		t.Fatal("JSONModeBasePrompt should not be empty")
+	}
+}
+
+func TestRPCBasePromptNoForcedJSON(t *testing.T) {
+	p := RPCBasePrompt()
+	if strings.Contains(strings.ToLower(p), "return an empty json with error field") {
+		t.Fatalf("RPC base prompt still forces legacy JSON fallback: %q", p)
+	}
+	if !strings.Contains(p, "If the user explicitly requires a JSON schema") {
+		t.Fatalf("RPC base prompt should keep conditional JSON rule: %q", p)
+	}
+}
+
+func TestPromptABMetricsSmoke(t *testing.T) {
+	legacyRPCBasePrompt := strings.TrimSpace(`You are a helpful AI coding assistant.
+- If you cannot answer the request, return an empty JSON with error field.
+- Do not hallucinate or add unnecessary commentary.
+- Respect facts and be critical in your thinking. Don't simply agree with everything the user says.`)
+
+	tools := []ToolInfo{
+		abTool{name: "read", desc: "Read files"},
+		abTool{name: "write", desc: "Write files"},
+		abTool{name: "bash", desc: "Execute commands"},
+		abTool{name: "grep", desc: "Search file contents"},
+		abTool{name: "edit", desc: "Edit file content"},
+		abTool{name: "change_workspace", desc: "Switch workspace directory"},
+	}
+
+	skills := make([]skill.Skill, 0, 24)
+	for i := 0; i < 24; i++ {
+		skills = append(skills, skill.Skill{
+			Name:        fmt.Sprintf("skill-%02d", i),
+			Description: "Long description for AB prompt benchmark with enough content to reflect realistic skill metadata and token cost.",
+			FilePath:    fmt.Sprintf("/tmp/skills/skill-%02d/SKILL.md", i),
+		})
+	}
+
+	oldPrompt := NewBuilder(legacyRPCBasePrompt, "/workspace").SetTools(tools).SetSkills(skills).Build()
+	newPrompt := NewBuilder(RPCBasePrompt(), "/workspace").SetTools(tools).SetSkills(skills).Build()
+
+	oldChars := len(oldPrompt)
+	newChars := len(newPrompt)
+	oldTokens := truncate.ApproxTokenCount(oldPrompt)
+	newTokens := truncate.ApproxTokenCount(newPrompt)
+
+	t.Logf("AB prompt metrics: old chars=%d tokens=%d | new chars=%d tokens=%d", oldChars, oldTokens, newChars, newTokens)
+
+	if oldTokens <= 0 || newTokens <= 0 {
+		t.Fatalf("expected positive token estimates, old=%d new=%d", oldTokens, newTokens)
+	}
+	if !strings.Contains(newPrompt, "- **skill-00**:") {
+		t.Fatalf("expected full skill entries in prompt, got: %s", newPrompt)
+	}
+}


### PR DESCRIPTION
## Summary
- move runtime base prompt definitions into `pkg/prompt/system.go` and reuse them across rpc/headless/json modes
- keep tooling section fully explicit and add tool-usage guidance checks in prompt builder tests
- simplify prompt builder flow by removing now-unused compact prompt path usage in call sites
- add prompt system tests for base prompt availability and JSON behavior guard

## Validation
- go test ./pkg/prompt ./pkg/skill ./cmd/ai
