### PR TITLE
fix(session): correct ai-log path display and resume list order

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -851,6 +851,14 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 		modelInfo := currentModelInfo
 		stateMu.Unlock()
 
+		// Get current trace file path from FileHandler
+		aiLogPath := traceOutputPath
+		if handler := traceevent.GetHandler(); handler != nil {
+			if fh, ok := handler.(*traceevent.FileHandler); ok {
+				aiLogPath = fh.TraceFilePath("")
+			}
+		}
+
 		return &rpc.SessionState{
 			Model:                 &modelInfo,
 			ThinkingLevel:         thinkingLevel,
@@ -862,7 +870,7 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 			SessionID:             currentSessionID,
 			SessionName:           currentSessionName,
 			AIPid:                 os.Getpid(),
-			AILogPath:             traceOutputPath,
+			AILogPath:             aiLogPath,
 			AIWorkingDir:          ws.GetCWD(),
 			AIStartupPath:         ws.GetGitRoot(),
 			AutoCompactionEnabled: autoCompact,

--- a/internal/winai/interpreter.go
+++ b/internal/winai/interpreter.go
@@ -2823,18 +2823,22 @@ func (p *AiInterpreter) handleListSessions(data json.RawMessage) {
 	p.writeRaw("Available Sessions\n")
 	p.writeRaw(sectionLine + "\n\n")
 
+	// Sort sessions: newest first at index 0
 	sort.Slice(payload.Sessions, func(i, j int) bool {
 		return payload.Sessions[i].UpdatedAt.After(payload.Sessions[j].UpdatedAt)
 	})
 
-	for i, sess := range payload.Sessions {
+	// Display in reverse order (oldest first, newest at bottom)
+	// so index 0 (newest) appears at the bottom of the list
+	for idx := len(payload.Sessions) - 1; idx >= 0; idx-- {
+		sess := payload.Sessions[idx]
 		name := sess.Name
 		if name == "" {
 			name = sess.ID
 		}
 
 		updated := sess.UpdatedAt.Format("2006-01-02 15:04")
-		p.writeRaw(fmt.Sprintf("%d: %s (id: %s)\n", i, name, sess.ID))
+		p.writeRaw(fmt.Sprintf("%d: %s (id: %s)\n", idx, name, sess.ID))
 		p.writeRaw(fmt.Sprintf("    updated: %s  messages: %d\n", updated, sess.MessageCount))
 	}
 


### PR DESCRIPTION
## Summary
- Fix `/session` command showing incorrect ai-log path after `/resume`
- Reverse `/resume` list display so newest sessions appear at bottom

## Details

### Issue 1: ai-log path not updated on session switch
- Previously, `AILogPath` was set from a static `traceOutputPath` variable
- When switching sessions via `/resume`, the trace handler's session ID was updated, but the cached path was not
- Now dynamically fetches the current path from `FileHandler.TraceFilePath()`

### Issue 2: /resume list display order
- Previously, sessions were displayed with newest at top (index 0)
- Now displays oldest first, newest at bottom of list
- Index 0 still corresponds to newest session for `/resume 0` usage
- Users no longer need to scroll up to see recent sessions

## Test plan
- [x] Build succeeds in worktree
- [ ] Manual test: restart ai process, `/resume` to old session, verify `/session` shows correct ai-log path
- [ ] Manual test: run `/resume`, verify newest sessions appear at bottom of list

🤖 Generated with [Claude Code](https://claude.com/claude-code)