### PR TITLE
feat: configurable LLM timeouts (10min total, 2min chunk interval)

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -30,6 +30,8 @@ const (
 	defaultLoopMaxToolCallsPerName     = 60
 	defaultMalformedToolCallRecoveries = 2
 	defaultRuntimeMetaHeartbeatTurns   = 6
+	defaultLLMTotalTimeout             = 10 * time.Minute // Total timeout for LLM request
+	defaultLLMFirstResponseTimeout      = 2 * time.Minute  // Timeout between streaming chunks (2min)
 )
 
 type LoopConfig struct {
@@ -55,6 +57,8 @@ type LoopConfig struct {
 	ContextWindow           int           // Context window for the model (0=use default 128000)
 	TaskTrackingEnabled     bool          // Enable task tracking reminders (llm_context_update)
 	ContextManagementEnabled bool         // Enable context management reminders (llm_context_decision)
+	LLMTotalTimeout         time.Duration // Total timeout for LLM request (default 10min)
+	LLMFirstResponseTimeout  time.Duration // Timeout between streaming chunks (default 2min)
 }
 
 // getEffectiveModel returns the current model, using GetModel callback if available.
@@ -84,6 +88,8 @@ func DefaultLoopConfig() *LoopConfig {
 		ContextManagementEnabled:  true,
 		Executor:                 NewExecutorPool(map[string]int{"maxConcurrentTools": 10, "queueTimeout": 60}),
 		ToolOutput:                DefaultToolOutputLimits(),
+		LLMTotalTimeout:           defaultLLMTotalTimeout,
+		LLMFirstResponseTimeout:   defaultLLMFirstResponseTimeout,
 	}
 }
 
