### PR TITLE
fix: add claw CI pipeline and implement missing Compactor methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
           cache: true
 
       - name: Download dependencies
@@ -38,4 +38,41 @@ jobs:
         with:
           name: coverage
           path: coverage.out
+          retention-days: 7
+
+  claw-build:
+    name: Build and Test (claw)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Download dependencies
+        working-directory: claw
+        run: make deps
+
+      - name: Build
+        working-directory: claw
+        run: make build
+
+      - name: Run vet
+        working-directory: claw
+        run: make vet
+
+      - name: Run tests
+        working-directory: claw
+        run: make test
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: claw-coverage
+          path: claw/coverage.out
           retention-days: 7

--- a/claw/pkg/adapter/adapter.go
+++ b/claw/pkg/adapter/adapter.go
@@ -188,6 +188,28 @@ func (c *clawCompactor) Compact(messages []agentctx.AgentMessage, previousSummar
 	}, nil
 }
 
+func (c *clawCompactor) CalculateDynamicThreshold() int {
+	c.mu.Lock()
+	comp := c.compactor
+	c.mu.Unlock()
+
+	if comp == nil {
+		return 0
+	}
+	return comp.CalculateDynamicThreshold()
+}
+
+func (c *clawCompactor) EstimateContextTokens(messages []agentctx.AgentMessage) int {
+	c.mu.Lock()
+	comp := c.compactor
+	c.mu.Unlock()
+
+	if comp == nil {
+		return 0
+	}
+	return comp.EstimateContextTokens(messages)
+}
+
 // Config 是 AgentLoop 的配置
 type Config struct {
 	Model        string          // 模型 ID，如 "claude-3-5-sonnet-20241022"


### PR DESCRIPTION
## 问题
1. claw/cmd/aiclaw 编译失败 - `clawCompactor` 缺少 `CalculateDynamicThreshold` 和 `EstimateContextTokens` 方法
2. CI 未拦截 - claw-ci.yml 的 paths 过滤只监控 `claw/**`，未监控依赖包修改

## 修复
- 在 `.github/workflows/ci.yml` 添加 `claw-build` job，每次 push/PR 都跑 claw 构建
- 在 `clawCompactor` 实现缺失的两个方法，委托给内部 `compact.Compactor`
- 统一 Go 版本为 1.26

## 测试
```bash
cd claw && make build  # ✅ 编译通过
cd claw && make test   # ✅ 测试通过
```