### PR TITLE
fix(trace): update trace handler session ID on session switch

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -757,6 +757,13 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 			sessionName = resolveSessionName(sessionMgr, newSessionID)
 			stateMu.Unlock()
 
+			// Update trace handler session ID
+			if handler := traceevent.GetHandler(); handler != nil {
+				if fh, ok := handler.(*traceevent.FileHandler); ok {
+					fh.SetSessionID(newSessionID)
+				}
+			}
+
 			slog.Info("Switched to session", "id", newSessionID, "count", len(newSess.GetMessages()))
 			return nil
 		}
@@ -791,6 +798,13 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 		sessionID = newSessionID
 		sessionName = resolveSessionName(sessionMgr, newSessionID)
 		stateMu.Unlock()
+
+		// Update trace handler session ID
+		if handler := traceevent.GetHandler(); handler != nil {
+			if fh, ok := handler.(*traceevent.FileHandler); ok {
+				fh.SetSessionID(newSessionID)
+			}
+		}
 
 		slog.Info("Switched to session", "id", newSessionID, "count", len(newSess.GetMessages()))
 		return nil


### PR DESCRIPTION
## Summary
- Fixed bug where trace file names used old session ID after switching sessions
- Added trace handler updates in both switch_session branches (path-based and ID-based)
- Trace file names now correctly match the actual session ID

## Root Cause
When switching sessions via `/switch_session`, the global `sessionID` variable was updated, but the trace file handler's session ID was not. This caused trace files to continue using the old session ID in their filenames.

## Fix
Added the following code in both `switch_session` handler branches:
```go
// Update trace handler session ID
if handler := traceevent.GetHandler(); handler != nil {
    if fh, ok := handler.(*traceevent.FileHandler); ok {
        fh.SetSessionID(newSessionID)
    }
}
```

## Testing
- ✅ Build successful (`go build`)
- ✅ All traceevent tests pass (16 tests)
- ✅ Code diff reviewed

## Related
Discovered during session analysis of `164a72c1-3ece-4f85-9e10-63875d547b3b`