### PR TITLE
fix: ensure tool_call/tool_result pairing after compaction

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -717,6 +717,8 @@ func extractText(msg agentctx.AgentMessage) string {
 // ensureToolCallPairing ensures that tool_call and tool_result messages remain paired.
 // If a tool_result is in recentMessages but its corresponding tool_call is in oldMessages,
 // the tool_result must be hidden (archived) so the API doesn't see a mismatch.
+// Similarly, if an assistant message contains tool_calls that are in oldMessages,
+// those tool_calls must be removed from the assistant message.
 // This prevents "tool call and result not match" errors after compaction.
 func ensureToolCallPairing(oldMessages, recentMessages []agentctx.AgentMessage) []agentctx.AgentMessage {
 	if len(recentMessages) == 0 {
@@ -741,7 +743,8 @@ func ensureToolCallPairing(oldMessages, recentMessages []agentctx.AgentMessage) 
 	// Find tool_results in recentMessages whose tool_call is in oldMessages
 	// These need to be hidden (archived) because their tool_calls will be summarized
 	keptMessages := make([]agentctx.AgentMessage, 0, len(recentMessages))
-	archivedCount := 0
+	archivedToolResultCount := 0
+	filteredToolCallCount := 0
 
 	for _, msg := range recentMessages {
 		if msg.Role == "toolResult" && msg.ToolCallID != "" {
@@ -749,16 +752,44 @@ func ensureToolCallPairing(oldMessages, recentMessages []agentctx.AgentMessage) 
 				// This tool_result's call is in oldMessages - hide it to prevent mismatch
 				archivedMsg := msg.WithVisibility(false, msg.IsUserVisible()).WithKind("tool_result_archived")
 				keptMessages = append(keptMessages, archivedMsg)
-				archivedCount++
+				archivedToolResultCount++
 				continue
 			}
 		}
+
+		if msg.Role == "assistant" {
+			// Check if this assistant message contains tool_calls that are in oldMessages
+			filteredContent := make([]agentctx.ContentBlock, 0, len(msg.Content))
+			hasOldToolCalls := false
+
+			for _, block := range msg.Content {
+				if tc, ok := block.(agentctx.ToolCallContent); ok {
+					if oldToolCallIDs[tc.ID] {
+						// This tool_call is in oldMessages - skip it
+						hasOldToolCalls = true
+						filteredToolCallCount++
+						continue
+					}
+				}
+				filteredContent = append(filteredContent, block)
+			}
+
+			if hasOldToolCalls {
+				// Create a new message with filtered content
+				filteredMsg := msg
+				filteredMsg.Content = filteredContent
+				keptMessages = append(keptMessages, filteredMsg)
+				continue
+			}
+		}
+
 		keptMessages = append(keptMessages, msg)
 	}
 
-	if archivedCount > 0 {
+	if archivedToolResultCount > 0 || filteredToolCallCount > 0 {
 		slog.Info("[Compact] Fixed tool_call/tool_result pairing",
-			"archived", archivedCount,
+			"archived_tool_results", archivedToolResultCount,
+			"filtered_tool_calls", filteredToolCallCount,
 			"kept", len(keptMessages))
 	}
 

--- a/pkg/compact/compact_tool_pairing_test.go
+++ b/pkg/compact/compact_tool_pairing_test.go
@@ -133,6 +133,94 @@ func TestEnsureToolCallPairing_NoToolCallsInOldMessages(t *testing.T) {
 	}
 }
 
+// TestEnsureToolCallPairing_AssistantWithOldToolCalls tests that tool_calls in assistant messages
+// that are in oldMessages are filtered out to prevent mismatch
+func TestEnsureToolCallPairing_AssistantWithOldToolCalls(t *testing.T) {
+	// Scenario: assistant message in recentMessages contains a tool_call whose ID is in oldMessages
+	// The tool_call should be filtered out from the assistant message
+
+	oldMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call-old-1",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/old.txt"},
+				},
+			},
+		},
+	}
+
+	recentMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "Here's what I found:"},
+				agentctx.ToolCallContent{
+					ID:   "call-old-1",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/old.txt"},
+				},
+			},
+		},
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-old-1",
+			ToolName:   "read",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "old content"},
+			},
+		},
+	}
+
+	result := ensureToolCallPairing(oldMessages, recentMessages)
+
+	// After fix: the tool_call should be filtered out from the assistant message
+	// and the tool_result should be hidden
+	if len(result) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(result))
+	}
+
+	// Check assistant message - should have text but not the tool_call
+	foundAssistant := false
+	for _, msg := range result {
+		if msg.Role == "assistant" {
+			foundAssistant = true
+			toolCalls := msg.ExtractToolCalls()
+			if len(toolCalls) != 0 {
+				t.Errorf("BUG: assistant message should have tool_calls filtered out, but found %d", len(toolCalls))
+			}
+			// Check that text content is preserved
+			hasText := false
+			for _, block := range msg.Content {
+				if tc, ok := block.(agentctx.TextContent); ok && tc.Text != "" {
+					hasText = true
+					break
+				}
+			}
+			if !hasText {
+				t.Error("BUG: assistant message should preserve text content")
+			}
+		}
+	}
+
+	if !foundAssistant {
+		t.Error("assistant message should be present in result")
+	}
+
+	// Check tool_result - should be hidden
+	for _, msg := range result {
+		if msg.Role == "toolResult" && msg.ToolCallID == "call-old-1" {
+			if msg.IsAgentVisible() {
+				t.Error("BUG: tool_result should be hidden when its tool_call is in oldMessages")
+			}
+		}
+	}
+}
+
 // TestFullCompactPreservesPairing tests the full compaction flow preserves tool_call/tool_result pairing
 func TestFullCompactPreservesPairing(t *testing.T) {
 	config := &Config{


### PR DESCRIPTION
## Problem

When `llm_context_decision` compact operation runs, the `ensureToolCallPairing` function only hid `tool_result` messages (if their `tool_call` was in oldMessages), but it didn't filter out `tool_calls` from assistant messages in recentMessages.

This caused "tool call result does not follow tool call" API errors because:
- oldMessages contained assistant messages with tool_calls (to be summarized)
- recentMessages also contained assistant messages with the same tool_calls
- After compact, both sets of tool_calls were sent to LLM, but only the recentMessages tool_results were included

## Solution

Modified `ensureToolCallPairing` function in `pkg/compact/compact.go`:
- In addition to archiving tool_results, also filter out tool_calls from assistant messages in recentMessages if their IDs are in oldMessages
- Preserve text content in assistant messages while removing old tool_calls
- Add test case to verify this behavior

## Testing

- All existing tests pass
- Added new test `TestEnsureToolCallPairing_AssistantWithOldToolCalls` to verify tool_call filtering

Co-Authored-By: Claude <noreply@anthropic.com>