### PR TITLE
fix: prevent mismatched assistant/tool call sequences

### DIFF
--- a/pkg/agent/conversion.go
+++ b/pkg/agent/conversion.go
@@ -125,7 +125,90 @@ func ConvertMessagesToLLM(ctx context.Context, messages []agentctx.AgentMessage)
 		llmMessages = append(llmMessages, llmMsg)
 	}
 
-	return llmMessages
+	return sanitizeToolCallProtocol(llmMessages)
+}
+
+// sanitizeToolCallProtocol ensures generated messages follow strict assistant/tool pairing rules:
+// - a tool message must follow a pending assistant tool call
+// - unresolved tool calls are stripped before appending non-tool messages
+func sanitizeToolCallProtocol(messages []llm.LLMMessage) []llm.LLMMessage {
+	if len(messages) == 0 {
+		return messages
+	}
+
+	sanitized := make([]llm.LLMMessage, 0, len(messages))
+	pendingToolCalls := map[string]struct{}{}
+
+	clearPending := func() {
+		if len(pendingToolCalls) == 0 {
+			return
+		}
+		sanitized = stripPendingToolCallsFromLastAssistant(sanitized, pendingToolCalls)
+		pendingToolCalls = map[string]struct{}{}
+	}
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case "assistant":
+			clearPending()
+			sanitized = append(sanitized, msg)
+			for _, toolCall := range msg.ToolCalls {
+				if strings.TrimSpace(toolCall.ID) == "" {
+					continue
+				}
+				pendingToolCalls[toolCall.ID] = struct{}{}
+			}
+		case "tool":
+			toolCallID := strings.TrimSpace(msg.ToolCallID)
+			if toolCallID == "" || len(pendingToolCalls) == 0 {
+				continue
+			}
+			if _, ok := pendingToolCalls[toolCallID]; !ok {
+				continue
+			}
+			sanitized = append(sanitized, msg)
+			delete(pendingToolCalls, toolCallID)
+		default:
+			clearPending()
+			sanitized = append(sanitized, msg)
+		}
+	}
+
+	clearPending()
+	return sanitized
+}
+
+func stripPendingToolCallsFromLastAssistant(messages []llm.LLMMessage, pending map[string]struct{}) []llm.LLMMessage {
+	if len(messages) == 0 || len(pending) == 0 {
+		return messages
+	}
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role != "assistant" {
+			continue
+		}
+		if len(messages[i].ToolCalls) == 0 {
+			return messages
+		}
+
+		filteredToolCalls := make([]llm.ToolCall, 0, len(messages[i].ToolCalls))
+		for _, toolCall := range messages[i].ToolCalls {
+			if _, drop := pending[toolCall.ID]; drop {
+				continue
+			}
+			filteredToolCalls = append(filteredToolCalls, toolCall)
+		}
+		messages[i].ToolCalls = filteredToolCalls
+
+		if len(messages[i].ToolCalls) == 0 &&
+			strings.TrimSpace(messages[i].Content) == "" &&
+			len(messages[i].ContentParts) == 0 {
+			return append(messages[:i], messages[i+1:]...)
+		}
+		return messages
+	}
+
+	return messages
 }
 
 func shouldInjectStaleToolMetadata(

--- a/pkg/agent/conversion_visibility_test.go
+++ b/pkg/agent/conversion_visibility_test.go
@@ -73,8 +73,14 @@ func TestAgentMessageMetadataRoundTrip(t *testing.T) {
 }
 
 func TestConvertMessagesToLLMDedupesToolResultsByCallID(t *testing.T) {
+	assistant := agentctx.NewAssistantMessage()
+	assistant.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{ID: "call-1", Type: "toolCall", Name: "read", Arguments: map[string]any{"path": "a.go"}},
+	}
+
 	msgs := []agentctx.AgentMessage{
 		agentctx.NewUserMessage("do work"),
+		assistant,
 		agentctx.NewToolResultMessage("call-1", "read", []agentctx.ContentBlock{
 			agentctx.TextContent{Type: "text", Text: "old output"},
 		}, false),
@@ -84,17 +90,20 @@ func TestConvertMessagesToLLMDedupesToolResultsByCallID(t *testing.T) {
 	}
 
 	llmMessages := ConvertMessagesToLLM(context.Background(), msgs)
-	if len(llmMessages) != 2 {
-		t.Fatalf("expected 2 messages after dedupe, got %d", len(llmMessages))
+	if len(llmMessages) != 3 {
+		t.Fatalf("expected 3 messages after dedupe, got %d", len(llmMessages))
 	}
-	if llmMessages[1].Role != "tool" {
-		t.Fatalf("expected second message role=tool, got %q", llmMessages[1].Role)
+	if llmMessages[1].Role != "assistant" {
+		t.Fatalf("expected second message role=assistant, got %q", llmMessages[1].Role)
 	}
-	if llmMessages[1].ToolCallID != "call-1" {
-		t.Fatalf("expected toolCallID call-1, got %q", llmMessages[1].ToolCallID)
+	if len(llmMessages[1].ToolCalls) != 1 || llmMessages[1].ToolCalls[0].ID != "call-1" {
+		t.Fatalf("expected assistant to keep tool call call-1, got %+v", llmMessages[1].ToolCalls)
 	}
-	if llmMessages[1].Content != "new output" {
-		t.Fatalf("expected newest tool output to be kept, got %q", llmMessages[1].Content)
+	if llmMessages[2].Role != "tool" || llmMessages[2].ToolCallID != "call-1" {
+		t.Fatalf("expected third message tool result for call-1, got role=%q id=%q", llmMessages[2].Role, llmMessages[2].ToolCallID)
+	}
+	if llmMessages[2].Content != "new output" {
+		t.Fatalf("expected newest tool output to be kept, got %q", llmMessages[2].Content)
 	}
 }
 
@@ -140,12 +149,25 @@ func TestConvertMessagesToLLMDedupesAssistantToolCallsByFullSet(t *testing.T) {
 		agentctx.NewUserMessage("start"),
 		a1,
 		a2,
+		agentctx.NewToolResultMessage("call-1", "read", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "read output"},
+		}, false),
+		agentctx.NewToolResultMessage("call-2", "bash", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "bash output"},
+		}, false),
 	})
