### PR TITLE
fix: /model 命令返回成功消息 (Issue #31)

### DIFF
--- a/claw/pkg/adapter/adapter.go
+++ b/claw/pkg/adapter/adapter.go
@@ -1278,7 +1278,11 @@ func (a *AgentLoop) cmdModel(args string, sess *Session) (string, error) {
 	}
 
 	// Otherwise, try to switch to the specified model
-	return "", a.switchModel(args, sess)
+	err := a.switchModel(args, sess)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Model switched to: %s (provider: %s)", a.model.ID, a.model.Provider), nil
 }
 
 // listModels lists all available models from ~/.aiclaw/models.json


### PR DESCRIPTION
## 修复 Issue #31: aiclaw 中的 /model 命令未生效

### 问题描述
通过 channel 发送 /model id 实际上并没有改变 mode

### 问题根因
cmdModel 函数在 switchModel 成功后返回空字符串（"", nil），导致用户看不到任何反馈，误以为命令没有生效

### 修复内容
当 switchModel 成功时返回明确的成功消息：
```go
err := a.switchModel(args, sess)
if err != nil {
    return "", err
}
return fmt.Sprintf("Model switched to: %s (provider: %s)", a.model.ID, a.model.Provider), nil
```

### 验证
go build ./... 成功

Closes #31