### PR TITLE
Refactor context reminder logic into independent state machines

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -436,16 +436,6 @@ func runInnerLoop(
 				agentCtx.Messages = append(agentCtx.Messages, result)
 				newMessages = append(newMessages, result)
 			}
-			// Check if llm context was updated
-			if agentCtx.LLMContext != nil || loopGuard != nil {
-				toolCalls := msg.ExtractToolCalls()
-				for _, tc := range toolCalls {
-					// Track if LLM called llm_context_decision tool
-					if strings.EqualFold(tc.Name, "llm_context_decision") {
-						agentCtx.LLMContext.MarkDecisionMade()
-					}
-				}
-			}
 		}
 
 		stream.Push(NewTurnEndEvent(msg, toolResults))
@@ -454,10 +444,6 @@ func runInnerLoop(
 		// If reminder was shown but LLM didn't call llm_context_decision, apply penalty
 		if agentCtx.ContextMgmtState != nil {
 			agentCtx.ContextMgmtState.CheckAndApplyCompliance()
-		}
-		if agentCtx.LLMContext != nil {
-			decisionMadeThisTurn := agentCtx.ContextMgmtState != nil && agentCtx.ContextMgmtState.DecisionMadeThisTurn
-			agentCtx.LLMContext.AdvanceDecisionState(decisionMadeThisTurn)
 		}
 		if agentCtx.ContextMgmtState != nil {
 			// Reset per-turn tracking for next turn
@@ -747,6 +733,14 @@ func streamAssistantResponse(
 
 	}
 
+	staleCount := 0
+	if len(agentCtx.Messages) > 0 {
+		staleCount, _ = collectStaleToolOutputStats(agentCtx.Messages, recentToolResultsNoMetadata)
+	}
+	if agentCtx.LLMContext != nil {
+		agentCtx.LLMContext.SetStaleToolCount(staleCount)
+	}
+
 	// Inject llm context reminder if LLM hasn't updated it for too many rounds
 	if agentCtx.LLMContext != nil && agentCtx.LLMContext.NeedsReminderMessage() {
 		reminderContent := agentCtx.LLMContext.GetReminderUserMessage()
@@ -763,33 +757,35 @@ func streamAssistantResponse(
 		)
 	}
 
-	// Inject decision reminder if LLM updated overview but didn't call llm_context_decision tool
-	// This is separate from overview update reminder - it triggers when decision is needed but not made
-	if agentCtx.LLMContext != nil && agentCtx.LLMContext.NeedsDecisionReminder() {
-		// Get stale count and available tool IDs for reminder
-		staleCount, _ := collectStaleToolOutputStats(agentCtx.Messages, recentToolResultsNoMetadata)
-		agentCtx.LLMContext.SetStaleToolCount(staleCount)
-
-		// Get available (non-truncated) tool IDs to include in reminder example
-		_, availableToolIDs := buildToolOutputsSummaryWithIDs(agentCtx.Messages)
-
-		decisionReminderContent := agentCtx.LLMContext.GetDecisionReminderMessage(availableToolIDs)
-		decisionReminderMsg := llm.LLMMessage{
-			Role:    "user",
-			Content: decisionReminderContent,
-		}
-		llmMessages = append(llmMessages, decisionReminderMsg)
-
-		// Record that a reminder was shown this turn (for proactive/reminded tracking)
-		if agentCtx.ContextMgmtState != nil {
-			agentCtx.ContextMgmtState.RecordReminder(agentCtx.ContextMgmtState.CurrentTurn, "high")
-		}
-
-		// Trace event for context decision reminder
-		traceevent.Log(ctx, traceevent.CategoryEvent, "context_decision_reminder",
-			traceevent.Field{Key: "reminder_type", Value: "llm_context_decision"},
-			traceevent.Field{Key: "stale_tool_outputs", Value: staleCount},
+	// Inject decision reminder based on independent decision-pressure state.
+	if agentCtx.LLMContext != nil && agentCtx.ContextMgmtState != nil {
+		meta := agentCtx.LLMContext.GetMeta()
+		showDecisionReminder, urgency := agentCtx.ContextMgmtState.ShouldShowDecisionReminder(
+			agentCtx.ContextMgmtState.CurrentTurn,
+			meta.TokensPercent,
+			staleCount,
 		)
+		if showDecisionReminder {
+			// Get available (non-truncated) tool IDs to include in reminder example
+			_, availableToolIDs := buildToolOutputsSummaryWithIDs(agentCtx.Messages)
+
+			decisionReminderContent := agentCtx.LLMContext.GetDecisionReminderMessage(availableToolIDs, agentCtx.ContextMgmtState, urgency)
+			decisionReminderMsg := llm.LLMMessage{
+				Role:    "user",
+				Content: decisionReminderContent,
+			}
+			llmMessages = append(llmMessages, decisionReminderMsg)
+
+			// Record that a reminder was shown this turn (for proactive/reminded tracking)
+			agentCtx.ContextMgmtState.RecordReminder(agentCtx.ContextMgmtState.CurrentTurn, urgency)
+
+			// Trace event for context decision reminder
+			traceevent.Log(ctx, traceevent.CategoryEvent, "context_decision_reminder",
+				traceevent.Field{Key: "reminder_type", Value: "llm_context_decision"},
+				traceevent.Field{Key: "stale_tool_outputs", Value: staleCount},
+				traceevent.Field{Key: "urgency", Value: urgency},
+			)
+		}
 	}
 
 	// Convert tools to LLM format

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -58,23 +58,36 @@ type ContextMgmtState struct {
 	LastReminderTurn    int    // Turn number of last reminder shown
 	LastReminderUrgency string // "none", "low", "medium", "high", "critical"
 
+	// Decision reminder state (independent from llm_context_update reminder)
+	DecisionPressureTurns int // Consecutive turns under decision pressure
+	LastPressureTurn      int // Last turn when pressure was observed
+
 	// Compliance tracking
 	ReminderShownThisTurn bool // Was reminder shown in current turn?
 	DecisionMadeThisTurn  bool // Did LLM call llm_context_decision this turn?
 }
 
+const (
+	decisionPressureTokensWithStale = 30.0
+	decisionPressureTokensOnly      = 50.0
+	decisionPressureStaleOnly       = 10
+	decisionReminderWarmupTurns     = 2
+)
+
 // DefaultContextMgmtState creates a new ContextMgmtState with defaults.
 func DefaultContextMgmtState() *ContextMgmtState {
 	return &ContextMgmtState{
-		ReminderFrequency:   10, // Default: remind every 10 turns
-		SkipUntilTurn:       0,
-		ProactiveDecisions:  0,
-		ReminderNeeded:      0,
-		CurrentTurn:         0,
-		LastDecisionTurn:    0,
-		LastActionTaken:     "none",
-		LastReminderTurn:    0,
-		LastReminderUrgency: "none",
+		ReminderFrequency:     10, // Default: remind every 10 turns
+		SkipUntilTurn:         0,
+		ProactiveDecisions:    0,
+		ReminderNeeded:        0,
+		CurrentTurn:           0,
+		LastDecisionTurn:      0,
+		LastActionTaken:       "none",
+		LastReminderTurn:      0,
+		LastReminderUrgency:   "none",
+		DecisionPressureTurns: 0,
+		LastPressureTurn:      0,
 	}
 }
 
@@ -159,6 +172,8 @@ func (s *ContextMgmtState) RecordDecision(turn int, action string, wasReminded b
 	} else {
 		s.ProactiveDecisions++
 	}
+	s.DecisionPressureTurns = 0
+	s.LastPressureTurn = 0
 
 	s.AdjustFrequency()
 }
@@ -217,6 +232,65 @@ func (s *ContextMgmtState) RecordReminder(turn int, urgency string) {
 
 	s.LastReminderTurn = turn
 	s.LastReminderUrgency = urgency
+	s.MarkReminderShown()
+}
+
+// DecisionPressureRequired reports whether llm_context_decision should be considered.
+func DecisionPressureRequired(tokensPercent float64, staleToolOutputs int) bool {
+	return (tokensPercent >= decisionPressureTokensWithStale && staleToolOutputs > 0) ||
+		tokensPercent >= decisionPressureTokensOnly ||
+		staleToolOutputs >= decisionPressureStaleOnly
+}
+
+// DecisionReminderUrgency classifies pressure severity for reminder telemetry.
+func DecisionReminderUrgency(tokensPercent float64, staleToolOutputs int) string {
+	switch {
+	case tokensPercent >= 75 || staleToolOutputs >= 40:
+		return "critical"
+	case tokensPercent >= 60 || staleToolOutputs >= 25:
+		return "high"
+	case tokensPercent >= 45 || staleToolOutputs >= 15:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+// ShouldShowDecisionReminder evaluates decision pressure and decides whether to remind this turn.
+// This logic is independent from llm_context_update reminder state.
+func (s *ContextMgmtState) ShouldShowDecisionReminder(turn int, tokensPercent float64, staleToolOutputs int) (bool, string) {
+	if s == nil {
+		return false, "none"
+	}
+
+	pressure := DecisionPressureRequired(tokensPercent, staleToolOutputs)
+	urgency := DecisionReminderUrgency(tokensPercent, staleToolOutputs)
+	if !pressure {
+		s.DecisionPressureTurns = 0
+		s.LastPressureTurn = 0
+		return false, "none"
+	}
+
+	// Count pressured turns only once per turn.
+	if s.LastPressureTurn != turn {
+		s.DecisionPressureTurns++
+		s.LastPressureTurn = turn
+	}
+
+	if turn < s.SkipUntilTurn {
+		return false, urgency
+	}
+	if s.DecisionPressureTurns < decisionReminderWarmupTurns {
+		return false, urgency
+	}
+
+	// First reminder for a pressure wave should be immediate after warmup.
+	if s.LastReminderTurn == 0 {
+		return true, urgency
+	}
+
+	turnsSinceReminder := turn - s.LastReminderTurn
+	return turnsSinceReminder >= s.ReminderFrequency, urgency
 }
 
 // GetScore returns a human-readable score of LLM's proactiveness.

--- a/pkg/context/llm_context.go
+++ b/pkg/context/llm_context.go
@@ -60,13 +60,10 @@ type LLMContext struct {
 	lastCheckTime         time.Time
 	roundsSinceUpdate     int
 	silentRoundsRemaining int  // Rounds to skip reminder after update
-	wasRemindedLastRound  bool // Was reminder injected in the last round?
+	wasRemindedLastRound  bool // Was update reminder injected in the current turn?
 
-	// Decision tracking - for separate reminder when LLM updates overview but doesn't call llm_context_decision.
-	updatedOverviewThisTurn   bool // LLM updated overview in the current turn
-	pendingDecisionReminder   bool // Waiting for llm_context_decision after overview update
-	roundsSinceDecisionNeeded int  // Rounds since decision became pending
-	staleToolOutputs          int  // Number of stale tool outputs (updated from runtime)
+	// Runtime decision pressure signal (for decision reminder rendering)
+	staleToolOutputs int // Number of stale tool outputs (updated from runtime)
 
 	// Update statistics for adaptive reminder frequency
 	totalUpdates      int // Total number of updates
@@ -316,6 +313,9 @@ func (wm *LLMContext) IncrementRound() {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
 
+	// New turn starts: clear per-turn "was reminded" marker.
+	wm.wasRemindedLastRound = false
+
 	// Skip increment if in silent period
 	if wm.silentRoundsRemaining > 0 {
 		wm.silentRoundsRemaining--
@@ -555,15 +555,15 @@ func (wm *LLMContext) adjustThreshold(autonomous bool) {
 	}
 	if wm.nextReminderRound > 30 {
 		wm.nextReminderRound = 30
-
-		slog.Info("[LLMContext] Adjusted reminder threshold",
-			"autonomous", autonomous,
-			"consciousness", consciousness,
-			"delta", delta,
-			"new_threshold", wm.nextReminderRound,
-			"autonomous_updates", wm.autonomousUpdates,
-			"prompted_updates", wm.promptedUpdates)
 	}
+
+	slog.Info("[LLMContext] Adjusted reminder threshold",
+		"autonomous", autonomous,
+		"consciousness", consciousness,
+		"delta", delta,
+		"new_threshold", wm.nextReminderRound,
+		"autonomous_updates", wm.autonomousUpdates,
+		"prompted_updates", wm.promptedUpdates)
 }
 
 // GetUpdateConsciousness returns the ratio of autonomous updates (0.0-1.0)
@@ -579,11 +579,11 @@ func (wm *LLMContext) GetUpdateConsciousness() float64 {
 
 // UpdateStats contains statistics about llm_context_update tool calls.
 type UpdateStats struct {
-	Total       int
-	Autonomous  int
-	Prompted    int
-	Score       string // "excellent", "good", "needs_improvement", "no_data"
-	ConsciousPct int   // percentage 0-100
+	Total        int
+	Autonomous   int
+	Prompted     int
+	Score        string // "excellent", "good", "needs_improvement", "no_data"
+	ConsciousPct int    // percentage 0-100
 }
 
 // GetUpdateStats returns statistics about llm_context_update tool calls.
@@ -638,98 +638,6 @@ func (wm *LLMContext) ResetReminderFlag() {
 	wm.wasRemindedLastRound = false
 }
 
-// SetUpdatedOverview marks that LLM updated overview.md this round.
-// This should be called when LLM writes to overview.md.
-func (wm *LLMContext) SetUpdatedOverview() {
-	wm.mu.Lock()
-	defer wm.mu.Unlock()
-	wm.updatedOverviewThisTurn = true
-}
-
-// MarkDecisionMade marks that LLM called llm_context_decision tool.
-// This resets the decision reminder counter.
-func (wm *LLMContext) MarkDecisionMade() {
-	wm.mu.Lock()
-	defer wm.mu.Unlock()
-	wm.updatedOverviewThisTurn = false
-	wm.pendingDecisionReminder = false
-	wm.roundsSinceDecisionNeeded = 0
-}
-
-// NeedsDecisionReminder checks if a decision reminder should be shown.
-// This is separate from overview update reminder - it triggers when:
-// - Context pressure is high (tokens or stale outputs)
-// - LLM hasn't called llm_context_decision tool recently
-//
-// The trigger is based on actual context pressure, not SetDecisionNeededThisTurn.
-func (wm *LLMContext) NeedsDecisionReminder() bool {
-	wm.mu.RLock()
-	defer wm.mu.RUnlock()
-
-	// Check if there's actual pressure requiring a decision
-	tokensPercent := 0.0
-	if wm.tokensMax > 0 {
-		tokensPercent = float64(wm.tokensUsed) / float64(wm.tokensMax) * 100
-	}
-
-	// Decision is needed when:
-	// - Token usage >= 30% AND stale outputs exist
-	// - OR token usage >= 50%
-	// - OR many stale outputs (>= 10)
-	hasPressure := (tokensPercent >= 30 && wm.staleToolOutputs > 0) ||
-		tokensPercent >= 50 ||
-		wm.staleToolOutputs >= 10
-
-	if !hasPressure {
-		return false
-	}
-
-	// Only remind after a delay (roundsSinceDecisionNeeded >= 2)
-	// This gives LLM time to act on the runtime_state information
-	return wm.pendingDecisionReminder && wm.roundsSinceDecisionNeeded >= 2
-}
-
-// AdvanceDecisionState advances per-turn decision reminder state at turn boundary.
-// It now calculates pressure internally based on tokens and stale outputs.
-func (wm *LLMContext) AdvanceDecisionState(decisionMadeThisTurn bool) {
-	wm.mu.Lock()
-	defer wm.mu.Unlock()
-
-	// Calculate current pressure
-	tokensPercent := 0.0
-	if wm.tokensMax > 0 {
-		tokensPercent = float64(wm.tokensUsed) / float64(wm.tokensMax) * 100
-	}
-
-	hasPressure := (tokensPercent >= 30 && wm.staleToolOutputs > 0) ||
-		tokensPercent >= 50 ||
-		wm.staleToolOutputs >= 10
-
-	if decisionMadeThisTurn {
-		wm.updatedOverviewThisTurn = false
-		wm.pendingDecisionReminder = false
-		wm.roundsSinceDecisionNeeded = 0
-		return
-	}
-
-	if !hasPressure {
-		wm.pendingDecisionReminder = false
-		wm.roundsSinceDecisionNeeded = 0
-		wm.updatedOverviewThisTurn = false
-		return
-	}
-
-	if wm.updatedOverviewThisTurn {
-		// The turn that updates overview is the baseline turn; start counting from next turn.
-		wm.pendingDecisionReminder = true
-		wm.roundsSinceDecisionNeeded = 0
-	} else if wm.pendingDecisionReminder {
-		wm.roundsSinceDecisionNeeded++
-	}
-
-	wm.updatedOverviewThisTurn = false
-}
-
 // SetStaleToolCount sets the number of stale tool outputs (called from runtime).
 func (wm *LLMContext) SetStaleToolCount(count int) {
 	wm.mu.Lock()
@@ -745,9 +653,19 @@ func (wm *LLMContext) GetStaleToolCount() int {
 }
 
 // GetDecisionReminderMessage returns a user message reminder for llm_context_decision.
-func (wm *LLMContext) GetDecisionReminderMessage(availableToolIDs []string) string {
+func (wm *LLMContext) GetDecisionReminderMessage(availableToolIDs []string, state *ContextMgmtState, urgency string) string {
 	meta := wm.GetMeta()
 	staleCount := wm.GetStaleToolCount()
+	proactive := 0
+	reminded := 0
+	frequency := 10
+	score := "no_data"
+	if state != nil {
+		proactive = state.ProactiveDecisions
+		reminded = state.ReminderNeeded
+		frequency = state.ReminderFrequency
+		score = state.GetScore()
+	}
 
 	// Build truncate_ids example from available (non-truncated) tool IDs
 	var truncateIDsExample string
@@ -771,7 +689,7 @@ func (wm *LLMContext) GetDecisionReminderMessage(availableToolIDs []string) stri
 
 	return fmt.Sprintf(`<agent:remind comment="system message by agent, not from real user">
 
-💡 Context management required: tokens at %d%%, %d stale tool outputs.
+💡 Context management required (%s): tokens at %d%%, %d stale tool outputs.
 
 <context_meta>
 tokens_used: %d
@@ -779,6 +697,13 @@ tokens_max: %d
 tokens_percent: %.0f%%
 messages_in_history: %d
 </context_meta>
+
+<decision_autonomy>
+proactive_decisions: %d
+reminder_needed: %d
+reminder_frequency_turns: %d
+autonomy_score: %s
+</decision_autonomy>
 
 Suggested: %s
 
@@ -794,8 +719,9 @@ reasoning: "Cleaning up %d stale tool outputs"
 truncate_ids: %s
 
 ⚠️ WARNING: Including already-truncated IDs will result in "0 truncated".`,
-		int(meta.TokensPercent), staleCount,
+		urgency, int(meta.TokensPercent), staleCount,
 		meta.TokensUsed, meta.TokensMax, meta.TokensPercent, meta.MessagesInHistory,
+		proactive, reminded, frequency, score,
 		getSuggestedAction(meta.TokensPercent, staleCount),
 		staleCount, truncateIDsExample)
 }

--- a/pkg/context/llm_context_decision_state_test.go
+++ b/pkg/context/llm_context_decision_state_test.go
@@ -2,133 +2,83 @@ package context
 
 import "testing"
 
-func TestDecisionReminderTriggersAfterPendingThreshold(t *testing.T) {
-	wm := NewLLMContext(t.TempDir())
+func TestDecisionReminderTriggersAfterPressureWarmup(t *testing.T) {
+	state := DefaultContextMgmtState()
 
-	// Set pressure: 35% tokens + stale outputs
-	wm.UpdateMeta(70000, 200000, 10) // 35% tokens
-	wm.SetStaleToolCount(5)
-
-	wm.SetUpdatedOverview()
-	wm.AdvanceDecisionState(false)
-	if wm.NeedsDecisionReminder() {
-		t.Fatal("did not expect reminder in overview update turn")
+	show, _ := state.ShouldShowDecisionReminder(1, 35, 5)
+	if show {
+		t.Fatal("did not expect reminder on first pressured turn")
 	}
 
-	wm.AdvanceDecisionState(false)
-	if wm.NeedsDecisionReminder() {
-		t.Fatal("did not expect reminder before threshold")
-	}
-
-	wm.AdvanceDecisionState(false)
-	if !wm.NeedsDecisionReminder() {
-		t.Fatal("expected reminder after two pending rounds")
+	show, _ = state.ShouldShowDecisionReminder(2, 35, 5)
+	if !show {
+		t.Fatal("expected reminder after warmup turns under pressure")
 	}
 }
 
-func TestDecisionReminderClearsWhenDecisionNotNeeded(t *testing.T) {
-	wm := NewLLMContext(t.TempDir())
+func TestDecisionReminderRespectsReminderFrequency(t *testing.T) {
+	state := DefaultContextMgmtState()
 
-	// Set pressure: 35% tokens + stale outputs
-	wm.UpdateMeta(70000, 200000, 10) // 35% tokens
-	wm.SetStaleToolCount(5)
-
-	wm.SetUpdatedOverview()
-	wm.AdvanceDecisionState(false)
-
-	wm.AdvanceDecisionState(false)
-	if wm.NeedsDecisionReminder() {
-		t.Fatal("did not expect reminder before threshold")
+	// Warmup + first reminder.
+	state.ShouldShowDecisionReminder(1, 35, 5)
+	show, urgency := state.ShouldShowDecisionReminder(2, 35, 5)
+	if !show {
+		t.Fatal("expected first reminder")
 	}
+	state.RecordReminder(2, urgency)
+	state.ResetTurnTracking()
 
-	// Remove pressure: low tokens + no stale outputs
-	wm.UpdateMeta(10000, 200000, 10) // 5% tokens
-	wm.SetStaleToolCount(0)
-
-	wm.AdvanceDecisionState(false)
-	if wm.NeedsDecisionReminder() {
-		t.Fatal("expected reminder state to reset when decision is not needed")
+	// Default frequency = 10, next one at turn 12.
+	show, _ = state.ShouldShowDecisionReminder(11, 35, 5)
+	if show {
+		t.Fatal("did not expect reminder before frequency window")
 	}
-
-	// Re-add pressure
-	wm.UpdateMeta(70000, 200000, 10) // 35% tokens
-	wm.SetStaleToolCount(5)
-
-	wm.AdvanceDecisionState(false)
-	if wm.NeedsDecisionReminder() {
-		t.Fatal("did not expect reminder without a new overview update")
+	show, _ = state.ShouldShowDecisionReminder(12, 35, 5)
+	if !show {
+		t.Fatal("expected reminder when frequency window is reached")
 	}
 }
 
-func TestDecisionReminderClearsWhenDecisionMade(t *testing.T) {
-	wm := NewLLMContext(t.TempDir())
+func TestDecisionReminderResetsAfterPressureClears(t *testing.T) {
+	state := DefaultContextMgmtState()
 
-	// Set pressure: 35% tokens + stale outputs
-	wm.UpdateMeta(70000, 200000, 10) // 35% tokens
-	wm.SetStaleToolCount(5)
+	state.ShouldShowDecisionReminder(1, 35, 5)
+	show, urgency := state.ShouldShowDecisionReminder(2, 35, 5)
+	if !show {
+		t.Fatal("expected reminder before pressure clears")
+	}
+	state.RecordReminder(2, urgency)
+	state.ResetTurnTracking()
 
-	wm.SetUpdatedOverview()
-	wm.AdvanceDecisionState(false)
-
-	wm.AdvanceDecisionState(false)
-	wm.AdvanceDecisionState(false)
-	if !wm.NeedsDecisionReminder() {
-		t.Fatal("expected reminder before decision is made")
+	// Pressure clears.
+	show, _ = state.ShouldShowDecisionReminder(3, 5, 0)
+	if show {
+		t.Fatal("did not expect reminder without pressure")
 	}
 
-	wm.AdvanceDecisionState(true)
-	if wm.NeedsDecisionReminder() {
-		t.Fatal("expected reminder state to clear after decision is made")
-	}
-}
-
-func TestDecisionReminderNoPressure(t *testing.T) {
-	wm := NewLLMContext(t.TempDir())
-
-	// No pressure: low tokens + no stale outputs
-	wm.UpdateMeta(10000, 200000, 10) // 5% tokens
-	wm.SetStaleToolCount(0)
-
-	wm.SetUpdatedOverview()
-	wm.AdvanceDecisionState(false)
-	wm.AdvanceDecisionState(false)
-	wm.AdvanceDecisionState(false)
-
-	if wm.NeedsDecisionReminder() {
-		t.Fatal("expected no reminder when there's no pressure")
+	// Pressure returns: warmup should restart.
+	show, _ = state.ShouldShowDecisionReminder(4, 35, 5)
+	if show {
+		t.Fatal("did not expect reminder on first pressured turn after reset")
 	}
 }
 
-func TestDecisionReminderHighTokens(t *testing.T) {
-	wm := NewLLMContext(t.TempDir())
-
-	// High pressure: 55% tokens (no stale outputs needed)
-	wm.UpdateMeta(110000, 200000, 10) // 55% tokens
-	wm.SetStaleToolCount(0)
-
-	wm.SetUpdatedOverview()
-	wm.AdvanceDecisionState(false)
-	wm.AdvanceDecisionState(false)
-	wm.AdvanceDecisionState(false)
-
-	if !wm.NeedsDecisionReminder() {
-		t.Fatal("expected reminder when tokens >= 50%")
+func TestDecisionReminderFrequencyChangesWithAutonomy(t *testing.T) {
+	proactive := DefaultContextMgmtState()
+	proactive.RecordDecision(1, "truncate", false)
+	proactive.RecordDecision(2, "truncate", false)
+	if proactive.ReminderFrequency <= 10 {
+		t.Fatalf("expected proactive decisions to reduce reminder frequency, got %d", proactive.ReminderFrequency)
 	}
-}
 
-func TestDecisionReminderManyStaleOutputs(t *testing.T) {
-	wm := NewLLMContext(t.TempDir())
-
-	// High pressure: 10+ stale outputs (low tokens)
-	wm.UpdateMeta(10000, 200000, 10) // 5% tokens
-	wm.SetStaleToolCount(15)
-
-	wm.SetUpdatedOverview()
-	wm.AdvanceDecisionState(false)
-	wm.AdvanceDecisionState(false)
-	wm.AdvanceDecisionState(false)
-
-	if !wm.NeedsDecisionReminder() {
-		t.Fatal("expected reminder when stale outputs >= 10")
+	ignored := DefaultContextMgmtState()
+	ignored.RecordReminder(1, "high")
+	ignored.CheckAndApplyCompliance()
+	ignored.ResetTurnTracking()
+	ignored.RecordReminder(2, "high")
+	ignored.CheckAndApplyCompliance()
+	ignored.ResetTurnTracking()
+	if ignored.ReminderFrequency >= 10 {
+		t.Fatalf("expected ignored reminders to increase reminder frequency, got %d", ignored.ReminderFrequency)
 	}
 }

--- a/pkg/tools/llm_context_decision.go
+++ b/pkg/tools/llm_context_decision.go
@@ -27,9 +27,9 @@ func (t *LLMContextDecisionTool) Name() string {
 	return "llm_context_decision"
 }
 
-// Description returns the tool description.
+// Description returns tool description.
 func (t *LLMContextDecisionTool) Description() string {
-	return `Declare your context management decision. Call this tool when you need to manage context, or when runtime_state indicates action_required.
+	return `Declare your context management decision. Call this tool when you need to manage context.
 
 IMPORTANT: This tool is for CONTEXT MANAGEMENT only. Use it to:
 - TRUNCATE: Remove old/large tool outputs to free up space
@@ -37,7 +37,7 @@ IMPORTANT: This tool is for CONTEXT MANAGEMENT only. Use it to:
 - SKIP: Defer context management for a specified number of turns
 
 USAGE:
-When runtime_state shows context_management.action_required is not "none", you MUST call this tool BEFORE answering the user.
+When runtime_state shows high context pressure (tokens_percent >= 30% with stale outputs, or >= 50% overall), you SHOULD call this tool proactively.
 
 DECISION OPTIONS:
 - "truncate": Remove specific tool outputs (provide truncate_ids)
@@ -114,11 +114,6 @@ func (t *LLMContextDecisionTool) Execute(ctx context.Context, params map[string]
 		return nil, fmt.Errorf("agent context not available")
 	}
 
-	// Mark that LLM made a decision this turn (compliance tracking)
-	if agentCtx.ContextMgmtState != nil {
-		agentCtx.ContextMgmtState.MarkDecisionMade()
-	}
-
 	// Parse decision
 	decision, ok := params["decision"].(string)
 	if !ok || decision == "" {
@@ -135,6 +130,9 @@ func (t *LLMContextDecisionTool) Execute(ctx context.Context, params map[string]
 	if agentCtx.ContextMgmtState == nil {
 		agentCtx.ContextMgmtState = agentctx.DefaultContextMgmtState()
 	}
+
+	// Mark that LLM made a decision this turn (compliance tracking)
+	agentCtx.ContextMgmtState.MarkDecisionMade()
 
 	// Get current turn from context (updated every loop iteration)
 	turn := agentCtx.ContextMgmtState.CurrentTurn

--- a/pkg/tools/llm_context_update.go
+++ b/pkg/tools/llm_context_update.go
@@ -119,8 +119,6 @@ func (t *LLMContextUpdateTool) Execute(ctx context.Context, params map[string]an
 			)
 			return nil, fmt.Errorf("failed to write context: %w", err)
 		}
-		// Mark that LLM updated context this turn (for decision reminder tracking)
-		agentCtx.LLMContext.SetUpdatedOverview()
 		// Mark updated to reset roundsSinceUpdate counter (stops reminder loop)
 		agentCtx.LLMContext.MarkUpdatedAfterToolCall(5)
 	}


### PR DESCRIPTION
## Summary
- split `llm_context_update` reminder and `llm_context_decision` reminder into independent state machines
- move decision reminder triggering to `ContextMgmtState` and unify pressure thresholds (`30%+stale`, `50%`, `stale>=10`)
- wire adaptive reminder frequency directly into decision reminders and include autonomy metrics in reminder message
- fix stale-tool-pressure timing (compute stale count before decision reminder check)
- simplify `LLMContext` by removing decision reminder state and compile-breaking fields
- refresh decision reminder tests to cover pressure warmup, frequency gating, and reset behavior

## Validation
- `go test ./pkg/context ./pkg/agent ./pkg/tools`
- `go test ./...`