-	if len(llmMessages) != 2 {
-		t.Fatalf("expected duplicate assistant tool-call set to dedupe, got %d", len(llmMessages))
+
+	assistantWithTools := 0
+	for _, msg := range llmMessages {
+		if msg.Role == "assistant" && len(msg.ToolCalls) == 2 {
+			assistantWithTools++
+		}
 	}
-	if len(llmMessages[1].ToolCalls) != 2 {
-		t.Fatalf("expected 2 tool calls after dedupe, got %d", len(llmMessages[1].ToolCalls))
+	if assistantWithTools != 1 {
+		t.Fatalf("expected exactly one assistant with duplicated tool-call set after dedupe, got %d", assistantWithTools)
+	}
+	if llmMessages[len(llmMessages)-1].Role != "tool" {
+		t.Fatalf("expected tool results to remain in protocol sequence, got last role=%q", llmMessages[len(llmMessages)-1].Role)
 	}
 }
 
@@ -157,17 +179,36 @@ func TestConvertMessagesToLLMKeepsAssistantToolCallsWhenSetDiffers(t *testing.T)
 	}
 	a2 := agentctx.NewAssistantMessage()
 	a2.Content = []agentctx.ContentBlock{
-		agentctx.ToolCallContent{ID: "call-1", Type: "toolCall", Name: "read", Arguments: map[string]any{"path": "a.go"}},
-		agentctx.ToolCallContent{ID: "call-3", Type: "toolCall", Name: "bash", Arguments: map[string]any{"command": "echo two"}},
+		agentctx.ToolCallContent{ID: "call-4", Type: "toolCall", Name: "read", Arguments: map[string]any{"path": "a.go"}},
+		agentctx.ToolCallContent{ID: "call-5", Type: "toolCall", Name: "bash", Arguments: map[string]any{"command": "echo two"}},
 	}
 
 	llmMessages := ConvertMessagesToLLM(context.Background(), []agentctx.AgentMessage{
 		agentctx.NewUserMessage("start"),
 		a1,
+		agentctx.NewToolResultMessage("call-1", "read", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "read output 1"},
+		}, false),
+		agentctx.NewToolResultMessage("call-2", "bash", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "bash output 1"},
+		}, false),
 		a2,
