### PR TITLE
feat: improve context management with persistence and trace session tracking

### DIFF
--- a/claw/skills/session-analyzer/SKILL.md
+++ b/claw/skills/session-analyzer/SKILL.md
@@ -36,7 +36,9 @@ license: MIT
 **⚠️ 重要：路径必须正确**
 
 - **Sessions**: `~/.ai/sessions/--<cwd>--/<session-id>/messages.jsonl`
-- **Traces**: `~/.ai/traces/pid<pid>-sess<session-id>.perfetto.json`
+- **Traces**: `~/.ai/traces/pid<pid>-sess<session-id>.<N>.perfetto.json`
+  - N 是每次 prompt 递增的序号（1, 2, 3...）
+  - 大文件可能还有 `-part-X` 后缀
 
 **不是** `~/.aiclaw/` 目录！
 

--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -368,6 +368,10 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 			}
 			// Restore conversation history from session
 			ctx.Messages = sess.GetMessages()
+			// Set up persistence callback for compact operations
+			ctx.OnMessagesChanged = func() error {
+				return sess.SaveMessages(ctx.Messages)
+			}
 		}
 		return ctx
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -345,6 +345,14 @@ func (a *Agent) rotateTraceForPrompt(ctx context.Context) {
 	if err := a.traceBuf.DiscardOrFlush(ctx); err != nil {
 		slog.Error("[Agent] Failed to rotate trace file", "error", err)
 	}
+
+	// Increment prompt count for unique trace file naming
+	if handler := traceevent.GetHandler(); handler != nil {
+		if fh, ok := handler.(*traceevent.FileHandler); ok {
+			fh.IncrementPromptCount()
+		}
+	}
+
 	seq := int(a.traceSeq.Add(1))
 	a.traceBuf.SetTraceID(traceevent.GenerateTraceID("session", seq))
 }

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -746,6 +746,11 @@ func streamAssistantResponse(
 		}
 		llmMessages = append(llmMessages, reminderMsg)
 		agentCtx.LLMContext.SetWasReminded()
+
+		// Trace event for context update reminder
+		traceevent.Log(ctx, traceevent.CategoryEvent, "context_update_reminder",
+			traceevent.Field{Key: "reminder_type", Value: "llm_context_update"},
+		)
 	}
 
 	// Inject decision reminder if LLM updated overview but didn't call llm_context_decision tool
@@ -764,6 +769,12 @@ func streamAssistantResponse(
 			Content: decisionReminderContent,
 		}
 		llmMessages = append(llmMessages, decisionReminderMsg)
+
+		// Trace event for context decision reminder
+		traceevent.Log(ctx, traceevent.CategoryEvent, "context_decision_reminder",
+			traceevent.Field{Key: "reminder_type", Value: "llm_context_decision"},
+			traceevent.Field{Key: "stale_tool_outputs", Value: staleCount},
+		)
 	}
 
 	// Convert tools to LLM format
@@ -1648,6 +1659,44 @@ func updateRuntimeMetaSnapshot(agentCtx *agentctx.AgentContext, meta agentctx.Co
 		cmStats = "  your_score: no_data_yet"
 	}
 
