### PR TITLE
fix(wf-tick): detect merged PR and update state to done

### DIFF
--- a/claw/skills/wf-tick/SKILL.md
+++ b/claw/skills/wf-tick/SKILL.md
@@ -306,8 +306,28 @@ For each registry item:
   - Wait for human review decision
 
 - Reconcile with GitHub PR state:
+  ```bash
+  # Check PR status using gh CLI
+  PR_STATE=$(gh pr view "$pr_number" --repo "$repo" --json state -q '.state')
+  
+  # Also check if merged (state might be MERGED even if not showing as merged)
+  IS_MERGED=$(gh pr view "$pr_number" --repo "$repo" --json merged -q '.merged')
+  
+  if [ "$PR_STATE" = "MERGED" ] || [ "$IS_MERGED" = "true" ]; then
+    echo "PR #$pr_number has been merged"
+    # Update status to done
+    jq ".state = \"done\" | .step = \"merged\"" "$worktree/.aiclaw/status.json" > /tmp/status.json && \
+      mv /tmp/status.json "$worktree/.aiclaw/status.json"
+    # Will trigger closeout on next tick
+  elif [ "$PR_STATE" = "CLOSED" ]; then
+    echo "PR #$pr_number was closed without merging"
+    jq ".state = \"failed\" | .last_error = \"PR closed without merging\"" "$worktree/.aiclaw/status.json" > /tmp/status.json && \
+      mv /tmp/status.json "$worktree/.aiclaw/status.json"
+  fi
+  ```
   - If merged: `state=done`
   - If review requested changes: `state=reviewing`
+- If no Worker ran (no_worker=true), still do the reconciliation above.
 
 ### `reviewing`
 
@@ -320,6 +340,17 @@ For each registry item:
 - Keep `state=pr_open`, `step=ready_to_merge`
 - Wait for human to merge the PR
 - Reconcile with GitHub PR state:
+  ```bash
+  # Check PR status using gh CLI
+  PR_STATE=$(gh pr view "$pr_number" --repo "$repo" --json state -q '.state')
+  IS_MERGED=$(gh pr view "$pr_number" --repo "$repo" --json merged -q '.merged')
+  
+  if [ "$PR_STATE" = "MERGED" ] || [ "$IS_MERGED" = "true" ]; then
+    echo "PR #$pr_number has been merged"
+    jq ".state = \"done\" | .step = \"merged\"" "$worktree/.aiclaw/status.json" > /tmp/status.json && \
+      mv /tmp/status.json "$worktree/.aiclaw/status.json"
+  fi
+  ```
   - If merged: `state=done`
 
 ### `done`


### PR DESCRIPTION
## 修复 Issue #40

### 问题
wf-tick 没有检测 PR 合并状态，导致：
1. PR 合并后 registry 状态仍是 pr_open
2. worktree 没有被自动清理

### 修复
在 `pr_open` 和 `ready_to_merge` 状态添加 GitHub PR 状态检查：
- 使用 `gh pr view` 检查 PR 状态
- 检查 merged 字段
- 发现已合并则更新 status.json 为 done