+		agentctx.NewToolResultMessage("call-4", "read", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "read output 2"},
+		}, false),
+		agentctx.NewToolResultMessage("call-5", "bash", []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "bash output 2"},
+		}, false),
 	})
-	if len(llmMessages) != 3 {
-		t.Fatalf("expected both assistant tool-call sets to be kept, got %d", len(llmMessages))
+
+	assistantWithTools := 0
+	for _, msg := range llmMessages {
+		if msg.Role == "assistant" && len(msg.ToolCalls) == 2 {
+			assistantWithTools++
+		}
+	}
+	if assistantWithTools != 2 {
+		t.Fatalf("expected both distinct assistant tool-call sets to be kept, got %d", assistantWithTools)
 	}
 }
 
@@ -176,6 +217,16 @@ func TestConvertMessagesToLLMInjectsStaleToolMetadataBeyondRecent10(t *testing.T
 		agentctx.NewUserMessage("old turn"),
 	}
 	for i := 1; i <= 11; i++ {
+		assistant := agentctx.NewAssistantMessage()
+		assistant.Content = []agentctx.ContentBlock{
+			agentctx.ToolCallContent{
+				ID:        fmt.Sprintf("call-%d", i),
+				Type:      "toolCall",
+				Name:      "read",
+				Arguments: map[string]any{"path": fmt.Sprintf("f-%d.txt", i)},
+			},
+		}
+		msgs = append(msgs, assistant)
 		msgs = append(msgs, agentctx.NewToolResultMessage(
 			fmt.Sprintf("call-%d", i),
 			"read",
@@ -234,5 +285,154 @@ func TestConvertMessagesToLLMDoesNotInjectMetadataForRecent10ToolOutputs(t *test
 		if strings.Contains(m.Content, `stale="true"`) {
 			t.Fatalf("expected no stale metadata within recent 10 tool outputs, got %q", m.Content)
 		}
+	}
+}
+
+func TestConvertMessagesToLLMStripsDanglingAssistantToolCalls(t *testing.T) {
+	assistant := agentctx.NewAssistantMessage()
+	assistant.Content = []agentctx.ContentBlock{
+		agentctx.TextContent{Type: "text", Text: "planning"},
+		agentctx.ToolCallContent{
+			ID:        "call-hidden",
+			Type:      "toolCall",
+			Name:      "bash",
+			Arguments: map[string]any{"command": "echo hidden"},
+		},
+	}
+
+	hiddenTool := agentctx.NewToolResultMessage(
+		"call-hidden",
+		"bash",
+		[]agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "hidden output"}},
+		false,
+	).WithVisibility(false, true)
+
+	llmMessages := ConvertMessagesToLLM(context.Background(), []agentctx.AgentMessage{
+		agentctx.NewUserMessage("start"),
+		assistant,
+		hiddenTool,
+		agentctx.NewUserMessage("next"),
+	})
+
+	assertNoOrphanedToolProtocol(t, llmMessages)
+	for _, msg := range llmMessages {
+		if msg.Role != "assistant" {
+			continue
+		}
+		if strings.TrimSpace(msg.Content) == "planning" && len(msg.ToolCalls) != 0 {
+			t.Fatalf("expected dangling tool calls to be removed, got %d", len(msg.ToolCalls))
+		}
+	}
+}
+
+func TestConvertMessagesToLLMDropsOrphanedToolResult(t *testing.T) {
+	llmMessages := ConvertMessagesToLLM(context.Background(), []agentctx.AgentMessage{
+		agentctx.NewUserMessage("start"),
+		agentctx.NewToolResultMessage(
+			"call-orphan",
+			"read",
+			[]agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "orphan"}},
+			false,
+		),
+		agentctx.NewUserMessage("next"),
+	})
+
+	assertNoOrphanedToolProtocol(t, llmMessages)
+	for _, msg := range llmMessages {
+		if msg.Role == "tool" {
+			t.Fatalf("expected orphan tool messages to be dropped, got %+v", msg)
+		}
+	}
+}
+
+func TestConvertMessagesToLLMRetainsResolvedToolCallsWhenPartiallyMatched(t *testing.T) {
+	assistant := agentctx.NewAssistantMessage()
+	assistant.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:        "call-keep",
+			Type:      "toolCall",
+			Name:      "read",
+			Arguments: map[string]any{"path": "a.txt"},
+		},
+		agentctx.ToolCallContent{
+			ID:        "call-drop",
+			Type:      "toolCall",
+			Name:      "bash",
+			Arguments: map[string]any{"command": "echo drop"},
+		},
+	}
+
+	visibleTool := agentctx.NewToolResultMessage(
+		"call-keep",
+		"read",
+		[]agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "kept"}},
+		false,
+	)
+	hiddenTool := agentctx.NewToolResultMessage(
+		"call-drop",
+		"bash",
+		[]agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "dropped"}},
+		false,
+	).WithVisibility(false, true)
+
+	llmMessages := ConvertMessagesToLLM(context.Background(), []agentctx.AgentMessage{
+		agentctx.NewUserMessage("start"),
+		assistant,
+		visibleTool,
+		hiddenTool,
+		agentctx.NewUserMessage("next"),
+	})
+
+	assertNoOrphanedToolProtocol(t, llmMessages)
+
+	var keptAssistant *llm.LLMMessage
+	toolCount := 0
+	for i := range llmMessages {
+		if llmMessages[i].Role == "assistant" && len(llmMessages[i].ToolCalls) > 0 {
+			keptAssistant = &llmMessages[i]
+		}
+		if llmMessages[i].Role == "tool" {
+			toolCount++
+		}
+	}
+	if keptAssistant == nil {
+		t.Fatal("expected assistant with resolved tool call to be kept")
+	}
+	if len(keptAssistant.ToolCalls) != 1 || keptAssistant.ToolCalls[0].ID != "call-keep" {
+		t.Fatalf("expected only resolved tool call to remain, got %+v", keptAssistant.ToolCalls)
+	}
+	if toolCount != 1 {
+		t.Fatalf("expected exactly one tool result to remain, got %d", toolCount)
+	}
+}
+
+func assertNoOrphanedToolProtocol(t *testing.T, messages []llm.LLMMessage) {
+	t.Helper()
+	pending := map[string]struct{}{}
+	for i, msg := range messages {
+		switch msg.Role {
+		case "assistant":
+			if len(pending) > 0 {
+				t.Fatalf("assistant at %d appeared before pending tools resolved: %+v", i, pending)
+			}
+			for _, tc := range msg.ToolCalls {
+				pending[tc.ID] = struct{}{}
+			}
+		case "tool":
+			if len(pending) == 0 {
+				t.Fatalf("orphaned tool message at %d: %+v", i, msg)
+			}
+			if _, ok := pending[msg.ToolCallID]; !ok {
+				t.Fatalf("tool message at %d has unknown toolCallID=%q pending=%+v", i, msg.ToolCallID, pending)
+			}
+			delete(pending, msg.ToolCallID)
+		default:
+			if len(pending) > 0 {
+				t.Fatalf("non-tool role=%q at %d before pending tools resolved: %+v", msg.Role, i, pending)
+			}
+		}
+	}
+	if len(pending) > 0 {
+		t.Fatalf("unresolved pending tool calls at end: %+v", pending)
 	}
 }

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -169,10 +169,10 @@ func estimateStringTokens(s string) int {
 
 // CompactionResult contains the result of a compaction operation.
 type CompactionResult struct {
-	Summary      string               // The generated summary
+	Summary      string                  // The generated summary
 	Messages     []agentctx.AgentMessage // The compressed message list
-	TokensBefore int                  // Token count before compaction
-	TokensAfter  int                  // Token count after compaction
+	TokensBefore int                     // Token count before compaction
+	TokensAfter  int                     // Token count after compaction
 }
 
 // Compact compresses the context by summarizing old messages.
@@ -650,16 +650,44 @@ func compactToolResultsInRecent(messages []agentctx.AgentMessage, cutoff int) []
 	)
 
 	compacted := append([]agentctx.AgentMessage{}, messages...)