+	// Build update metrics section
+	var updateMetrics string
+	if agentCtx.LLMContext != nil {
+		updateStats := agentCtx.LLMContext.GetUpdateStats()
+		if updateStats.Total > 0 {
+			updateMetrics = fmt.Sprintf(`
+context_metrics:
+  update:
+    total: %d
+    autonomous: %d
+    prompted: %d
+    consciousness: %d%%
+    score: %s
+  decision:
+    proactive: %d
+    reminded: %d
+    score: %s`,
+				updateStats.Total,
+				updateStats.Autonomous,
+				updateStats.Prompted,
+				updateStats.ConsciousPct,
+				updateStats.Score,
+				state.ProactiveDecisions,
+				state.ReminderNeeded,
+				state.GetScore())
+		} else {
+			updateMetrics = `
+context_metrics:
+  update:
+    total: 0
+    score: no_data
+  decision:
+    proactive: 0
+    reminded: 0
+    score: no_data_yet`
+		}
+	}
+
 	snapshot := fmt.Sprintf(`<runtime_state>
 context_meta:
   tokens_band: %s
@@ -1665,7 +1714,7 @@ context_management:
   action_required: %s
   urgency: %s
   skip_until_turn: %d
-%s
+%s%s
 compact_decision_signals:
   context_usage_percent: %.1f
   topic_shift_since_last_user: llm_judge
@@ -1694,6 +1743,7 @@ guidance:
 		urgency,
 		state.SkipUntilTurn,
 		cmStats,
+		updateMetrics,
 		meta.TokensPercent,
 		yesNo(fastPathAllowed),
 		stageHint,

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -271,7 +271,12 @@ func runInnerLoop(
 				if compacted != nil {
 					agentCtx.Messages = compacted.Messages
 					agentCtx.LastCompactionSummary = compacted.Summary
-					// Note: SaveCompactionSummary is now handled inside Session.Compact()
+					// Persist changes to session storage
+					if agentCtx.OnMessagesChanged != nil {
+						if persistErr := agentCtx.OnMessagesChanged(); persistErr != nil {
+							slog.Warn("[Agent] Failed to persist compacted messages", "error", persistErr)
+						}
+					}
 				}
 				// Set flag to inject overview.md for recovery on next request
 				agentCtx.PostCompactRecovery = true
@@ -324,7 +329,12 @@ func runInnerLoop(
 					if compacted != nil {
 						agentCtx.Messages = compacted.Messages
 						agentCtx.LastCompactionSummary = compacted.Summary
-						// Note: SaveCompactionSummary is now handled inside Session.Compact()
+						// Persist changes to session storage
+						if agentCtx.OnMessagesChanged != nil {
+							if persistErr := agentCtx.OnMessagesChanged(); persistErr != nil {
+								slog.Warn("[Agent] Failed to persist compacted messages", "error", persistErr)
+							}
+						}
 					}
 					// Set flag to inject overview.md for recovery on next request
 					agentCtx.PostCompactRecovery = true
@@ -769,6 +779,11 @@ func streamAssistantResponse(
 			Content: decisionReminderContent,
 		}
 		llmMessages = append(llmMessages, decisionReminderMsg)
+
+		// Record that a reminder was shown this turn (for proactive/reminded tracking)
+		if agentCtx.ContextMgmtState != nil {
+			agentCtx.ContextMgmtState.RecordReminder(agentCtx.ContextMgmtState.CurrentTurn, "high")
+		}
 
 		// Trace event for context decision reminder
 		traceevent.Log(ctx, traceevent.CategoryEvent, "context_decision_reminder",
@@ -1590,74 +1605,20 @@ func updateRuntimeMetaSnapshot(agentCtx *agentctx.AgentContext, meta agentctx.Co
 		agentCtx.RuntimeMetaTurns >= heartbeatTurns
 
 	if !shouldRefresh {
-		if agentCtx.LLMContext != nil {
-			agentCtx.LLMContext.SetDecisionNeededThisTurn(runtimeSnapshotNeedsDecision(agentCtx.RuntimeMetaSnapshot))
-		}
 		return agentCtx.RuntimeMetaSnapshot, false
 	}
 
 	tokensUsedApprox := normalizeApprox(meta.TokensUsed)
 	toolPressure := collectRuntimeToolPressure(agentCtx.Messages)
 	toolOutputsSummary := buildToolOutputsSummary(agentCtx.Messages)
-	stageHint := runtimeContextManagementHint(meta.TokensPercent)
 	actionHint := runtimeActionHint(band)
 	fastPathAllowed := actionHint == "normal" && toolPressure.StaleCount == 0 && toolPressure.LargeCount == 0
-
-	// Determine action_required based on tool pressure and context usage
-	actionRequired := "none"
-	urgency := "none"
-	if meta.TokensPercent >= 65 || toolPressure.StaleCount > 20 || toolPressure.LargeCount > 5 {
-		actionRequired = "compact"
-		urgency = "critical"
-	} else if meta.TokensPercent >= 50 || toolPressure.StaleCount > 10 || toolPressure.LargeCount > 3 {
-		actionRequired = "truncate"
-		urgency = "high"
-	} else if meta.TokensPercent >= 30 || toolPressure.StaleCount > 5 {
-		actionRequired = "truncate"
-		urgency = "medium"
-	} else if toolOutputsSummary != "none" {
-		actionRequired = "truncate"
-		urgency = "low"
-	}
 
 	// Get or initialize ContextMgmtState
 	if agentCtx.ContextMgmtState == nil {
 		agentCtx.ContextMgmtState = agentctx.DefaultContextMgmtState()
 	}
 	state := agentCtx.ContextMgmtState
-
-	// Check if we should show reminder based on adaptive frequency
-	// If we're in a skip period or haven't reached the frequency threshold, suppress the reminder
-	// Use CurrentTurn instead of RuntimeMetaTurns to ensure consistency with llm_context_decision tool
-	showReminder := state.ShouldShowReminder(agentCtx.ContextMgmtState.CurrentTurn, actionRequired, urgency, int(meta.TokensPercent))
-	if !showReminder && actionRequired != "none" {
-		// Suppress the reminder - don't show action_required in runtime_state
-		actionRequired = "none"
-		urgency = "none"
-	} else if showReminder && actionRequired != "none" {
-		// We're showing a reminder, record it
-		state.RecordReminder(state.CurrentTurn, urgency)
-		// Mark that reminder was shown this turn (for compliance tracking)
-		state.MarkReminderShown()
-	}
-	if agentCtx.LLMContext != nil {
-		agentCtx.LLMContext.SetDecisionNeededThisTurn(actionRequired != "none")
-	}
-
-	// Build context management stats section
-	var cmStats string
-	if state.ProactiveDecisions > 0 || state.ReminderNeeded > 0 {
-		cmStats = fmt.Sprintf(`  your_score: %s
-  proactive_decisions: %d
-  reminders_needed: %d
-  current_frequency: every %d turns`,
-			state.GetScore(),
-			state.ProactiveDecisions,
-			state.ReminderNeeded,
-			state.ReminderFrequency)
-	} else {
-		cmStats = "  your_score: no_data_yet"
-	}
 
 	// Build update metrics section
 	var updateMetrics string
@@ -1697,7 +1658,9 @@ context_metrics:
 		}
 	}
 
-	snapshot := fmt.Sprintf(`<runtime_state>
+	// runtime_state is purely informational - no directives or commands
+	// Reminders are handled separately via NeedsReminderMessage/NeedsDecisionReminder
+	snapshot := fmt.Sprintf(`<agent:runtime_state comment="telemetry snapshot, updated periodically"/>
 context_meta:
   tokens_band: %s
   action_hint: %s
@@ -1709,26 +1672,14 @@ tool_output_pressure:
   stale_tool_outputs_bucket: %s
   tool_outputs_summary: %s
   large_tool_outputs_bucket: %s
-  largest_tool_output_bucket: %s
-context_management:
-  action_required: %s
-  urgency: %s
-  skip_until_turn: %d
-%s%s
+  largest_tool_output_bucket: %s%s
 compact_decision_signals:
   context_usage_percent: %.1f
   topic_shift_since_last_user: llm_judge
   phase_completed_recently: llm_judge
   llm_judge_hint: Compare the latest user intent with recent task thread and milestone status, then set COMPACT confidence accordingly.
 decision:
-  fast_path_allowed: %s
-guidance:
-  - If action_required is not "none", you MUST call llm_context_decision tool BEFORE answering the user.
-  - Use decision="skip" with appropriate skip_turns (1-30) to defer when not urgent.
-  - Higher skip_turns values (15-30) indicate you promise to be proactive; this increases trust and reduces reminder frequency.
-  - Lower skip_turns values (1-5) are for uncertain situations; reminders will come more frequently.
-  - Stage hint: %s
-</runtime_state>`,
+  fast_path_allowed: %s`,
 		band,
 		actionHint,
 		tokensUsedApprox,
@@ -1739,14 +1690,9 @@ guidance:
 		toolOutputsSummary,
 		runtimeCountBucket(toolPressure.LargeCount),
 		runtimeToolOutputSizeBucket(toolPressure.LargestChars),
-		actionRequired,
-		urgency,
-		state.SkipUntilTurn,
-		cmStats,
 		updateMetrics,
 		meta.TokensPercent,
 		yesNo(fastPathAllowed),
-		stageHint,
 	)
 
 	agentCtx.RuntimeMetaSnapshot = snapshot
@@ -1754,16 +1700,6 @@ guidance:
 	agentCtx.RuntimeMetaTurns = 0
 
 	return snapshot, true
-}
-
-func runtimeSnapshotNeedsDecision(snapshot string) bool {
-	if snapshot == "" {
-		return false
-	}
-	if strings.Contains(snapshot, "action_required: none") {
-		return false
-	}
-	return strings.Contains(snapshot, "action_required:")
 }
 
 type runtimeToolPressure struct {

--- a/pkg/agent/loop_stream_integration_test.go
+++ b/pkg/agent/loop_stream_integration_test.go
@@ -146,7 +146,7 @@ func TestStreamAssistantResponse_RuntimeStateInjectedAsUserMessage(t *testing.T)
 		t.Fatalf("expected runtime user content to NOT include llm_context in normal request, got: %q", runtimeContent)
 	}
 	// runtime_state should still be injected
-	if !strings.Contains(runtimeContent, "<runtime_state>") {
+	if !strings.Contains(runtimeContent, "<agent:runtime_state") {
 		t.Fatalf("expected runtime user content to include runtime_state, got: %q", runtimeContent)
 	}
 }
@@ -355,7 +355,7 @@ func TestStreamAssistantResponse_KeepsSeveralRecentRealUserTurns(t *testing.T) {
 		if strings.Contains(content, "<llm_context>") {
 			continue // runtime state injection (llm context part)
 		}
-		if strings.Contains(content, "<runtime_state>") {
+		if strings.Contains(content, "<agent:runtime_state") {
 			continue // runtime state injection (meta part)
 		}
 		if strings.Contains(content, "[system message by agent, not from real user]") {

--- a/pkg/agent/metrics.go
+++ b/pkg/agent/metrics.go
@@ -21,11 +21,12 @@ type Metrics struct {
 	flushInterval time.Duration
 
 	// Cached aggregations (updated on demand)
-	cachedToolStats    map[string]*toolStatsCache
-	cachedLLMStats     *llmStatsCache
-	cachedPromptStats  *promptStatsCache
-	cachedMessageStats *messageStatsCache
-	cacheValid         bool
+	cachedToolStats     map[string]*toolStatsCache
+	cachedLLMStats      *llmStatsCache
+	cachedPromptStats   *promptStatsCache
+	cachedMessageStats  *messageStatsCache
+	cachedContextStats  *contextStatsCache
+	cacheValid          bool
 
 	// Incremental aggregation state
 	lastAggregatedCount int       // Number of events aggregated last time
@@ -110,6 +111,14 @@ type messageStatsCache struct {
 	ToolResults       int64
 }
 
+// contextStatsCache holds aggregated context management statistics
+type contextStatsCache struct {
+	UpdateReminders   int64
+	DecisionReminders int64
+	LastReminderType  string
+	LastReminderAtNs  int64
+}
+
 // NewMetrics creates a new metrics collector attached to a trace buffer.
 func NewMetrics(buf *traceevent.TraceBuf) *Metrics {
 	return &Metrics{
@@ -120,6 +129,7 @@ func NewMetrics(buf *traceevent.TraceBuf) *Metrics {
 		cachedLLMStats:      &llmStatsCache{RecentWindowSeconds: int64(defaultLLMRecentWindow.Seconds())},
 		cachedPromptStats:   &promptStatsCache{},
 		cachedMessageStats:  &messageStatsCache{},
+		cachedContextStats:  &contextStatsCache{},
 		lastAggregatedCount: 0,
 		lastAggregatedTime:  time.Time{},
 		bufferResetDetected: false,
@@ -169,7 +179,7 @@ func (m *Metrics) refreshAggregations() {
 		!m.lastAggregatedTime.IsZero() &&
 		newestEventTime.After(m.lastAggregatedTime)
 
-	// Detect buffer reset/overwrite and fall back to full re-aggregation.
+// Detect buffer reset/overwrite and fall back to full re-aggregation.
 	needsFullAggregation := m.bufferResetDetected ||
 		currentCount < m.lastAggregatedCount ||
 		newestWentBackward ||
@@ -181,6 +191,7 @@ func (m *Metrics) refreshAggregations() {
 		m.cachedLLMStats = &llmStatsCache{RecentWindowSeconds: int64(defaultLLMRecentWindow.Seconds())}
 		m.cachedPromptStats = &promptStatsCache{}
 		m.cachedMessageStats = &messageStatsCache{}
+		m.cachedContextStats = &contextStatsCache{}
 
 		for _, event := range events {
 			m.aggregateEvent(event)
@@ -272,6 +283,8 @@ func (m *Metrics) aggregateEvent(event traceevent.TraceEvent) {
 		m.aggregateTool(event)
 	case "message_end":
 		m.aggregateMessage(event)
+	case "context_update_reminder", "context_decision_reminder":
+		m.aggregateContext(event)
 	}
 }
 
@@ -415,6 +428,24 @@ func (m *Metrics) aggregateMessage(event traceevent.TraceEvent) {
 		m.cachedMessageStats.UserMessages++
 	case "assistant":
 		m.cachedMessageStats.AssistantMessages++
+	}
+}
+
+// aggregateContext processes context management reminder events
+func (m *Metrics) aggregateContext(event traceevent.TraceEvent) {
+	if event.Phase != traceevent.PhaseInstant {
+		return
+	}
+
+	reminderType := traceFieldString(event.Fields, "reminder_type")
+	m.cachedContextStats.LastReminderType = reminderType
+	m.cachedContextStats.LastReminderAtNs = event.Timestamp.UnixNano()
+
+	switch event.Name {
+	case "context_update_reminder":
+		m.cachedContextStats.UpdateReminders++
+	case "context_decision_reminder":
+		m.cachedContextStats.DecisionReminders++
 	}
 }
 
@@ -596,6 +627,16 @@ func (m *Metrics) messageCountsSnapshotLocked() MessageCountsSnapshot {
 	}
 }
 
+func (m *Metrics) contextMetricsSnapshotLocked() ContextMetricsSnapshot {
+	return ContextMetricsSnapshot{
+		UpdateReminders:   m.cachedContextStats.UpdateReminders,
+		DecisionReminders: m.cachedContextStats.DecisionReminders,
+		TotalReminders:    m.cachedContextStats.UpdateReminders + m.cachedContextStats.DecisionReminders,
+		LastReminderType:  m.cachedContextStats.LastReminderType,
+		LastReminderAt:    timeFromNs(m.cachedContextStats.LastReminderAtNs),
+	}
+}
+
 // GetAllTools returns all tool names that have metrics.
 func (m *Metrics) GetAllTools() []string {
 	m.refreshAggregations()
@@ -631,11 +672,12 @@ func (m *Metrics) GetFullMetrics() FullMetricsSnapshot {
 	}
 
 	return FullMetricsSnapshot{
-		SessionUptime: time.Since(m.sessionStart),
-		ToolMetrics:   toolSnapshots,
-		LLMMetrics:    m.llmMetricsSnapshotLocked(),
-		MessageCounts: m.messageCountsSnapshotLocked(),
-		PromptMetrics: m.promptMetricsSnapshotLocked(),
+		SessionUptime:  time.Since(m.sessionStart),
+		ToolMetrics:    toolSnapshots,
+		LLMMetrics:     m.llmMetricsSnapshotLocked(),
+		MessageCounts:  m.messageCountsSnapshotLocked(),
+		PromptMetrics:  m.promptMetricsSnapshotLocked(),
+		ContextMetrics: m.contextMetricsSnapshotLocked(),
 	}
 }
 
@@ -653,6 +695,7 @@ func (m *Metrics) Reset() {
 	m.cachedLLMStats = &llmStatsCache{RecentWindowSeconds: int64(defaultLLMRecentWindow.Seconds())}
 	m.cachedPromptStats = &promptStatsCache{}
 	m.cachedMessageStats = &messageStatsCache{}
+	m.cachedContextStats = &contextStatsCache{}
 	m.cacheValid = false
 	m.sessionStart = time.Now()
 
@@ -873,10 +916,19 @@ type PromptMetricsSnapshot struct {
 	LastEnd          time.Time     `json:"lastEnd"`
 }
 
+type ContextMetricsSnapshot struct {
+	UpdateReminders   int64     `json:"updateReminders"`
+	DecisionReminders int64     `json:"decisionReminders"`
+	TotalReminders    int64     `json:"totalReminders"`
+	LastReminderType  string    `json:"lastReminderType"`
+	LastReminderAt    time.Time `json:"lastReminderAt"`
+}
+
 type FullMetricsSnapshot struct {
-	SessionUptime time.Duration         `json:"sessionUptime"`
-	ToolMetrics   []ToolMetricsSnapshot `json:"toolMetrics"`
-	LLMMetrics    LLMMetricsSnapshot    `json:"llmMetrics"`
-	MessageCounts MessageCountsSnapshot `json:"messageCounts"`
-	PromptMetrics PromptMetricsSnapshot `json:"promptMetrics"`
+	SessionUptime   time.Duration         `json:"sessionUptime"`
+	ToolMetrics     []ToolMetricsSnapshot `json:"toolMetrics"`
+	LLMMetrics      LLMMetricsSnapshot    `json:"llmMetrics"`
+	MessageCounts   MessageCountsSnapshot `json:"messageCounts"`
+	PromptMetrics   PromptMetricsSnapshot `json:"promptMetrics"`
+	ContextMetrics  ContextMetricsSnapshot `json:"contextMetrics"`
 }

--- a/pkg/agent/runtime_meta_test.go
+++ b/pkg/agent/runtime_meta_test.go
@@ -180,9 +180,8 @@ func TestBuildToolOutputsSummaryUsesStaleHistoryExcludingRecent10(t *testing.T) 
 	if !containsString(summary, "1 bash, 1 read") {
 		t.Fatalf("expected grouped tool counts, got: %s", summary)
 	}
-	if !containsString(summary, "consider TRUNCATE") {
-		t.Fatalf("expected truncate guidance, got: %s", summary)
-	}
+	// Note: guidance is no longer included in buildToolOutputsSummary
+	// LLM decides based on runtime_state telemetry
 }
 
 func TestUpdateRuntimeMetaSnapshotIncludesCompactDecisionSignals(t *testing.T) {
@@ -241,9 +240,8 @@ func TestUpdateRuntimeMetaSnapshotRecordsReminderUsingCurrentTurn(t *testing.T) 
 	if !refreshed {
 		t.Fatal("expected refreshed snapshot")
 	}
-	if agentCtx.ContextMgmtState.LastReminderTurn != 7 {
-		t.Fatalf("expected LastReminderTurn to use CurrentTurn=7, got %d", agentCtx.ContextMgmtState.LastReminderTurn)
-	}
+	// Note: LastReminderTurn is now set when reminder is actually shown (in streamAssistantResponse)
+	// not in updateRuntimeMetaSnapshot which is telemetry-only
 }
 
 func TestRuntimeContextManagementHintByUsageStage(t *testing.T) {

--- a/pkg/agent/runtime_meta_test.go
+++ b/pkg/agent/runtime_meta_test.go
@@ -425,3 +425,36 @@ func TestFindLatestToolCallID(t *testing.T) {
 		t.Fatalf("expected empty string for nonexistent tool, got %s", id)
 	}
 }
+
+func TestUpdateRuntimeMetaSnapshotIncludesContextMetrics(t *testing.T) {
+	agentCtx := agentctx.NewAgentContext("sys")
+	agentCtx.LLMContext = agentctx.NewLLMContext(t.TempDir())
+
+	meta := agentctx.ContextMeta{
+		TokensUsed:        12345,
+		TokensMax:         128000,
+		TokensPercent:     15.0,
+		MessagesInHistory: 10,
+		LLMContextSize:    500,
+	}
+
+	snapshot, _ := updateRuntimeMetaSnapshot(agentCtx, meta, 3)
+
+	// Should contain context_metrics section
+	if !containsString(snapshot, "context_metrics:") {
+		t.Fatalf("expected context_metrics section in snapshot:\n%s", snapshot)
+	}
+
+	// Should have update subsection with no_data initially
+	if !containsString(snapshot, "update:") {
+		t.Fatalf("expected update subsection:\n%s", snapshot)
+	}
+	if !containsString(snapshot, "total: 0") {
+		t.Fatalf("expected total: 0 for no data yet:\n%s", snapshot)
+	}
+
+	// Should have decision subsection
+	if !containsString(snapshot, "decision:") {
+		t.Fatalf("expected decision subsection:\n%s", snapshot)
+	}
+}

--- a/pkg/agent/tool_metadata.go
+++ b/pkg/agent/tool_metadata.go
@@ -163,7 +163,7 @@ func buildToolOutputsSummary(messages []agentctx.AgentMessage) string {
 		parts = append(parts, "...")
 	}
 
-	return fmt.Sprintf("%d stale outputs (%s), consider TRUNCATE", staleCount, strings.Join(parts, ", "))
+	return fmt.Sprintf("%d stale outputs (%s)", staleCount, strings.Join(parts, ", "))
 }
 
 // buildToolOutputsSummaryWithIDs returns summary and list of tool call IDs that can be truncated.
@@ -241,6 +241,6 @@ func buildToolOutputsSummaryWithIDs(messages []agentctx.AgentMessage) (string, [
 		allIDs = append(allIDs, ids...)
 	}
 
-	summary := fmt.Sprintf("%d stale outputs (%s), consider TRUNCATE", staleCount, strings.Join(parts, ", "))
+	summary := fmt.Sprintf("%d stale outputs (%s)", staleCount, strings.Join(parts, ", "))
 	return summary, allIDs
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -33,6 +33,10 @@ type AgentContext struct {
 	// PostCompactRecovery indicates that overview.md should be injected for recovery after compact.
 	// Set after compact completes, reset after injection.
 	PostCompactRecovery bool `json:"-"`
+
+	// OnMessagesChanged is called when messages are modified (e.g., after compact).
+	// This allows persistence to session storage.
+	OnMessagesChanged func() error `json:"-"`
 }
 
 // ContextMgmtState tracks LLM's context management decisions for adaptive reminder frequency.

--- a/pkg/context/llm_context.go
+++ b/pkg/context/llm_context.go
@@ -64,7 +64,6 @@ type LLMContext struct {
 
 	// Decision tracking - for separate reminder when LLM updates overview but doesn't call llm_context_decision.
 	updatedOverviewThisTurn   bool // LLM updated overview in the current turn
-	decisionNeededThisTurn    bool // runtime_state.action_required != none for the current turn
 	pendingDecisionReminder   bool // Waiting for llm_context_decision after overview update
 	roundsSinceDecisionNeeded int  // Rounds since decision became pending
 	staleToolOutputs          int  // Number of stale tool outputs (updated from runtime)
@@ -647,53 +646,76 @@ func (wm *LLMContext) SetUpdatedOverview() {
 	wm.updatedOverviewThisTurn = true
 }
 
-// SetDecisionNeededThisTurn marks whether context management is required in this turn.
-func (wm *LLMContext) SetDecisionNeededThisTurn(needed bool) {
-	wm.mu.Lock()
-	defer wm.mu.Unlock()
-	wm.decisionNeededThisTurn = needed
-}
-
 // MarkDecisionMade marks that LLM called llm_context_decision tool.
 // This resets the decision reminder counter.
 func (wm *LLMContext) MarkDecisionMade() {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
 	wm.updatedOverviewThisTurn = false
-	wm.decisionNeededThisTurn = false
 	wm.pendingDecisionReminder = false
 	wm.roundsSinceDecisionNeeded = 0
 }
 
 // NeedsDecisionReminder checks if a decision reminder should be shown.
 // This is separate from overview update reminder - it triggers when:
-// - LLM has updated overview.md
-// - But hasn't called llm_context_decision tool
-// - And decision is still needed (action_required != "none")
+// - Context pressure is high (tokens or stale outputs)
+// - LLM hasn't called llm_context_decision tool recently
+//
+// The trigger is based on actual context pressure, not SetDecisionNeededThisTurn.
 func (wm *LLMContext) NeedsDecisionReminder() bool {
 	wm.mu.RLock()
 	defer wm.mu.RUnlock()
+
+	// Check if there's actual pressure requiring a decision
+	tokensPercent := 0.0
+	if wm.tokensMax > 0 {
+		tokensPercent = float64(wm.tokensUsed) / float64(wm.tokensMax) * 100
+	}
+
+	// Decision is needed when:
+	// - Token usage >= 30% AND stale outputs exist
+	// - OR token usage >= 50%
+	// - OR many stale outputs (>= 10)
+	hasPressure := (tokensPercent >= 30 && wm.staleToolOutputs > 0) ||
+		tokensPercent >= 50 ||
+		wm.staleToolOutputs >= 10
+
+	if !hasPressure {
+		return false
+	}
+
+	// Only remind after a delay (roundsSinceDecisionNeeded >= 2)
+	// This gives LLM time to act on the runtime_state information
 	return wm.pendingDecisionReminder && wm.roundsSinceDecisionNeeded >= 2
 }
 
 // AdvanceDecisionState advances per-turn decision reminder state at turn boundary.
+// It now calculates pressure internally based on tokens and stale outputs.
 func (wm *LLMContext) AdvanceDecisionState(decisionMadeThisTurn bool) {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
 
+	// Calculate current pressure
+	tokensPercent := 0.0
+	if wm.tokensMax > 0 {
+		tokensPercent = float64(wm.tokensUsed) / float64(wm.tokensMax) * 100
+	}
+
+	hasPressure := (tokensPercent >= 30 && wm.staleToolOutputs > 0) ||
+		tokensPercent >= 50 ||
+		wm.staleToolOutputs >= 10
+
 	if decisionMadeThisTurn {
 		wm.updatedOverviewThisTurn = false
-		wm.decisionNeededThisTurn = false
 		wm.pendingDecisionReminder = false
 		wm.roundsSinceDecisionNeeded = 0
 		return
 	}
 
-	if !wm.decisionNeededThisTurn {
+	if !hasPressure {
 		wm.pendingDecisionReminder = false
 		wm.roundsSinceDecisionNeeded = 0
 		wm.updatedOverviewThisTurn = false
-		wm.decisionNeededThisTurn = false
 		return
 	}
 
@@ -706,7 +728,6 @@ func (wm *LLMContext) AdvanceDecisionState(decisionMadeThisTurn bool) {
 	}
 
 	wm.updatedOverviewThisTurn = false
-	wm.decisionNeededThisTurn = false
 }
 
 // SetStaleToolCount sets the number of stale tool outputs (called from runtime).

--- a/pkg/context/llm_context.go
+++ b/pkg/context/llm_context.go
@@ -578,6 +578,44 @@ func (wm *LLMContext) GetUpdateConsciousness() float64 {
 	return float64(wm.autonomousUpdates) / float64(wm.totalUpdates)
 }
 
+// UpdateStats contains statistics about llm_context_update tool calls.
+type UpdateStats struct {
+	Total       int
+	Autonomous  int
+	Prompted    int
+	Score       string // "excellent", "good", "needs_improvement", "no_data"
+	ConsciousPct int   // percentage 0-100
+}
+
+// GetUpdateStats returns statistics about llm_context_update tool calls.
+func (wm *LLMContext) GetUpdateStats() UpdateStats {
+	wm.mu.RLock()
+	defer wm.mu.RUnlock()
+
+	stats := UpdateStats{
+		Total:      wm.totalUpdates,
+		Autonomous: wm.autonomousUpdates,
+		Prompted:   wm.promptedUpdates,
+	}
+
+	if wm.totalUpdates > 0 {
+		stats.ConsciousPct = int(float64(wm.autonomousUpdates) * 100 / float64(wm.totalUpdates))
+		// Score based on autonomous percentage
+		switch {
+		case stats.ConsciousPct >= 80:
+			stats.Score = "excellent"
+		case stats.ConsciousPct >= 60:
+			stats.Score = "good"
+		default:
+			stats.Score = "needs_improvement"
+		}
+	} else {
+		stats.Score = "no_data"
+	}
+
+	return stats
+}
+
 // GetNextReminderRound returns the current dynamic threshold
 func (wm *LLMContext) GetNextReminderRound() int {
 	wm.mu.RLock()

--- a/pkg/context/llm_context_decision_state_test.go
+++ b/pkg/context/llm_context_decision_state_test.go
@@ -5,20 +5,21 @@ import "testing"
 func TestDecisionReminderTriggersAfterPendingThreshold(t *testing.T) {
 	wm := NewLLMContext(t.TempDir())
 
-	wm.SetDecisionNeededThisTurn(true)
+	// Set pressure: 35% tokens + stale outputs
+	wm.UpdateMeta(70000, 200000, 10) // 35% tokens
+	wm.SetStaleToolCount(5)
+
 	wm.SetUpdatedOverview()
 	wm.AdvanceDecisionState(false)
 	if wm.NeedsDecisionReminder() {
 		t.Fatal("did not expect reminder in overview update turn")
 	}
 
-	wm.SetDecisionNeededThisTurn(true)
 	wm.AdvanceDecisionState(false)
 	if wm.NeedsDecisionReminder() {
 		t.Fatal("did not expect reminder before threshold")
 	}
 
-	wm.SetDecisionNeededThisTurn(true)
 	wm.AdvanceDecisionState(false)
 	if !wm.NeedsDecisionReminder() {
 		t.Fatal("expected reminder after two pending rounds")
@@ -28,23 +29,31 @@ func TestDecisionReminderTriggersAfterPendingThreshold(t *testing.T) {
 func TestDecisionReminderClearsWhenDecisionNotNeeded(t *testing.T) {
 	wm := NewLLMContext(t.TempDir())
 
-	wm.SetDecisionNeededThisTurn(true)
+	// Set pressure: 35% tokens + stale outputs
+	wm.UpdateMeta(70000, 200000, 10) // 35% tokens
+	wm.SetStaleToolCount(5)
+
 	wm.SetUpdatedOverview()
 	wm.AdvanceDecisionState(false)
 
-	wm.SetDecisionNeededThisTurn(true)
 	wm.AdvanceDecisionState(false)
 	if wm.NeedsDecisionReminder() {
 		t.Fatal("did not expect reminder before threshold")
 	}
 
-	wm.SetDecisionNeededThisTurn(false)
+	// Remove pressure: low tokens + no stale outputs
+	wm.UpdateMeta(10000, 200000, 10) // 5% tokens
+	wm.SetStaleToolCount(0)
+
 	wm.AdvanceDecisionState(false)
 	if wm.NeedsDecisionReminder() {
 		t.Fatal("expected reminder state to reset when decision is not needed")
 	}
 
-	wm.SetDecisionNeededThisTurn(true)
+	// Re-add pressure
+	wm.UpdateMeta(70000, 200000, 10) // 35% tokens
+	wm.SetStaleToolCount(5)
+
 	wm.AdvanceDecisionState(false)
 	if wm.NeedsDecisionReminder() {
 		t.Fatal("did not expect reminder without a new overview update")
@@ -54,13 +63,14 @@ func TestDecisionReminderClearsWhenDecisionNotNeeded(t *testing.T) {
 func TestDecisionReminderClearsWhenDecisionMade(t *testing.T) {
 	wm := NewLLMContext(t.TempDir())
 
-	wm.SetDecisionNeededThisTurn(true)
+	// Set pressure: 35% tokens + stale outputs
+	wm.UpdateMeta(70000, 200000, 10) // 35% tokens
+	wm.SetStaleToolCount(5)
+
 	wm.SetUpdatedOverview()
 	wm.AdvanceDecisionState(false)
 
-	wm.SetDecisionNeededThisTurn(true)
 	wm.AdvanceDecisionState(false)
-	wm.SetDecisionNeededThisTurn(true)
 	wm.AdvanceDecisionState(false)
 	if !wm.NeedsDecisionReminder() {
 		t.Fatal("expected reminder before decision is made")
@@ -69,5 +79,56 @@ func TestDecisionReminderClearsWhenDecisionMade(t *testing.T) {
 	wm.AdvanceDecisionState(true)
 	if wm.NeedsDecisionReminder() {
 		t.Fatal("expected reminder state to clear after decision is made")
+	}
+}
+
+func TestDecisionReminderNoPressure(t *testing.T) {
+	wm := NewLLMContext(t.TempDir())
+
+	// No pressure: low tokens + no stale outputs
+	wm.UpdateMeta(10000, 200000, 10) // 5% tokens
+	wm.SetStaleToolCount(0)
+
+	wm.SetUpdatedOverview()
+	wm.AdvanceDecisionState(false)
+	wm.AdvanceDecisionState(false)
+	wm.AdvanceDecisionState(false)
+
+	if wm.NeedsDecisionReminder() {
+		t.Fatal("expected no reminder when there's no pressure")
+	}
+}
+
+func TestDecisionReminderHighTokens(t *testing.T) {
+	wm := NewLLMContext(t.TempDir())
+
+	// High pressure: 55% tokens (no stale outputs needed)
+	wm.UpdateMeta(110000, 200000, 10) // 55% tokens
+	wm.SetStaleToolCount(0)
+
+	wm.SetUpdatedOverview()
+	wm.AdvanceDecisionState(false)
+	wm.AdvanceDecisionState(false)
+	wm.AdvanceDecisionState(false)
+
+	if !wm.NeedsDecisionReminder() {
+		t.Fatal("expected reminder when tokens >= 50%")
+	}
+}
+
+func TestDecisionReminderManyStaleOutputs(t *testing.T) {
+	wm := NewLLMContext(t.TempDir())
+
+	// High pressure: 10+ stale outputs (low tokens)
+	wm.UpdateMeta(10000, 200000, 10) // 5% tokens
+	wm.SetStaleToolCount(15)
+
+	wm.SetUpdatedOverview()
+	wm.AdvanceDecisionState(false)
+	wm.AdvanceDecisionState(false)
+	wm.AdvanceDecisionState(false)
+
+	if !wm.NeedsDecisionReminder() {
+		t.Fatal("expected reminder when stale outputs >= 10")
 	}
 }

--- a/pkg/prompt/base.md
+++ b/pkg/prompt/base.md
@@ -4,3 +4,5 @@ You are a pragmatic AI coding assistant.
 - Do not hallucinate tools, file contents, command outputs, or capabilities.
 - Use tools for file/system operations; never pretend a tool was executed.
 - Analyze tool errors before retrying; do not loop blindly.
+- For normal conversation, respond in natural language.
+- If the user explicitly requires a JSON schema, output valid JSON only.

--- a/pkg/prompt/base.md
+++ b/pkg/prompt/base.md
@@ -1,8 +1,6 @@
 You are a pragmatic AI coding assistant.
 - Be accurate and concise. Avoid unnecessary commentary.
-- Do not hallucinate tools, file contents, command outputs, or capabilities.
 - Respect facts and critically evaluate user assumptions; do not blindly agree.
+- Do not hallucinate tools, file contents, command outputs, or capabilities.
 - Use tools for file/system operations; never pretend a tool was executed.
 - Analyze tool errors before retrying; do not loop blindly.
-- For normal conversation, respond in natural language.
-- If the user explicitly requires a JSON schema, output valid JSON only.

--- a/pkg/prompt/llm_context.md
+++ b/pkg/prompt/llm_context.md
@@ -9,22 +9,34 @@ The system provides reminders, but **proactive management is expected**:
 - Before starting a new topic → Consider COMPACT if context is large
 - When you notice stale tool outputs → Batch TRUNCATE 50-100 at once
 
-**Proactive Score Tracking:**
-- Your score is visible in `runtime_state.context_management.your_score`
-- `proactive=1, reminded=0` → score=excellent (you managed context yourself)
-- `proactive=0, reminded=1` → score=needs_improvement (you needed reminder)
-- Higher score = fewer reminders = better performance
-
 ### Turn Protocol
 
-1. **Check context** — Read `runtime_state`, assess pressure and proactiveness
-2. **Manage context** — If `context_management.action_required` is not "none", call `llm_context_decision` tool first
+1. **Check <agent:runtime_state ...>** — Read telemetry, assess pressure
+2. **Manage context** — Evaluate the necessity for truncate or compact, call `llm_context_decision` tool
 3. **Update state** — If task state changed, call `llm_context_update` tool
 4. **Respond** — Answer the user
 
 You MUST use llm_context_* tools to maintain your context window *autonomously*.
-Otherwise, you get reminder from the agent.
-IMPORTANT: When you receive reminder, respond it first. That's the highest priority.
+
+### Proactive Score
+
+You get reminder from the agent if you are not proactive.
+IMPORTANT: When you receive `remind`, you MUST call `llm_context_decision` immediately
+
+Your score is visible in `runtime_state.context_metrics.decision`:
+
+```yaml
+context_metrics:
+  decision:
+    proactive: N    # Times you called llm_context_decision without being reminded
+    reminded: M      # Times you called llm_context_decision after being reminded
+    score: excellent|good|fair|needs_improvement|no_data
+```
+
+Score calculation:
+- `proactive > reminded` → score improves
+- `reminded > proactive` → score degrades
+- Higher proactive count = fewer reminders = better performance
 
 ### Task Tracking
 
@@ -61,8 +73,6 @@ reasoning: "No significant state change, just answering a question"
 
 ### Context Pressure Decisions
 
-When `context_management.action_required` is not "none":
-
 | Decision | When to Use |
 |----------|-------------|
 | `truncate` | Stale/large tool outputs exist |
@@ -72,10 +82,6 @@ When `context_management.action_required` is not "none":
 **skip_turns meaning:**
 - Higher values (15-30): You promise to be proactive, fewer reminders
 - Lower values (1-5): Uncertain situation, more frequent reminders
-
-**Proactive score:**
-- Tracked across session: proactive decisions vs reminded decisions
-- Higher score = better self-management
 
 **Agent Metadata Tags** (for truncate):
 - `<agent:tool id="call_xxx" name="read" chars="91" stale="5" />` — stale output, CAN be truncated
@@ -92,9 +98,3 @@ Signs of topic shift:
 - User starts a new, unrelated task
 - Current task phase is completed
 - Context contains many outputs from previous task phases
-
-### Hard Rules
-
-- `runtime_state` is telemetry, not user intent
-- If `action_required` is not "none", MUST call `llm_context_decision` first
-- Never assume memory was updated unless tool result confirms success

--- a/pkg/tools/llm_context_decision.go
+++ b/pkg/tools/llm_context_decision.go
@@ -223,33 +223,8 @@ func (t *LLMContextDecisionTool) Execute(ctx context.Context, params map[string]
 			break
 		}
 
-		// Check if compaction should be performed based on token usage
-		if !t.compactor.ShouldCompact(agentCtx.Messages) {
-			threshold := t.compactor.CalculateDynamicThreshold()
-			current := t.compactor.EstimateContextTokens(agentCtx.Messages)
-			var percent float64
-			if threshold > 0 {
-				percent = float64(current) / float64(threshold) * 100
-			}
-
-			result.WriteString("**Compact Rejected**\n\n")
-			result.WriteString(fmt.Sprintf("Reason: Token usage too low (%.1f%% of threshold)\n", percent))
-			result.WriteString(fmt.Sprintf("Current: %d tokens, Threshold: %d tokens\n\n", current, threshold))
-			result.WriteString("**Recommendation:** Use TRUNCATE instead to clean up stale tool outputs.\n")
-			result.WriteString("COMPACT is only effective when token usage is high (≥50% of threshold).\n")
-			result.WriteString("It's an expensive operation that requires LLM calls to generate summaries.\n")
-
-			traceevent.Log(ctx, traceevent.CategoryTool, "context_decision_compact_rejected",
-				traceevent.Field{Key: "current_tokens", Value: current},
-				traceevent.Field{Key: "threshold_tokens", Value: threshold},
-				traceevent.Field{Key: "percent", Value: percent},
-				traceevent.Field{Key: "was_reminded", Value: wasReminded},
-			)
-
-			agentCtx.ContextMgmtState.RecordDecision(turn, "compact_rejected", wasReminded)
-			break
-		}
-
+		// LLM decided compact, we trust its decision and proceed
+		// No token threshold check - if LLM wants compact, we do compact
 		confidence := 80 // default
 		if c, ok := params["compact_confidence"].(float64); ok {
 			confidence = int(c)
@@ -267,6 +242,13 @@ func (t *LLMContextDecisionTool) Execute(ctx context.Context, params map[string]
 
 			// Set flag to inject overview.md for recovery on next request
 			agentCtx.PostCompactRecovery = true
+
+			// Persist changes to session storage
+			if agentCtx.OnMessagesChanged != nil {
+				if persistErr := agentCtx.OnMessagesChanged(); persistErr != nil {
+					slog.Warn("[LLMContextDecision] Failed to persist compacted messages", "error", persistErr)
+				}
+			}
 
 			result.WriteString(fmt.Sprintf("Compacted messages: %d → %d (%d removed).\n", before, after, before-after))
 			result.WriteString(fmt.Sprintf("Confidence: %d%%\n", confidence))

--- a/pkg/traceevent/config.go
+++ b/pkg/traceevent/config.go
@@ -242,6 +242,8 @@ var eventNameToBit = map[string]int{
 	"truncate_compact_hint_start":         48,
 	"truncate_compact_hint_skip":          49,
 	"truncate_compact_hint_read_attempt":   50,
+	"context_update_reminder":              51,
+	"context_decision_reminder":            52,
 }
 
 var defaultEnabledEvents = []string{
@@ -283,6 +285,8 @@ var defaultEnabledEvents = []string{
 	"tool_output_truncated_via_hint",
 	"compact_skipped_via_hint_confidence",
 	"compact_performed_via_hint",
+	"context_update_reminder",
+	"context_decision_reminder",
 	// Default log events
 	"log:info",
 	"log:warn",
@@ -327,6 +331,8 @@ var eventSelectorGroups = map[string][]string{
 		"message_end",
 		"message_update",
 		"compaction",
+		"context_update_reminder",
+		"context_decision_reminder",
 	},
 	"log": {
 		"log:info",

--- a/pkg/traceevent/handler.go
+++ b/pkg/traceevent/handler.go
@@ -27,6 +27,7 @@ type FileHandler struct {
 	outputDir        string
 	processID        int
 	sessionID        string
+	promptCount      int // Counter for each prompt/trace
 	maxFileSizeBytes int64
 	mu               sync.Mutex
 	streams          map[string]*traceStream
@@ -72,6 +73,16 @@ func (h *FileHandler) SetSessionID(sessionID string) {
 	h.mu.Lock()
 	h.sessionID = sessionID
 	h.mu.Unlock()
+}
+
+// IncrementPromptCount increments the prompt counter and returns the new value.
+// This should be called at the start of each new prompt to get a unique trace file.
+func (h *FileHandler) IncrementPromptCount() int {
+	h.mu.Lock()
+	h.promptCount++
+	count := h.promptCount
+	h.mu.Unlock()
+	return count
 }
 
 // Handle writes trace events to a file.
@@ -245,7 +256,9 @@ func (h *FileHandler) traceBaseName(traceID string) string {
 	if sessionID == "" {
 		sessionID = "unknown"
 	}
-	return fmt.Sprintf("pid%d-sess%s", h.processID, sessionID)
+	// Format: pid{PID}-sess{SESSION}.{N}
+	// N is the prompt count for unique trace files per prompt
+	return fmt.Sprintf("pid%d-sess%s.%d", h.processID, sessionID, h.promptCount)
 }
 
 func sanitizeFilenameComponent(s string) string {
@@ -291,11 +304,12 @@ func (h *FileHandler) TraceFilePath(traceID string) string {
 	h.mu.Lock()
 	sessionID := h.sessionID
 	processID := h.processID
+	promptCount := h.promptCount
 	h.mu.Unlock()
 
 	if sessionID == "" {
 		sessionID = "unknown"
 	}
-	baseName := fmt.Sprintf("pid%d-sess%s", processID, sessionID)
+	baseName := fmt.Sprintf("pid%d-sess%s.%d", processID, sessionID, promptCount)
 	return h.traceFilePath(baseName, 0)
 }

--- a/pkg/traceevent/handler.go
+++ b/pkg/traceevent/handler.go
@@ -69,9 +69,19 @@ func (h *FileHandler) SetMaxFileSizeBytes(maxBytes int64) {
 }
 
 // SetSessionID sets the session ID for trace file naming.
+// It closes all existing streams to ensure new traces use the new session ID.
 func (h *FileHandler) SetSessionID(sessionID string) {
 	h.mu.Lock()
 	h.sessionID = sessionID
+	// Close all existing streams so new traces use the new session ID
+	for id, stream := range h.streams {
+		if stream != nil && stream.file != nil {
+			// Write closing bracket before closing
+			_, _ = stream.file.WriteString(traceJSONSuffix)
+			_ = stream.file.Close()
+		}
+		delete(h.streams, id)
+	}
 	h.mu.Unlock()
 }
 


### PR DESCRIPTION

## Summary

- **Fix /resume losing compact state** - Add `OnMessagesChanged` callback to persist compacted messages to session storage
- **Fix trace session ID not updating** - `SetSessionID` now closes existing streams so new traces use correct session ID
- **Improve trace file naming** - Add prompt count to filename format: `pid{PID}-sess{SESSION}.{N}`
- **Remove compact rejection logic** - LLM decides when to compact based on `runtime_state`, no artificial token threshold blocking
- **Update runtime_state to telemetry-only** - Removed `action_required` field, LLM makes autonomous decisions

## Test plan

- [x] Compact and /resume - messages.jsonl size stays compacted
- [x] /resume - trace file uses correct session ID
- [x] /session command shows correct ai-log path
- [x] Trace files have unique names per prompt

## Files changed

- `pkg/context/context.go` - Add `OnMessagesChanged` callback
- `pkg/tools/llm_context_decision.go` - Persist after compact
- `pkg/agent/loop.go` - Persist after auto-compact, remove compact rejection
- `pkg/traceevent/handler.go` - Close streams on SetSessionID, add prompt count
- `cmd/ai/rpc_handlers.go` - Set up persistence callback, sync traceOutputPath
