### PR TITLE
Unify /model selection logic and make model listing deterministic

### DIFF
--- a/claw/cmd/aiclaw/main.go
+++ b/claw/cmd/aiclaw/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -77,6 +78,13 @@ func main() {
 	}
 
 	clawDir := filepath.Join(homeDir, ".aiclaw")
+
+	lockFile, err := acquireInstanceLock(clawDir)
+	if err != nil {
+		slog.Error("Failed to acquire instance lock", "error", err)
+		os.Exit(1)
+	}
+	defer releaseInstanceLock(lockFile)
 
 	// 设置 trace 输出到 ~/.aiclaw/traces/（可选，调试时启用）
 	if *trace {
@@ -421,6 +429,42 @@ func setupTracing(clawDir string) error {
 	traceevent.SetHandler(handler)
 	slog.Info("Tracing enabled", "dir", tracesDir)
 	return nil
+}
+
+func acquireInstanceLock(clawDir string) (*os.File, error) {
+	if err := os.MkdirAll(clawDir, 0755); err != nil {
+		return nil, fmt.Errorf("create claw dir: %w", err)
+	}
+
+	lockPath := filepath.Join(clawDir, "aiclaw.lock")
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file %s: %w", lockPath, err)
+	}
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = lockFile.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf("another aiclaw instance is already running (lock: %s)", lockPath)
+		}
+		return nil, fmt.Errorf("acquire lock %s: %w", lockPath, err)
+	}
+
+	_ = lockFile.Truncate(0)
+	if _, err := lockFile.Seek(0, 0); err == nil {
+		_, _ = fmt.Fprintf(lockFile, "%d\n", os.Getpid())
+	}
+
+	return lockFile, nil
+}
+
+func releaseInstanceLock(lockFile *os.File) {
+	if lockFile == nil {
+		return
+	}
+
+	_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	_ = lockFile.Close()
 }
 
 func isFFmpegAvailable() bool {

--- a/claw/pkg/adapter/adapter.go
+++ b/claw/pkg/adapter/adapter.go
@@ -28,8 +28,10 @@ import (
 	"github.com/tiancaiamao/ai/claw/pkg/voice"
 	"github.com/tiancaiamao/ai/pkg/agent"
 	"github.com/tiancaiamao/ai/pkg/compact"
+	aiconfig "github.com/tiancaiamao/ai/pkg/config"
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
+	"github.com/tiancaiamao/ai/pkg/modelselect"
 	"github.com/tiancaiamao/ai/pkg/session"
 	"github.com/tiancaiamao/ai/pkg/skill"
 	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
@@ -118,9 +120,9 @@ type AgentLoop struct {
 	commands *CommandRegistry
 
 	// Statistics
-	messageCount  atomic.Int64
-	totalTokens   atomic.Int64
-	startTime     time.Time
+	messageCount atomic.Int64
+	totalTokens  atomic.Int64
+	startTime    time.Time
 }
 
 // Session represents an isolated conversation session
@@ -276,15 +278,8 @@ func NewAgentLoop(cfg *Config, msgBus *bus.MessageBus) *AgentLoop {
 	return loop
 }
 
-// ModelSpec 模型规格定义
-type ModelSpec struct {
-	ID            string `json:"id"`
-	Name          string `json:"name,omitempty"`
-	Provider      string `json:"provider"`
-	BaseURL       string `json:"baseUrl"`
-	API           string `json:"api"`
-	ContextWindow int    `json:"contextWindow"`
-}
+// ModelSpec aliases shared model specification to avoid duplicate schema definitions.
+type ModelSpec = aiconfig.ModelSpec
 
 // resolveModel 从 claw 配置目录加载模型配置
 func resolveModel(cfg *Config) llm.Model {
@@ -306,15 +301,9 @@ func resolveModel(cfg *Config) llm.Model {
 	}
 
 	modelsPath := filepath.Join(cfg.ClawDir, "models.json")
-	data, err := os.ReadFile(modelsPath)
+	specs, err := aiconfig.LoadModelSpecs(modelsPath)
 	if err != nil {
-		slog.Warn("[AgentLoop] Failed to read models.json", "error", err, "path", modelsPath)
-		return model
-	}
-
-	var specs []ModelSpec
-	if err := json.Unmarshal(data, &specs); err != nil {
-		slog.Warn("[AgentLoop] Failed to parse models.json", "error", err, "path", modelsPath)
+		slog.Warn("[AgentLoop] Failed to load models.json", "error", err, "path", modelsPath)
 		return model
 	}
 
@@ -1113,18 +1102,18 @@ func (a *AgentLoop) handleControlCommand(ctx context.Context, cmdLine, sessionKe
 func (a *AgentLoop) cmdHelp() string {
 	// Define command descriptions
 	descriptions := map[string]string{
-		"help":        "Show this help message",
-		"commands":    "List available skills (alias: /skills)",
-		"skills":      "List available skills (alias: /commands)",
-		"session":     "Show current session info",
-		"history":     "Show message history (alias: /messages)",
-		"messages":    "Show message history (alias: /history)",
-		"clear":       "Clear current session messages",
-		"model":       "List or switch AI models",
-		"traceevent":  "Manage trace events for debugging",
-		"cron":        "Manage cron jobs",
-		"show":        "Show settings or usage (usage: /show [settings|usage])",
-		"thinking":    "Toggle or set thinking level (usage: /thinking [off|minimal|low|medium|high|xhigh])",
+		"help":       "Show this help message",
+		"commands":   "List available skills (alias: /skills)",
+		"skills":     "List available skills (alias: /commands)",
+		"session":    "Show current session info",
+		"history":    "Show message history (alias: /messages)",
+		"messages":   "Show message history (alias: /history)",
+		"clear":      "Clear current session messages",
+		"model":      "List or switch AI models",
+		"traceevent": "Manage trace events for debugging",
+		"cron":       "Manage cron jobs",
+		"show":       "Show settings or usage (usage: /show [settings|usage])",
+		"thinking":   "Toggle or set thinking level (usage: /thinking [off|minimal|low|medium|high|xhigh])",
 	}
 
 	commands := a.commands.List()
@@ -1267,8 +1256,9 @@ func (a *AgentLoop) cmdClear(sess *Session) string {
 
 // cmdModel lists available models or switches to a specific model
 // Usage:
-//   /model          - list all available models
-//   /model <id>     - switch to the specified model
+//
+//	/model          - list all available models
+//	/model <id>     - switch to the specified model
 func (a *AgentLoop) cmdModel(args string, sess *Session) (string, error) {
 	args = strings.TrimSpace(args)
 
@@ -1295,7 +1285,7 @@ func (a *AgentLoop) listModels() string {
 	}
 
 	modelsPath := filepath.Join(homeDir, ".aiclaw", "models.json")
-	specs, err := a.loadModelSpecs(modelsPath)
+	specs, err := aiconfig.LoadModelSpecs(modelsPath)
 	if err != nil {
 		return fmt.Sprintf("Model Info (current):\n  ID: %s\n  Provider: %s\n\nCannot load models list: %v\n\nExpected file: %s",
 			a.model.ID, a.model.Provider, err, modelsPath)
@@ -1333,6 +1323,8 @@ func (a *AgentLoop) listModels() string {
 
 // switchModel switches to the specified model
 func (a *AgentLoop) switchModel(modelID string, sess *Session) error {
+	modelID = strings.TrimSpace(modelID)
+
 	// Load available models
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -1340,34 +1332,29 @@ func (a *AgentLoop) switchModel(modelID string, sess *Session) error {
 	}
 
 	modelsPath := filepath.Join(homeDir, ".aiclaw", "models.json")
-	specs, err := a.loadModelSpecs(modelsPath)
+	specs, err := aiconfig.LoadModelSpecs(modelsPath)
 	if err != nil {
 		return fmt.Errorf("failed to load models: %w (path: %s)", err, modelsPath)
 	}
 
 	// Try to parse as numeric index first
-	var targetSpec *ModelSpec
-	if idx, err := strconv.Atoi(modelID); err == nil && idx >= 0 && idx < len(specs) {
-		// Numeric index selection
-		targetSpec = &specs[idx]
-	} else {
-		// Find by ID or name (partial match supported)
-		for i := range specs {
-			spec := &specs[i]
-			if spec.ID == modelID || strings.HasPrefix(spec.ID, modelID) {
-				targetSpec = spec
-				break
-			}
-			// Also match by name if provided
-			if spec.Name != "" && (spec.Name == modelID || strings.HasPrefix(spec.Name, modelID)) {
-				targetSpec = spec
-				break
-			}
+	var targetSpec ModelSpec
+	if idx, parseErr := strconv.Atoi(modelID); parseErr == nil {
+		if idx < 0 || idx >= len(specs) {
+			return fmt.Errorf("model index out of range: %d\nUse /model to list available models", idx)
 		}
-	}
-
-	if targetSpec == nil {
-		return fmt.Errorf("model not found: %s\nUse /model to list available models", modelID)
+		targetSpec = specs[idx]
+	} else {
+		targetSpec, err = modelselect.SelectByQuery(specs, modelID, func(spec ModelSpec) modelselect.Keys {
+			return modelselect.Keys{
+				Provider: spec.Provider,
+				ID:       spec.ID,
+				Name:     spec.Name,
+			}
+		})
+		if err != nil {
+			return fmt.Errorf("%w\nUse /model to list available models", err)
+		}
 	}
 
 	// Resolve API key for the provider
@@ -1423,54 +1410,6 @@ func (a *AgentLoop) switchModel(modelID string, sess *Session) error {
 		"contextWindow", newModel.ContextWindow)
 
 	return nil
-}
-
-// loadModelSpecs loads model specs from a models.json file
-func (a *AgentLoop) loadModelSpecs(path string) ([]ModelSpec, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var cfg struct {
-		Providers map[string]struct {
-			BaseURL string `json:"baseUrl,omitempty"`
-			API     string `json:"api,omitempty"`
-			Models  []struct {
-				ID            string   `json:"id"`
-				Name          string   `json:"name,omitempty"`
-				BaseURL       string   `json:"baseUrl,omitempty"`
-				API           string   `json:"api,omitempty"`
-				ContextWindow int      `json:"contextWindow,omitempty"`
-				MaxTokens     int      `json:"maxTokens,omitempty"`
-			} `json:"models,omitempty"`
-		} `json:"providers"`
-	}
-
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, err
-	}
-
-	var specs []ModelSpec
-	for provider, pcfg := range cfg.Providers {
-		baseURL := pcfg.BaseURL
-		api := pcfg.API
-		for _, m := range pcfg.Models {
-			if m.ID == "" {
-				continue
-			}
-			specs = append(specs, ModelSpec{
-				ID:            m.ID,
-				Name:          m.Name,
-				Provider:      provider,
-				BaseURL:       firstNonEmpty(m.BaseURL, baseURL),
-				API:           firstNonEmpty(m.API, api),
-				ContextWindow: m.ContextWindow,
-			})
-		}
-	}
-
-	return specs, nil
 }
 
 // resolveAPIKey resolves API key from environment or auth.json
@@ -1561,13 +1500,14 @@ func (a *AgentLoop) saveModelConfig(model llm.Model) error {
 
 // cmdTraceevent manages trace event settings
 // Usage:
-//   /traceevent              - list enabled events
-//   /traceevent default      - reset to default set
-//   /traceevent all          - enable all events
-//   /traceevent off          - disable all events
-//   /traceevent <events>     - set specific events (e.g., llm, tool, event)
-//   /traceevent enable <events>   - enable additional events
-//   /traceevent disable <events>  - disable specific events
+//
+//	/traceevent              - list enabled events
+//	/traceevent default      - reset to default set
+//	/traceevent all          - enable all events
+//	/traceevent off          - disable all events
+//	/traceevent <events>     - set specific events (e.g., llm, tool, event)
+//	/traceevent enable <events>   - enable additional events
+//	/traceevent disable <events>  - disable specific events
 func (a *AgentLoop) cmdTraceevent(args string) string {
 	args = strings.TrimSpace(args)
 
@@ -1649,20 +1589,12 @@ func (a *AgentLoop) cmdTraceevent(args string) string {
 	}
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if v := strings.TrimSpace(value); v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
 // cmdShow displays settings or usage statistics
 // Usage:
-//   /show              - show settings (default)
-//   /show settings     - show current settings
-//   /show usage        - show usage statistics
+//
+//	/show              - show settings (default)
+//	/show settings     - show current settings
+//	/show usage        - show usage statistics
 func (a *AgentLoop) cmdShow(args string, sess *Session) string {
 	args = strings.TrimSpace(args)
 
@@ -1770,8 +1702,9 @@ func formatDuration(d time.Duration) string {
 
 // cmdThinking toggles or sets the thinking level
 // Usage:
-//   /thinking              - toggle to next level
-//   /thinking <level>      - set specific level (off, minimal, low, medium, high, xhigh)
+//
+//	/thinking              - toggle to next level
+//	/thinking <level>      - set specific level (off, minimal, low, medium, high, xhigh)
 func (a *AgentLoop) cmdThinking(args string, sess *Session) string {
 	levels := []string{"off", "minimal", "low", "medium", "high", "xhigh"}
 	levelMap := make(map[string]string)

--- a/internal/winai/interpreter.go
+++ b/internal/winai/interpreter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sminez/ad/win/pkg/ad"
 	"github.com/sminez/ad/win/pkg/repl"
 	"github.com/tiancaiamao/ai/pkg/agent"
+	"github.com/tiancaiamao/ai/pkg/modelselect"
 	"github.com/tiancaiamao/ai/pkg/rpc"
 )
 
@@ -77,6 +78,7 @@ type AiInterpreter struct {
 	pipeline              pipelineMetrics
 	pendingSessionList    bool
 	pendingSessionSwitch  string
+	pendingModelInput     string
 	pendingForkList       bool
 	pendingForkSelect     string
 	pendingTreeList       bool
@@ -561,6 +563,10 @@ func (p *AiInterpreter) handleInput(input string, fromControl bool) (bool, error
 }
 
 func (p *AiInterpreter) handleModelSelect() (bool, error) {
+	p.stateMu.Lock()
+	p.availableModels = nil
+	p.stateMu.Unlock()
+
 	// Send request to get available models
 	if err := p.sendCommand("get_available_models", nil, ""); err != nil {
 		return false, err
@@ -630,6 +636,27 @@ func (p *AiInterpreter) handleModelSelect() (bool, error) {
 
 }
 
+func (p *AiInterpreter) handleModel(args string, fromControl bool) (bool, error) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return p.handleModelSelect()
+	}
+
+	if err := p.setModelFromInput(args); err != nil {
+		if errors.Is(err, errModelListRequired) {
+			p.stateMu.Lock()
+			p.pendingModelInput = args
+			p.stateMu.Unlock()
+			return true, p.sendCommand("get_available_models", nil, "")
+		}
+
+		p.writeStatusMaybeDefer(fromControl, fmt.Sprintf("ai: %v", err))
+		return true, nil
+	}
+
+	return true, nil
+}
+
 func (p *AiInterpreter) handleCommand(cmdLine string, fromControl bool) (bool, error) {
 	if cmdLine == "" {
 		return false, nil
@@ -684,8 +711,10 @@ func (p *AiInterpreter) handleCommand(cmdLine string, fromControl bool) (bool, e
 		return true, p.handleShow(args, fromControl)
 	case "thinking":
 		return true, p.handleThinking(args, fromControl)
+	case "model":
+		return p.handleModel(args, fromControl)
 	case "model-select":
-		return p.handleModelSelect()
+		return p.handleModel(args, fromControl)
 	case "new":
 		data := map[string]any{}
 
@@ -1359,7 +1388,7 @@ func (p *AiInterpreter) resolveModelInput(input string) (*rpc.ModelInfo, error) 
 			return nil, fmt.Errorf("invalid model: %s", input)
 		}
 
-		return &rpc.ModelInfo{Provider: parts[0], ID: parts[1]}, nil
+		return &rpc.ModelInfo{Provider: strings.TrimSpace(parts[0]), ID: strings.TrimSpace(parts[1])}, nil
 	}
 
 	if len(models) == 0 {
@@ -1370,11 +1399,18 @@ func (p *AiInterpreter) resolveModelInput(input string) (*rpc.ModelInfo, error) 
 		return nil, errModelListRequired
 	}
 
-	for _, m := range models {
-		if m.ID == input || m.Name == input {
-			return &m, nil
+	match, err := modelselect.SelectByQuery(models, input, func(model rpc.ModelInfo) modelselect.Keys {
+		return modelselect.Keys{
+			Provider: model.Provider,
+			ID:       model.ID,
+			Name:     model.Name,
 		}
-
+	})
+	if err == nil {
+		return &match, nil
+	}
+	if !errors.Is(err, modelselect.ErrNotFound) {
+		return nil, err
 	}
 
 	if currentProvider != "" {
@@ -2141,7 +2177,8 @@ func (p *AiInterpreter) showHelp(fromControl bool) {
   /set <tools|prefix|thinking|auto-compaction|busy-mode> [value]
   /show settings|pipeline|usage
   /thinking [level]                    - Show/set thinking level (off|minimal|low|medium|high|xhigh)
-  /model-select
+  /model [number|id|provider/id]
+  /model-select                        - Alias of /model
   /new [name]
   /resume [id|path|index]
   /compact
@@ -2291,10 +2328,20 @@ func (p *AiInterpreter) handleAvailableModels(data json.RawMessage) {
 		return
 	}
 
+	models := append([]rpc.ModelInfo(nil), payload.Models...)
+	modelselect.SortByModelKey(models, func(model rpc.ModelInfo) modelselect.Keys {
+		return modelselect.Keys{
+			Provider: model.Provider,
+			ID:       model.ID,
+			Name:     model.Name,
+		}
+	})
+
+	var pendingInput string
 	p.stateMu.Lock()
-	p.availableModels = payload.Models
+	p.availableModels = models
 	if p.currentModelProvider == "" && p.currentModelID != "" {
-		for _, model := range payload.Models {
+		for _, model := range models {
 			if model.ID == p.currentModelID {
 				p.currentModelProvider = model.Provider
 				break
@@ -2303,8 +2350,16 @@ func (p *AiInterpreter) handleAvailableModels(data json.RawMessage) {
 		}
 
 	}
+	pendingInput = strings.TrimSpace(p.pendingModelInput)
+	p.pendingModelInput = ""
 
 	p.stateMu.Unlock()
+
+	if pendingInput != "" {
+		if err := p.setModelFromInput(pendingInput); err != nil {
+			p.writeStatus(fmt.Sprintf("ai: %v", err))
+		}
+	}
 }
 
 func (p *AiInterpreter) showModelList(models []rpc.ModelInfo, showUsage bool) {
@@ -2353,7 +2408,8 @@ func (p *AiInterpreter) showModelList(models []rpc.ModelInfo, showUsage bool) {
 Usage:
   - Visual select a model line above
   - Press: <space> p m to set selected model
-  - Or type: /model <number|provider/model-id>
+  - Or type: /model <number|id|provider/model-id>
+  - /model-select is an alias of /model
 `)
 	}
 

--- a/internal/winai/interpreter_model_test.go
+++ b/internal/winai/interpreter_model_test.go
@@ -1,0 +1,80 @@
+package winai
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tiancaiamao/ai/pkg/rpc"
+)
+
+func TestResolveModelInputPrefersExactMatch(t *testing.T) {
+	p := newBaseInterpreter()
+	p.availableModels = []rpc.ModelInfo{
+		{Provider: "zai", ID: "glm-4.7-flash", Name: "GLM 4.7 Flash"},
+		{Provider: "zai", ID: "glm-4.7", Name: "GLM 4.7"},
+	}
+
+	model, err := p.resolveModelInput("glm-4.7")
+	if err != nil {
+		t.Fatalf("resolveModelInput returned error: %v", err)
+	}
+	if model.ID != "glm-4.7" {
+		t.Fatalf("model ID = %q, want %q", model.ID, "glm-4.7")
+	}
+}
+
+func TestResolveModelInputAmbiguousPrefix(t *testing.T) {
+	p := newBaseInterpreter()
+	p.availableModels = []rpc.ModelInfo{
+		{Provider: "zai", ID: "glm-4.7-flash", Name: "GLM 4.7 Flash"},
+		{Provider: "zai", ID: "glm-4.7", Name: "GLM 4.7"},
+	}
+
+	_, err := p.resolveModelInput("glm-4")
+	if err == nil {
+		t.Fatal("expected ambiguity error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %q, want to contain %q", err.Error(), "ambiguous")
+	}
+}
+
+func TestHandleAvailableModelsSortsDeterministic(t *testing.T) {
+	p := newBaseInterpreter()
+	payload := struct {
+		Models []rpc.ModelInfo `json:"models"`
+	}{
+		Models: []rpc.ModelInfo{
+			{Provider: "zai", ID: "glm-5"},
+			{Provider: "anthropic", ID: "claude-sonnet-4-20250514"},
+			{Provider: "zai", ID: "glm-4.7"},
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	p.handleAvailableModels(data)
+	if len(p.availableModels) != 3 {
+		t.Fatalf("available models len = %d, want 3", len(p.availableModels))
+	}
+
+	got := []string{
+		p.availableModels[0].Provider + "/" + p.availableModels[0].ID,
+		p.availableModels[1].Provider + "/" + p.availableModels[1].ID,
+		p.availableModels[2].Provider + "/" + p.availableModels[2].ID,
+	}
+	want := []string{
+		"anthropic/claude-sonnet-4-20250514",
+		"zai/glm-4.7",
+		"zai/glm-5",
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/config/models.go
+++ b/pkg/config/models.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
+
+	"github.com/tiancaiamao/ai/pkg/modelselect"
 )
 
 // ModelSpec represents a resolved model entry from models.json.
@@ -75,15 +76,8 @@ func LoadModelSpecs(path string) ([]ModelSpec, error) {
 		return nil, nil
 	}
 
-	providers := make([]string, 0, len(cfg.Providers))
-	for provider := range cfg.Providers {
-		providers = append(providers, provider)
-	}
-	sort.Strings(providers)
-
 	specs := make([]ModelSpec, 0)
-	for _, provider := range providers {
-		pcfg := cfg.Providers[provider]
+	for provider, pcfg := range cfg.Providers {
 		provider = strings.TrimSpace(provider)
 		baseURL := strings.TrimSpace(pcfg.BaseURL)
 		api := strings.TrimSpace(pcfg.API)
@@ -108,6 +102,14 @@ func LoadModelSpecs(path string) ([]ModelSpec, error) {
 			})
 		}
 	}
+
+	modelselect.SortByModelKey(specs, func(spec ModelSpec) modelselect.Keys {
+		return modelselect.Keys{
+			Provider: spec.Provider,
+			ID:       spec.ID,
+			Name:     spec.Name,
+		}
+	})
 
 	return specs, nil
 }

--- a/pkg/config/models_test.go
+++ b/pkg/config/models_test.go
@@ -85,3 +85,54 @@ func TestLoadModelSpecsOverrides(t *testing.T) {
 		t.Errorf("api = %q, want %q", spec.API, "anthropic-messages")
 	}
 }
+
+func TestLoadModelSpecsDeterministicSort(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models.json")
+	data := `{
+  "providers": {
+    "zai": {
+      "baseUrl": "https://api.z.ai/api/coding/paas/v4",
+      "api": "openai-completions",
+      "models": [
+        { "id": "glm-5", "name": "GLM 5" },
+        { "id": "glm-4.7", "name": "GLM 4.7" }
+      ]
+    },
+    "anthropic": {
+      "baseUrl": "https://api.anthropic.com/v1",
+      "api": "anthropic-messages",
+      "models": [
+        { "id": "claude-sonnet-4-20250514", "name": "Claude Sonnet 4" }
+      ]
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatalf("write models.json: %v", err)
+	}
+
+	specs, err := LoadModelSpecs(path)
+	if err != nil {
+		t.Fatalf("LoadModelSpecs error: %v", err)
+	}
+	if len(specs) != 3 {
+		t.Fatalf("expected 3 specs, got %d", len(specs))
+	}
+
+	got := []string{
+		specs[0].Provider + "/" + specs[0].ID,
+		specs[1].Provider + "/" + specs[1].ID,
+		specs[2].Provider + "/" + specs[2].ID,
+	}
+	want := []string{
+		"anthropic/claude-sonnet-4-20250514",
+		"zai/glm-4.7",
+		"zai/glm-5",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/modelselect/modelselect.go
+++ b/pkg/modelselect/modelselect.go
@@ -1,0 +1,141 @@
+package modelselect
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Keys represents normalized model identity fields used for selection and sorting.
+type Keys struct {
+	Provider string
+	ID       string
+	Name     string
+}
+
+// KeyExtractor extracts model identity fields from a value.
+type KeyExtractor[T any] func(item T) Keys
+
+var (
+	// ErrNotFound indicates no model matched a selector.
+	ErrNotFound = errors.New("model not found")
+	// ErrAmbiguous indicates a selector matches multiple models.
+	ErrAmbiguous = errors.New("model selector is ambiguous")
+)
+
+// SortByModelKey sorts models by provider, id, then name (case-insensitive).
+func SortByModelKey[T any](items []T, extract KeyExtractor[T]) {
+	sort.Slice(items, func(i, j int) bool {
+		keyI := normalize(extract(items[i]))
+		keyJ := normalize(extract(items[j]))
+		if keyI.Provider != keyJ.Provider {
+			return keyI.Provider < keyJ.Provider
+		}
+		if keyI.ID != keyJ.ID {
+			return keyI.ID < keyJ.ID
+		}
+		return keyI.Name < keyJ.Name
+	})
+}
+
+// SelectByQuery resolves a model selector by exact match first, then prefix match.
+func SelectByQuery[T any](items []T, query string, extract KeyExtractor[T]) (T, error) {
+	var zero T
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return zero, fmt.Errorf("model id is empty")
+	}
+	if len(items) == 0 {
+		return zero, fmt.Errorf("no models configured")
+	}
+
+	if idx := findExactMatchIndex(items, query, extract); idx >= 0 {
+		return items[idx], nil
+	}
+
+	matches := findPrefixMatches(items, query, extract)
+	switch len(matches) {
+	case 0:
+		return zero, fmt.Errorf("%w: %s", ErrNotFound, query)
+	case 1:
+		return items[matches[0]], nil
+	default:
+		return zero, fmt.Errorf("%w: %s (matches: %s)", ErrAmbiguous, query, formatMatches(items, matches, extract))
+	}
+}
+
+func findExactMatchIndex[T any](items []T, query string, extract KeyExtractor[T]) int {
+	queryLower := strings.ToLower(query)
+	for i := range items {
+		key := normalize(extract(items[i]))
+		if key.ID == queryLower {
+			return i
+		}
+	}
+	for i := range items {
+		key := normalize(extract(items[i]))
+		if key.Name != "" && key.Name == queryLower {
+			return i
+		}
+	}
+	return -1
+}
+
+func findPrefixMatches[T any](items []T, query string, extract KeyExtractor[T]) []int {
+	queryLower := strings.ToLower(query)
+	matches := make([]int, 0)
+	seen := make(map[string]struct{}, len(items))
+
+	for i := range items {
+		key := normalize(extract(items[i]))
+		if strings.HasPrefix(key.ID, queryLower) {
+			identity := key.Provider + "\x00" + key.ID
+			if _, ok := seen[identity]; ok {
+				continue
+			}
+			seen[identity] = struct{}{}
+			matches = append(matches, i)
+		}
+	}
+
+	for i := range items {
+		key := normalize(extract(items[i]))
+		if key.Name == "" || !strings.HasPrefix(key.Name, queryLower) {
+			continue
+		}
+		identity := key.Provider + "\x00" + key.ID
+		if _, ok := seen[identity]; ok {
+			continue
+		}
+		seen[identity] = struct{}{}
+		matches = append(matches, i)
+	}
+
+	return matches
+}
+
+func normalize(key Keys) Keys {
+	return Keys{
+		Provider: strings.ToLower(strings.TrimSpace(key.Provider)),
+		ID:       strings.ToLower(strings.TrimSpace(key.ID)),
+		Name:     strings.ToLower(strings.TrimSpace(key.Name)),
+	}
+}
+
+func formatMatches[T any](items []T, indices []int, extract KeyExtractor[T]) string {
+	parts := make([]string, 0, len(indices))
+	for _, idx := range indices {
+		key := extract(items[idx])
+		provider := strings.TrimSpace(key.Provider)
+		id := strings.TrimSpace(key.ID)
+		name := strings.TrimSpace(key.Name)
+		ref := fmt.Sprintf("%s/%s", provider, id)
+		if name != "" && !strings.EqualFold(name, id) {
+			parts = append(parts, fmt.Sprintf("%s (%s)", ref, name))
+			continue
+		}
+		parts = append(parts, ref)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/pkg/modelselect/modelselect_test.go
+++ b/pkg/modelselect/modelselect_test.go
@@ -1,0 +1,91 @@
+package modelselect
+
+import (
+	"errors"
+	"testing"
+)
+
+type testModel struct {
+	Provider string
+	ID       string
+	Name     string
+}
+
+func keyOfModel(m testModel) Keys {
+	return Keys{
+		Provider: m.Provider,
+		ID:       m.ID,
+		Name:     m.Name,
+	}
+}
+
+func TestSelectByQueryPrefersExactMatch(t *testing.T) {
+	models := []testModel{
+		{Provider: "zai", ID: "glm-4.7-flash", Name: "GLM 4.7 Flash"},
+		{Provider: "zai", ID: "glm-4.7", Name: "GLM 4.7"},
+	}
+
+	selected, err := SelectByQuery(models, "glm-4.7", keyOfModel)
+	if err != nil {
+		t.Fatalf("SelectByQuery error: %v", err)
+	}
+	if selected.ID != "glm-4.7" {
+		t.Fatalf("selected id = %q, want %q", selected.ID, "glm-4.7")
+	}
+}
+
+func TestSelectByQueryAmbiguousPrefix(t *testing.T) {
+	models := []testModel{
+		{Provider: "zai", ID: "glm-4.7-flash", Name: "GLM 4.7 Flash"},
+		{Provider: "zai", ID: "glm-4.7", Name: "GLM 4.7"},
+	}
+
+	_, err := SelectByQuery(models, "glm-4", keyOfModel)
+	if err == nil {
+		t.Fatal("expected ambiguous error, got nil")
+	}
+	if !errors.Is(err, ErrAmbiguous) {
+		t.Fatalf("error = %v, want ErrAmbiguous", err)
+	}
+}
+
+func TestSelectByQueryNotFound(t *testing.T) {
+	models := []testModel{
+		{Provider: "zai", ID: "glm-4.7", Name: "GLM 4.7"},
+	}
+
+	_, err := SelectByQuery(models, "gpt-4o", keyOfModel)
+	if err == nil {
+		t.Fatal("expected not found error, got nil")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSortByModelKeyDeterministic(t *testing.T) {
+	models := []testModel{
+		{Provider: "zai", ID: "glm-5"},
+		{Provider: "anthropic", ID: "claude-sonnet-4-20250514"},
+		{Provider: "zai", ID: "glm-4.7"},
+	}
+
+	SortByModelKey(models, keyOfModel)
+
+	got := []string{
+		models[0].Provider + "/" + models[0].ID,
+		models[1].Provider + "/" + models[1].ID,
+		models[2].Provider + "/" + models[2].ID,
+	}
+	want := []string{
+		"anthropic/claude-sonnet-4-20250514",
+		"zai/glm-4.7",
+		"zai/glm-5",
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add shared pkg/modelselect utilities for deterministic model sorting and selector resolution
- switch both aiclaw and internal/winai to reuse shared /model selection logic
- keep .ai and .aiclaw configs independent while removing duplicate model parsing code in aiclaw
- add single-instance lock for aiclaw to prevent mixed responses from multiple running processes

## Testing
- go test ./pkg/modelselect ./pkg/config ./internal/winai ./cmd/ai
- (cd claw && go test ./...)