@@ -699,7 +705,10 @@ func streamAssistantResponse(
 	thinkingLevel := prompt.NormalizeThinkingLevel(config.ThinkingLevel)
 
 	// Create timeout context for LLM calls
-	llmTimeout := 120 * time.Second
+	llmTimeout := config.LLMTotalTimeout
+	if llmTimeout == 0 {
+		llmTimeout = defaultLLMTotalTimeout
+	}
 	llmCtx, llmCancel := context.WithTimeout(ctx, llmTimeout)
 	defer llmCancel()
 
@@ -852,7 +861,13 @@ func streamAssistantResponse(
 	firstTokenRecorded := false
 	firstTokenLatency := time.Duration(0)
 
-	llmStream := llm.StreamLLM(llmCtx, model, llmCtxParams, getEffectiveAPIKey(config))
+	llmStream := llm.StreamLLM(
+		llmCtx,
+		model,
+		llmCtxParams,
+		getEffectiveAPIKey(config),
+		config.LLMFirstResponseTimeout,
+	)
 
 	type toolCallState struct {
 		id        string

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -299,7 +299,8 @@ func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage
 	}
 
 	ctx := context.Background()
-	llmStream := llm.StreamLLM(ctx, c.model, llmCtx, c.apiKey)
+	// Use 0 for chunk timeout to use defaults - compaction is less latency-sensitive
+	llmStream := llm.StreamLLM(ctx, c.model, llmCtx, c.apiKey, 0)
 
 	var summary strings.Builder
 	for event := range llmStream.Iterator(ctx) {

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -16,12 +16,13 @@ import (
 	"github.com/tiancaiamao/ai/pkg/traceevent"
 )
 
-// StreamAnthropic streams a completion from the Anthropic Messages API.
+// StreamAnthropic streams a completion from Anthropic Messages API.
 func StreamAnthropic(
 	ctx context.Context,
 	model Model,
 	llmCtx LLMContext,
 	apiKey string,
+	chunkIntervalTimeout time.Duration, // Timeout between chunks
 ) *EventStream[LLMEvent, LLMMessage] {
 	stream := NewEventStream[LLMEvent, LLMMessage](
 		func(e LLMEvent) bool {
@@ -106,12 +107,34 @@ func StreamAnthropic(
 		partial := NewPartialMessage()
 		stream.Push(LLMStartEvent{Partial: partial})
 
+		// Set read deadline for chunk interval timeout
+		type deadliner interface {
+			SetReadDeadline(time.Time) error
+		}
+		if dl, ok := resp.Body.(deadliner); ok && chunkIntervalTimeout > 0 {
+			// Each scan should complete within chunkIntervalTimeout
+			dl.SetReadDeadline(time.Now().Add(chunkIntervalTimeout))
+		}
+
 		scanner := bufio.NewScanner(resp.Body)
 		scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
 		chunkIndex := 0
 		lastUsage := Usage{}
 
 		for scanner.Scan() {
+			// Update read deadline for each chunk
+			if dl, ok := resp.Body.(deadliner); ok && chunkIntervalTimeout > 0 {
+				dl.SetReadDeadline(time.Now().Add(chunkIntervalTimeout))
+			}
+
+			// Check parent context cancellation
+			select {
+			case <-ctx.Done():
+				stream.Push(LLMErrorEvent{Error: ctx.Err()})
+				return
+			default:
+			}
+
 			line := scanner.Text()
 
 			// SSE format: "data: {...}"

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -16,12 +16,13 @@ import (
 	"github.com/tiancaiamao/ai/pkg/traceevent"
 )
 
-// StreamLLM streams a completion from the LLM.
+// StreamLLM streams a completion from LLM.
 func StreamLLM(
 	ctx context.Context,
 	model Model,
 	llmCtx LLMContext,
 	apiKey string,
+	chunkIntervalTimeout time.Duration, // Timeout between chunks (e.g., 2min)
 ) *EventStream[LLMEvent, LLMMessage] {
 	// Route to Anthropic API if requested
 	if model.API == "anthropic-messages" {
@@ -132,11 +133,34 @@ func StreamLLM(
 		partial := NewPartialMessage()
 		stream.Push(LLMStartEvent{Partial: partial})
 
+		// Set read deadline for chunk interval timeout
+		type deadliner interface {
+			SetReadDeadline(time.Time) error
+		}
+		if dl, ok := resp.Body.(deadliner); ok && chunkIntervalTimeout > 0 {
+			// Each scan should complete within chunkIntervalTimeout
+			dl.SetReadDeadline(time.Now().Add(chunkIntervalTimeout))
+		}
+
 		scanner := bufio.NewScanner(resp.Body)
 		scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
 		chunkIndex := 0
 		lastUsage := Usage{}
+
 		for scanner.Scan() {
+			// Update read deadline for each chunk
+			if dl, ok := resp.Body.(deadliner); ok && chunkIntervalTimeout > 0 {
+				dl.SetReadDeadline(time.Now().Add(chunkIntervalTimeout))
+			}
+
+			// Check parent context cancellation
+			select {
+			case <-ctx.Done():
+				stream.Push(LLMErrorEvent{Error: ctx.Err()})
+				return
+			default:
+			}
+
 			line := scanner.Text()
 
 			// SSE format: "data: {...}"

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -26,7 +26,7 @@ func StreamLLM(
 ) *EventStream[LLMEvent, LLMMessage] {
 	// Route to Anthropic API if requested
 	if model.API == "anthropic-messages" {
-		return StreamAnthropic(ctx, model, llmCtx, apiKey)
+		return StreamAnthropic(ctx, model, llmCtx, apiKey, chunkIntervalTimeout)
 	}
 
 	stream := NewEventStream[LLMEvent, LLMMessage](

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -33,7 +33,7 @@ func TestStreamLLMEmitsDoneOnBareDoneFrame(t *testing.T) {
 		},
 	}
 
-	stream := StreamLLM(context.Background(), model, llmCtx, "test-key")
+	stream := StreamLLM(context.Background(), model, llmCtx, "test-key", 0)
 
 	var sawDone bool
 	for item := range stream.Iterator(context.Background()) {
@@ -82,7 +82,7 @@ func TestStreamLLMHandlesLargeSSELine(t *testing.T) {
 		},
 	}
 
-	stream := StreamLLM(context.Background(), model, llmCtx, "test-key")
+	stream := StreamLLM(context.Background(), model, llmCtx, "test-key", 0)
 
 	var doneContent string
 	for item := range stream.Iterator(context.Background()) {


### PR DESCRIPTION
## Summary

Add configurable LLM timeout settings to prevent indefinite hangs during streaming responses.

## Changes

- **Total timeout**: 10 minutes for entire LLM request (was hardcoded 2min)
- **Chunk interval timeout**: 2 minutes between streaming chunks
- New LoopConfig fields: LLMTotalTimeout, LLMFirstResponseTimeout

## Implementation

- Uses SetReadDeadline() on response body for chunk-level timeout
- Backward compatible: defaults apply if config fields are zero
- Applied to both StreamLLM() and StreamAnthropic()