### PR TITLE
fix: exclude llm_context_update from loop guard detection

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -415,12 +415,17 @@ func runInnerLoop(
 				newMessages = append(newMessages, result)
 			}
 			// Check if llm context was updated
-			if agentCtx.LLMContext != nil {
+			if agentCtx.LLMContext != nil || loopGuard != nil {
 				toolCalls := msg.ExtractToolCalls()
 				for _, tc := range toolCalls {
 					// Track if LLM called llm_context_decision tool
 					if strings.EqualFold(tc.Name, "llm_context_decision") {
 						agentCtx.LLMContext.MarkDecisionMade()
+					}
+					// Reset loop guard counter for llm_context_update tool
+					// This tool is used for task state management and should not trigger loop guard
+					if strings.EqualFold(tc.Name, "llm_context_update") {
+						loopGuard.ResetToolCount("llm_context_update")
 					}
 				}
 			}

--- a/pkg/agent/loop_recovery_test.go
+++ b/pkg/agent/loop_recovery_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"strings"
 	"testing"
@@ -770,5 +771,81 @@ func TestRunInnerLoopEmitsToolCallRecoveryEvent(t *testing.T) {
 	}
 	if !sawRecovery {
 		t.Fatal("expected tool_call_recovery event")
+	}
+}
+
+// TestRunInnerLoopLLMContextUpdateDoesNotTriggerLoopGuard verifies that llm_context_update
+// tool calls do not contribute to loop guard detection.
+func TestRunInnerLoopLLMContextUpdateDoesNotTriggerLoopGuard(t *testing.T) {
+	orig := streamAssistantResponseFn
+	defer func() { streamAssistantResponseFn = orig }()
+
+	callCount := 0
+	// Simulate LLM calling llm_context_update repeatedly, which should NOT trigger loop guard
+	streamAssistantResponseFn = func(
+		_ context.Context,
+		_ *agentctx.AgentContext,
+		_ *LoopConfig,
+		_ *llm.EventStream[AgentEvent, []agentctx.AgentMessage],
+	) (*agentctx.AgentMessage, error) {
+		callCount++
+		msg := agentctx.NewAssistantMessage()
+
+		// Call llm_context_update repeatedly - this should never trigger loop guard
+		// because we reset the counter after each execution
+		if callCount <= 10 {
+			msg.Content = []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:        "call-llm-context-" + fmt.Sprint(callCount),
+					Type:      "toolCall",
+					Name:      "llm_context_update",
+					Arguments: map[string]any{"content": fmt.Sprintf("task %d", callCount)},
+				},
+			}
+		} else {
+			// After 10+ iterations, just return "done" to stop
+			msg.Content = []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "done"},
+			}
+			msg.StopReason = "stop"
+			return &msg, nil
+		}
+		msg.StopReason = "tool_calls"
+		return &msg, nil
+	}
+
+	agentCtx := agentctx.NewAgentContext("sys")
+	agentCtx.Messages = append(agentCtx.Messages, agentctx.NewUserMessage("start"))
+
+	// Set a very low limit - without the fix, this would stop at 61 calls (default)
+	// With the fix, llm_context_update should be exempt and not trigger loop guard
+	stream := newTestAgentEventStream()
+	runInnerLoop(context.Background(), agentCtx, nil, &LoopConfig{
+		MaxConsecutiveToolCalls: 10,
+		MaxToolCallsPerName:     3, // Would stop any tool after 3 calls
+	}, stream)
+
+	// Should have more than 10 calls because llm_context_update resets its counter each time
+	// Without the fix, loop would stop at 61 calls (default) or earlier if MaxToolCallsPerName=3
+	if callCount <= 10 {
+		t.Fatalf("expected more than 10 LLM calls (llm_context_update should be exempt), got %d", callCount)
+	}
+
+	var guardTriggeredForLLMContextUpdate bool
+	for item := range stream.Iterator(context.Background()) {
+		if item.Done {
+			break
+		}
+		if item.Value.Type == EventLoopGuardTriggered && item.Value.LoopGuard != nil {
+			reason := item.Value.LoopGuard.Reason
+			// Check if loop guard was triggered for llm_context_update
+			if strings.Contains(reason, "llm_context_update") {
+				guardTriggeredForLLMContextUpdate = true
+			}
+		}
+	}
+
+	if guardTriggeredForLLMContextUpdate {
+		t.Fatal("llm_context_update should NOT trigger loop guard")
 	}
 }


### PR DESCRIPTION
## Summary

修复 loop guard regression：之前当 LLM 重复调用 llm_context_update 工具时会错误触发 loop guard。

## Problem

用户报告：

但实际情况是 LLM 在每次迭代中都调用了 llm_context_update，这个工具用于更新任务状态，不应该被计入循环检测。

## Root Cause

代码中存在  方法来排除特定工具的循环检测，但在重构后（从 write overview.md 改为调用 llm_context_update），这个方法从未被调用。

## Fix

在 loop.go 中工具执行后，检查是否有 llm_context_update 调用，如果有则调用  重置计数器。

## Testing

- 添加了新的测试  验证修复
- 所有现有测试通过