+	archivedToolCallIDs := make(map[string]struct{}, excess)
 
-	// Hide excess tool_results from agent (but keep visible to user)
-	// Unlike before, we don't hide tool_calls or add a summary message,
-	// which avoids protocol violations.
+	// Hide excess tool_results from agent (but keep visible to user).
+	// We also remove corresponding tool_calls from assistant messages below,
+	// otherwise strict APIs reject unmatched assistant/tool sequences.
 	for i := 0; i < excess; i++ {
 		idx := visibleToolIndexes[i]
 		original := compacted[idx]
 		compacted[idx] = original.WithVisibility(false, original.IsUserVisible()).WithKind("tool_result_archived")
+		if strings.TrimSpace(original.ToolCallID) != "" {
+			archivedToolCallIDs[strings.TrimSpace(original.ToolCallID)] = struct{}{}
+		}
 	}
 
+	filteredToolCalls := 0
+	for i := range compacted {
+		if compacted[i].Role != "assistant" || len(archivedToolCallIDs) == 0 {
+			continue
+		}
+		filtered := make([]agentctx.ContentBlock, 0, len(compacted[i].Content))
+		removed := false
+		for _, block := range compacted[i].Content {
+			toolCall, ok := block.(agentctx.ToolCallContent)
+			if ok {
+				if _, drop := archivedToolCallIDs[strings.TrimSpace(toolCall.ID)]; drop {
+					removed = true
+					filteredToolCalls++
+					continue
+				}
+			}
+			filtered = append(filtered, block)
+		}
+		if removed {
+			compacted[i].Content = filtered
+		}
+	}
+
+	summarySpan.AddField("filtered_tool_calls", filteredToolCalls)
 	summarySpan.End()
 	return compacted
 }
