### PR TITLE
fix: prevent bash tool hangs on heavy stderr output

### DIFF
--- a/pkg/tools/bash.go
+++ b/pkg/tools/bash.go
@@ -252,27 +252,37 @@ func (r *CommandRegistry) Execute(ctx context.Context, cmdID string, command str
 	state.PGID = cmd.Process.Pid // Process group ID equals process ID when Setpgid is true
 	state.mu.Unlock()
 
-	// Stream output in background
-	outputDone := make(chan struct{})
-	go func() {
-		defer close(outputDone)
-		scanner := bufio.NewScanner(io.MultiReader(stdout, stderr))
+	// Stream stdout/stderr concurrently to avoid pipe backpressure deadlocks.
+	var outputWG sync.WaitGroup
+	streamPipe := func(reader io.Reader) {
+		defer outputWG.Done()
+		scanner := bufio.NewScanner(reader)
+		// Increase scanner token limit to avoid dropping large lines.
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			line := scanner.Text()
 			state.mu.Lock()
 			state.Output.WriteString(line + "\n")
 			state.mu.Unlock()
 		}
-	}()
+		if scanErr := scanner.Err(); scanErr != nil {
+			state.mu.Lock()
+			state.Output.WriteString(fmt.Sprintf("stream read error: %v\n", scanErr))
+			state.mu.Unlock()
+		}
+	}
+
+	outputWG.Add(2)
+	go streamPipe(stdout)
+	go streamPipe(stderr)
 
 	// Wait for command to finish
 	err = cmd.Wait()
 
+	// Wait for output streaming to complete before marking done.
+	outputWG.Wait()
+
 	state.mu.Lock()
-	defer state.mu.Unlock()
-
-	<-outputDone // Wait for output streaming to complete
-
 	state.Done = true
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -284,6 +294,7 @@ func (r *CommandRegistry) Execute(ctx context.Context, cmdID string, command str
 	} else {
 		state.ExitCode = 0
 	}
+	state.mu.Unlock()
 }
 
 // BashTool executes bash commands with dynamic workspace support and async execution.

--- a/pkg/tools/bash_async_test.go
+++ b/pkg/tools/bash_async_test.go
@@ -156,3 +156,25 @@ func TestCommandStatusTool(t *testing.T) {
 	assert.Contains(t, statusResult.Text, "PGID:")
 	assert.Contains(t, statusResult.Text, "Elapsed time:")
 }
+
+func TestBashToolHandlesLargeStderrOutput(t *testing.T) {
+	ws, _ := NewWorkspace("/tmp")
+	tool := NewBashTool(ws)
+
+	// This writes >64KB to stderr quickly; bash tool must still complete.
+	args := map[string]any{
+		"command": `i=0; while [ $i -lt 20000 ]; do echo "err-$i" 1>&2; i=$((i+1)); done; echo done`,
+		"timeout": float64(5),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	blocks, err := tool.Execute(ctx, args)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, blocks)
+
+	result := blocks[0].(agentctx.TextContent)
+	assert.Contains(t, result.Text, "done")
+	assert.NotContains(t, result.Text, "timed out")
+}


### PR DESCRIPTION
## Summary
- read stdout and stderr concurrently in `BashTool` to avoid pipe backpressure deadlocks
- avoid waiting for stream completion while holding `CommandState` mutex
- increase scanner buffer limit and record stream read errors in output
- add regression test for large stderr output to ensure command completes

## Testing
- go test ./pkg/tools -v