@@ -795,6 +823,7 @@ func ensureToolCallPairing(oldMessages, recentMessages []agentctx.AgentMessage) 
 
 	return keptMessages
 }
+
 // ToContextCompactor adapts this Compactor to implement context.Compactor interface.
 // This allows the compact.Compactor to be used where context.Compactor is expected.
 func (c *Compactor) ToContextCompactor() agentctx.Compactor {

--- a/pkg/compact/compact_visibility_test.go
+++ b/pkg/compact/compact_visibility_test.go
@@ -88,8 +88,8 @@ func TestCompactToolResultsInRecent(t *testing.T) {
 		}
 	}
 
-	// Verify tool_call messages are still present (not hidden)
-	// This ensures protocol compliance - we don't hide tool_calls anymore
+	// Verify tool_call messages are filtered for archived tool_results
+	// so assistant/tool protocol stays valid.
 	toolCallCount := 0
 	for _, msg := range compacted {
 		if msg.Role == "assistant" {
@@ -100,8 +100,8 @@ func TestCompactToolResultsInRecent(t *testing.T) {
 			}
 		}
 	}
-	if toolCallCount != 2 {
-		t.Fatalf("expected 2 tool_calls to still be present (not hidden), got %d", toolCallCount)
+	if toolCallCount != 1 {
+		t.Fatalf("expected 1 remaining tool_call after filtering archived pair, got %d", toolCallCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
This patch fixes `tool call result does not follow tool call` errors that can still occur on `main`.

### Root cause
- During compaction, archived `tool_result` messages could become agent-invisible while corresponding assistant `toolCall` blocks stayed visible.
- Message conversion did not sanitize orphaned `tool` messages or dangling assistant `tool_calls` before sending to the LLM API.

### Changes
- Add protocol sanitizer in `pkg/agent/conversion.go`:
  - drop orphaned `tool` messages
  - strip unresolved assistant `tool_calls` when no matching visible `tool_result` exists
- Update `compactToolResultsInRecent` in `pkg/compact/compact.go`:
  - record archived tool call IDs
  - remove matching assistant `toolCall` blocks to keep strict pairing valid
- Add/adjust tests in:
  - `pkg/agent/conversion_visibility_test.go`
  - `pkg/compact/compact_visibility_test.go`

## Tests
- `go test ./pkg/agent -run "TestConvertMessagesToLLM|TestConvertVisibleMessagesToLLM" -v`
- `go test ./pkg/compact -run "TestCompactToolResultsInRecent|TestFullCompactPreservesPairing|TestEnsureToolCallPairing" -v`
