### PR TITLE
feat: auto-cleanup truncate_ids from context_management tool calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ ai
 __pycache__/
 *.pyc
 benchmark/results/progress.json
+benchmark/tasks/*/setup/
+benchmark/tasks/*/*/setup/

--- a/benchmark/tasks/fast-manifest.json
+++ b/benchmark/tasks/fast-manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1",
-  "frozen_at": "2026-03-26T01:45:00+08:00",
+  "version": "1.2",
+  "frozen_at": "2026-03-27T00:45:00+08:00",
   "description": "Tasks that complete in under 10 minutes (based on benchmark results) - environment-dependent cases removed",
   "tasks": [
     "001_fix_off_by_one",
@@ -20,16 +20,28 @@
     "agent_009_partial_info",
     "agent_010_memory",
     "agent_011_compact_tool_call_mismatch",
+    "tbench/bn-fit-modify",
     "tbench/cancel-async-tasks",
     "tbench/chess-best-move",
     "tbench/code-from-image",
+    "tbench/count-dataset-tokens",
     "tbench/db-wal-recovery",
+    "tbench/dna-insert",
     "tbench/extract-moves-from-video",
     "tbench/feal-differential-cryptanalysis",
     "tbench/fix-code-vulnerability",
     "tbench/gcode-to-text",
     "tbench/kv-store-grpc",
     "tbench/log-summary-date-ranges",
-    "tbench/pypi-server"
+    "tbench/mteb-leaderboard",
+    "tbench/password-recovery",
+    "tbench/portfolio-optimization",
+    "tbench/protein-assembly",
+    "tbench/prove-plus-comm",
+    "tbench/pypi-server",
+    "tbench/regex-chess",
+    "tbench/regex-log",
+    "tbench/torch-tensor-parallelism",
+    "tbench/vulnerable-secret"
   ]
 }

--- a/benchmark/tasks/tbench/configure-git-webserver/setup/hello.html
+++ b/benchmark/tasks/tbench/configure-git-webserver/setup/hello.html
@@ -1,0 +1,1 @@
+hello world

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -280,7 +280,7 @@ func runInnerLoop(
 		}
 
 		// Update current turn counter
-		agentCtx.ContextMgmtState.CurrentTurn = turnCount + 1
+		agentCtx.ContextMgmtState.SetCurrentTurn(turnCount + 1)
 
 		turnCount++
 
@@ -825,8 +825,9 @@ func streamAssistantResponse(
 	// Only if context management is enabled
 	if agentCtx.LLMContext != nil && agentCtx.ContextMgmtState != nil && config.ContextManagementEnabled {
 		meta := agentCtx.LLMContext.GetMeta()
+		currentTurn := agentCtx.ContextMgmtState.GetCurrentTurn()
 		showDecisionReminder, urgency := agentCtx.ContextMgmtState.ShouldShowDecisionReminder(
-			agentCtx.ContextMgmtState.CurrentTurn,
+			currentTurn,
 			meta.TokensPercent,
 			staleCount,
 		)
@@ -844,7 +845,7 @@ func streamAssistantResponse(
 			llmMessages = append(llmMessages, decisionReminderMsg)
 
 			// Record that a reminder was shown this turn (for proactive/reminded tracking)
-			agentCtx.ContextMgmtState.RecordReminder(agentCtx.ContextMgmtState.CurrentTurn, urgency)
+			agentCtx.ContextMgmtState.RecordReminder(currentTurn, urgency)
 			agentCtx.ContextMgmtState.MarkReminderShown()
 
 			// Trace event for context decision reminder
@@ -1701,11 +1702,12 @@ func updateRuntimeMetaSnapshot(
 		agentCtx.ContextMgmtState = agentctx.DefaultContextMgmtState()
 	}
 	state := agentCtx.ContextMgmtState
+	stateSnapshot := state.Snapshot()
 
 	// Calculate reminders_remaining (turns until next reminder)
 	remindersRemaining := 0
-	if state.ReminderFrequency > 0 {
-		remindersRemaining = state.ReminderFrequency - (state.CurrentTurn - state.LastReminderTurn)
+	if stateSnapshot.ReminderFrequency > 0 {
+		remindersRemaining = stateSnapshot.ReminderFrequency - (stateSnapshot.CurrentTurn - stateSnapshot.LastReminderTurn)
 		if remindersRemaining < 0 {
 			remindersRemaining = 0
 		}
@@ -1734,10 +1736,10 @@ context_metrics:
 				updateStats.Prompted,
 				updateStats.ConsciousPct,
 				updateStats.Score,
-				state.ProactiveDecisions,
-				state.ReminderNeeded,
+				stateSnapshot.ProactiveDecisions,
+				stateSnapshot.ReminderNeeded,
 				remindersRemaining,
-				state.GetScore())
+				stateSnapshot.Score)
 		} else {
 			updateMetrics = fmt.Sprintf(`
 context_metrics:

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1345,6 +1345,10 @@ func executeToolCalls(
 		wg.Add(1)
 		go func(plan toolExecutionPlan) {
 			defer wg.Done()
+
+			// Set current tool call ID for tools that need to reference their own call (e.g., context_management)
+			agentCtx.CurrentToolCallID = plan.normalized.ID
+
 			start := time.Now()
 			var content []agentctx.ContentBlock
 			var err error
@@ -1353,6 +1357,10 @@ func executeToolCalls(
 			} else {
 				content, err = plan.tool.Execute(toolExecCtx, plan.normalized.Arguments)
 			}
+
+			// Clear current tool call ID after execution
+			agentCtx.CurrentToolCallID = ""
+
 			outcomes <- toolExecutionOutcome{
 				plan:     plan,
 				content:  content,

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1345,21 +1345,16 @@ func executeToolCalls(
 		wg.Add(1)
 		go func(plan toolExecutionPlan) {
 			defer wg.Done()
-
-			// Set current tool call ID for tools that need to reference their own call (e.g., context_management)
-			agentCtx.CurrentToolCallID = plan.normalized.ID
+			executionCtx := agentctx.WithToolExecutionCallID(toolExecCtx, plan.normalized.ID)
 
 			start := time.Now()
 			var content []agentctx.ContentBlock
 			var err error
 			if executor != nil {
-				content, err = executor.Execute(toolExecCtx, plan.tool, plan.normalized.Arguments)
+				content, err = executor.Execute(executionCtx, plan.tool, plan.normalized.Arguments)
 			} else {
-				content, err = plan.tool.Execute(toolExecCtx, plan.normalized.Arguments)
+				content, err = plan.tool.Execute(executionCtx, plan.normalized.Arguments)
 			}
-
-			// Clear current tool call ID after execution
-			agentCtx.CurrentToolCallID = ""
 
 			outcomes <- toolExecutionOutcome{
 				plan:     plan,

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -3,6 +3,7 @@ package context
 import (
 	"context"
 	"log/slog"
+	"sync"
 
 	"github.com/tiancaiamao/ai/pkg/skill"
 )
@@ -40,10 +41,16 @@ type AgentContext struct {
 	// OnMessagesChanged is called when messages are modified (e.g., after compact).
 	// This allows persistence to session storage.
 	OnMessagesChanged func() error `json:"-"`
+
+	// contextMgmtMu serializes context_management mutations to shared turn state
+	// and assistant message tool-call arguments.
+	contextMgmtMu sync.Mutex `json:"-"`
 }
 
 // ContextMgmtState tracks LLM's context management decisions for adaptive reminder frequency.
 type ContextMgmtState struct {
+	mu sync.RWMutex
+
 	// Frequency adjustment (turns between reminders)
 	ReminderFrequency int // Current: 5-30, Default: 10
 	SkipUntilTurn     int // Skip reminders until this turn (set by LLM via skip_turns)
@@ -68,6 +75,16 @@ type ContextMgmtState struct {
 	// Compliance tracking
 	ReminderShownThisTurn bool // Was reminder shown in current turn?
 	DecisionMadeThisTurn  bool // Did LLM call context_management this turn?
+}
+
+// ContextMgmtSnapshot is an immutable runtime view of ContextMgmtState.
+type ContextMgmtSnapshot struct {
+	ReminderFrequency  int
+	ProactiveDecisions int
+	ReminderNeeded     int
+	CurrentTurn        int
+	LastReminderTurn   int
+	Score              string
 }
 
 const (
@@ -99,6 +116,8 @@ func (s *ContextMgmtState) MarkReminderShown() {
 	if s == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.ReminderShownThisTurn = true
 }
 
@@ -108,6 +127,8 @@ func (s *ContextMgmtState) MarkDecisionMade() {
 	if s == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.DecisionMadeThisTurn = true
 
 	// Reset pressure counters when LLM makes a decision
@@ -136,6 +157,8 @@ func (s *ContextMgmtState) ResetTurnTracking() {
 	if s == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.ReminderShownThisTurn = false
 	s.DecisionMadeThisTurn = false
 }
@@ -146,10 +169,12 @@ func (s *ContextMgmtState) CheckAndApplyCompliance() {
 	if s == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	// If reminder was shown but LLM didn't make a decision, apply penalty
 	if s.ReminderShownThisTurn && !s.DecisionMadeThisTurn {
 		s.ReminderNeeded++
-		s.AdjustFrequency()
+		s.adjustFrequencyLocked()
 		slog.Info("[ContextMgmt] LLM ignored reminder, applying penalty",
 			"reminder_shown", s.ReminderShownThisTurn,
 			"decision_made", s.DecisionMadeThisTurn,
@@ -165,7 +190,12 @@ func (s *ContextMgmtState) AdjustFrequency() {
 	if s == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.adjustFrequencyLocked()
+}
 
+func (s *ContextMgmtState) adjustFrequencyLocked() {
 	// Calculate ratio: positive means proactive, negative means needs reminders
 	ratio := s.ProactiveDecisions - s.ReminderNeeded
 
@@ -187,6 +217,8 @@ func (s *ContextMgmtState) RecordDecision(turn int, action string, wasReminded b
 	if s == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	s.LastDecisionTurn = turn
 	s.LastActionTaken = action
@@ -199,7 +231,7 @@ func (s *ContextMgmtState) RecordDecision(turn int, action string, wasReminded b
 	s.DecisionPressureTurns = 0
 	s.LastPressureTurn = 0
 
-	s.AdjustFrequency()
+	s.adjustFrequencyLocked()
 }
 
 // SetSkipUntil sets the skip period.
@@ -208,6 +240,8 @@ func (s *ContextMgmtState) SetSkipUntil(turn, skipTurns int, _ bool) {
 	if s == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	s.SkipUntilTurn = turn + skipTurns
 }
@@ -219,6 +253,8 @@ func (s *ContextMgmtState) ShouldShowReminder(turn int, actionRequired string, u
 	if s == nil {
 		return false
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	// Always show for critical urgency
 	if urgency == "critical" {
@@ -253,10 +289,12 @@ func (s *ContextMgmtState) RecordReminder(turn int, urgency string) {
 	if s == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	s.LastReminderTurn = turn
 	s.LastReminderUrgency = urgency
-	s.MarkReminderShown()
+	s.ReminderShownThisTurn = true
 }
 
 // DecisionPressureRequired reports whether context_management should be considered.
@@ -286,6 +324,8 @@ func (s *ContextMgmtState) ShouldShowDecisionReminder(turn int, tokensPercent fl
 	if s == nil {
 		return false, "none"
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	pressure := DecisionPressureRequired(tokensPercent, staleToolOutputs)
 	urgency := DecisionReminderUrgency(tokensPercent, staleToolOutputs)
@@ -322,9 +362,14 @@ func (s *ContextMgmtState) GetScore() string {
 	if s == nil {
 		return "unknown"
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return scoreFromCounts(s.ProactiveDecisions, s.ReminderNeeded)
+}
 
-	ratio := s.ProactiveDecisions - s.ReminderNeeded
-	total := s.ProactiveDecisions + s.ReminderNeeded
+func scoreFromCounts(proactiveDecisions, reminderNeeded int) string {
+	ratio := proactiveDecisions - reminderNeeded
+	total := proactiveDecisions + reminderNeeded
 	if total == 0 {
 		return "no_data"
 	}
@@ -338,6 +383,55 @@ func (s *ContextMgmtState) GetScore() string {
 		return "fair"
 	default:
 		return "needs_improvement"
+	}
+}
+
+// SetCurrentTurn updates the state's current turn counter.
+func (s *ContextMgmtState) SetCurrentTurn(turn int) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.CurrentTurn = turn
+}
+
+// GetCurrentTurn returns the current turn number.
+func (s *ContextMgmtState) GetCurrentTurn() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.CurrentTurn
+}
+
+// GetTurnAndReminderStatus returns the current turn and whether this turn
+// has already been marked as reminded.
+func (s *ContextMgmtState) GetTurnAndReminderStatus() (int, bool) {
+	if s == nil {
+		return 0, false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	turn := s.CurrentTurn
+	return turn, s.LastReminderTurn == turn
+}
+
+// Snapshot returns a consistent view for read-heavy callers.
+func (s *ContextMgmtState) Snapshot() ContextMgmtSnapshot {
+	if s == nil {
+		return ContextMgmtSnapshot{Score: "unknown"}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return ContextMgmtSnapshot{
+		ReminderFrequency:  s.ReminderFrequency,
+		ProactiveDecisions: s.ProactiveDecisions,
+		ReminderNeeded:     s.ReminderNeeded,
+		CurrentTurn:        s.CurrentTurn,
+		LastReminderTurn:   s.LastReminderTurn,
+		Score:              scoreFromCounts(s.ProactiveDecisions, s.ReminderNeeded),
 	}
 }
 
@@ -426,6 +520,22 @@ func NewAgentContextWithSkills(systemPrompt string, skills []skill.Skill) *Agent
 // AddMessage adds a message to the context.
 func (c *AgentContext) AddMessage(message AgentMessage) {
 	c.Messages = append(c.Messages, message)
+}
+
+// LockContextManagement serializes context_management updates on this context.
+func (c *AgentContext) LockContextManagement() {
+	if c == nil {
+		return
+	}
+	c.contextMgmtMu.Lock()
+}
+
+// UnlockContextManagement releases the context_management serialization lock.
+func (c *AgentContext) UnlockContextManagement() {
+	if c == nil {
+		return
+	}
+	c.contextMgmtMu.Unlock()
 }
 
 // AddTool adds a tool to the context.

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -40,6 +40,10 @@ type AgentContext struct {
 	// OnMessagesChanged is called when messages are modified (e.g., after compact).
 	// This allows persistence to session storage.
 	OnMessagesChanged func() error `json:"-"`
+
+	// CurrentToolCallID is the tool call ID being executed in the current tool execution.
+	// Used by context_management to identify and modify the assistant message that called it.
+	CurrentToolCallID string `json:"-"`
 }
 
 // ContextMgmtState tracks LLM's context management decisions for adaptive reminder frequency.

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -40,10 +40,6 @@ type AgentContext struct {
 	// OnMessagesChanged is called when messages are modified (e.g., after compact).
 	// This allows persistence to session storage.
 	OnMessagesChanged func() error `json:"-"`
-
-	// CurrentToolCallID is the tool call ID being executed in the current tool execution.
-	// Used by context_management to identify and modify the assistant message that called it.
-	CurrentToolCallID string `json:"-"`
 }
 
 // ContextMgmtState tracks LLM's context management decisions for adaptive reminder frequency.
@@ -361,6 +357,7 @@ type Tool interface {
 }
 
 type toolExecutionAgentContextKey struct{}
+type toolExecutionCallIDKey struct{}
 
 // WithToolExecutionAgentContext stores the current loop AgentContext in ctx so
 // tools can mutate the active turn state instead of stale outer pointers.
@@ -379,6 +376,25 @@ func ToolExecutionAgentContext(ctx context.Context) *AgentContext {
 	}
 	agentCtx, _ := ctx.Value(toolExecutionAgentContextKey{}).(*AgentContext)
 	return agentCtx
+}
+
+// WithToolExecutionCallID stores the current tool call ID in ctx so tools can
+// access their own call metadata without sharing mutable state across goroutines.
+func WithToolExecutionCallID(ctx context.Context, toolCallID string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, toolExecutionCallIDKey{}, toolCallID)
+}
+
+// ToolExecutionCallID returns the current tool call ID for the running tool
+// execution, when available.
+func ToolExecutionCallID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	toolCallID, _ := ctx.Value(toolExecutionCallIDKey{}).(string)
+	return toolCallID
 }
 
 // NewAgentContext creates a new AgentContext with the given system prompt.

--- a/pkg/tools/context_management.go
+++ b/pkg/tools/context_management.go
@@ -134,6 +134,11 @@ func (t *ContextManagementTool) Execute(ctx context.Context, params map[string]a
 		return nil, fmt.Errorf("reasoning (or reason) parameter is required")
 	}
 
+	// context_management may be called multiple times in one assistant message.
+	// Serialize state/message mutations to avoid races and lost updates.
+	agentCtx.LockContextManagement()
+	defer agentCtx.UnlockContextManagement()
+
 	// Get or create ContextMgmtState
 	if agentCtx.ContextMgmtState == nil {
 		agentCtx.ContextMgmtState = agentctx.DefaultContextMgmtState()
@@ -142,10 +147,7 @@ func (t *ContextManagementTool) Execute(ctx context.Context, params map[string]a
 	// Mark that LLM made a decision this turn (compliance tracking)
 	agentCtx.ContextMgmtState.MarkDecisionMade()
 
-	// Get current turn from context (updated every loop iteration)
-	turn := agentCtx.ContextMgmtState.CurrentTurn
-	// wasReminded indicates whether a reminder was shown THIS turn
-	wasReminded := agentCtx.ContextMgmtState.LastReminderTurn == turn
+	turn, wasReminded := agentCtx.ContextMgmtState.GetTurnAndReminderStatus()
 
 	var result strings.Builder
 	result.WriteString(fmt.Sprintf("**Context Management Decision: %s**\n\n", strings.ToUpper(decision)))
@@ -280,11 +282,12 @@ func (t *ContextManagementTool) Execute(ctx context.Context, params map[string]a
 
 	// Add stats summary
 	if decision != "skip" {
+		stats := agentCtx.ContextMgmtState.Snapshot()
 		result.WriteString(fmt.Sprintf("\n**Stats:** proactive=%d, reminded=%d, frequency=%d turns, score=%s\n",
-			agentCtx.ContextMgmtState.ProactiveDecisions,
-			agentCtx.ContextMgmtState.ReminderNeeded,
-			agentCtx.ContextMgmtState.ReminderFrequency,
-			agentCtx.ContextMgmtState.GetScore()))
+			stats.ProactiveDecisions,
+			stats.ReminderNeeded,
+			stats.ReminderFrequency,
+			stats.Score))
 	}
 
 	return []agentctx.ContentBlock{
@@ -445,6 +448,11 @@ func (t *ContextManagementTool) filterAlreadyTruncated(ctx context.Context, agen
 // The cleanup prevents these IDs from wasting context space after truncation has been
 // executed, and avoids misleading the LLM into thinking they're still usable.
 func (t *ContextManagementTool) CleanupContextManagementInput(agentCtx *agentctx.AgentContext) {
+	if agentCtx == nil {
+		return
+	}
+	agentCtx.LockContextManagement()
+	defer agentCtx.UnlockContextManagement()
 	t.cleanupContextManagementInput(agentCtx, "")
 }
 

--- a/pkg/tools/context_management.go
+++ b/pkg/tools/context_management.go
@@ -216,7 +216,7 @@ func (t *ContextManagementTool) Execute(ctx context.Context, params map[string]a
 		}
 
 		// Clean up truncate_ids from the assistant message that called this tool
-		t.cleanupContextManagementInput(agentCtx)
+		t.cleanupContextManagementInput(agentCtx, agentctx.ToolExecutionCallID(ctx))
 
 		// Record decision
 		agentCtx.ContextMgmtState.RecordDecision(turn, "truncate", wasReminded)
@@ -445,21 +445,19 @@ func (t *ContextManagementTool) filterAlreadyTruncated(ctx context.Context, agen
 // The cleanup prevents these IDs from wasting context space after truncation has been
 // executed, and avoids misleading the LLM into thinking they're still usable.
 func (t *ContextManagementTool) CleanupContextManagementInput(agentCtx *agentctx.AgentContext) {
-	t.cleanupContextManagementInput(agentCtx)
+	t.cleanupContextManagementInput(agentCtx, "")
 }
 
 // cleanupContextManagementInput removes truncate_ids parameter from the assistant message
 // that called context_management tool. This prevents these IDs from wasting context space
 // after the truncation has been executed, and avoids misleading LLM into thinking they're still usable.
-func (t *ContextManagementTool) cleanupContextManagementInput(agentCtx *agentctx.AgentContext) {
-	// Get the current tool call ID (the context_management call)
-	currentCallID := agentCtx.CurrentToolCallID
-	if currentCallID == "" {
-		slog.Warn("[ContextManagement] cleanupContextManagementInput: no current tool call ID")
+func (t *ContextManagementTool) cleanupContextManagementInput(agentCtx *agentctx.AgentContext, currentCallID string) {
+	if agentCtx == nil {
 		return
 	}
 
-	// Find the assistant message that made this tool call
+	// Find the assistant message that made this tool call.
+	// If currentCallID is empty, fallback to cleaning the latest context_management call.
 	for i := len(agentCtx.Messages) - 1; i >= 0; i-- {
 		msg := agentCtx.Messages[i]
 		if msg.Role != "assistant" {
@@ -469,38 +467,76 @@ func (t *ContextManagementTool) cleanupContextManagementInput(agentCtx *agentctx
 		toolCalls := msg.ExtractToolCalls()
 		found := false
 		for _, tc := range toolCalls {
-			if tc.ID == currentCallID && tc.Name == "context_management" {
+			if tc.Name != "context_management" {
+				continue
+			}
+			if currentCallID != "" && tc.ID != currentCallID {
+				continue
+			}
+			if _, hasTruncateIDs := tc.Arguments["truncate_ids"]; !hasTruncateIDs {
+				continue
+			}
+			if currentCallID != "" {
 				found = true
 				break
 			}
+			// Fallback mode: clean the latest context_management call that still has truncate_ids.
+			found = true
+			break
 		}
 
 		if found {
-			// Found the assistant message with the context_management call
-			// Remove truncate_ids from its arguments
-			cleanedContent := []agentctx.ContentBlock{}
+			// Found the assistant message with the target context_management call.
+			// Remove truncate_ids from its arguments.
+			cleanedContent := make([]agentctx.ContentBlock, 0, len(msg.Content))
+			updated := false
 
 			for _, block := range msg.Content {
-				if tc, ok := block.(agentctx.ToolCallContent); ok && tc.ID == currentCallID && tc.Name == "context_management" {
-					// Remove truncate_ids from arguments
-					newArgs := make(map[string]any)
-					for k, v := range tc.Arguments {
-						if k != "truncate_ids" {
-							newArgs[k] = v
-						}
-					}
-					tc.Arguments = newArgs
-					cleanedContent = append(cleanedContent, tc)
-					slog.Debug("[ContextManagement] Removed truncate_ids from tool call input",
-						"tool_call_id", currentCallID)
-				} else {
+				tc, ok := block.(agentctx.ToolCallContent)
+				if !ok || tc.Name != "context_management" {
 					cleanedContent = append(cleanedContent, block)
+					continue
+				}
+				if currentCallID != "" && tc.ID != currentCallID {
+					cleanedContent = append(cleanedContent, block)
+					continue
+				}
+				if _, hasTruncateIDs := tc.Arguments["truncate_ids"]; !hasTruncateIDs {
+					cleanedContent = append(cleanedContent, block)
+					continue
+				}
+
+				newArgs := make(map[string]any, len(tc.Arguments))
+				for k, v := range tc.Arguments {
+					if k != "truncate_ids" {
+						newArgs[k] = v
+					}
+				}
+				tc.Arguments = newArgs
+				cleanedContent = append(cleanedContent, tc)
+				updated = true
+				slog.Debug("[ContextManagement] Removed truncate_ids from tool call input",
+					"tool_call_id", tc.ID)
+
+				// In fallback mode we only clean the latest matching call once.
+				if currentCallID == "" {
+					cleanedContent = append(cleanedContent, msg.Content[len(cleanedContent):]...)
+					break
 				}
 			}
 
-			agentCtx.Messages[i].Content = cleanedContent
-			return
+			if updated {
+				agentCtx.Messages[i].Content = cleanedContent
+				return
+			}
+
+			// Matching call exists but no update occurred; continue searching older messages.
 		}
+	}
+
+	if currentCallID == "" {
+		slog.Warn("[ContextManagement] cleanupContextManagementInput: no target context_management call found")
+		return
 	}
 
 	slog.Warn("[ContextManagement] cleanupContextManagementInput: assistant message not found",

--- a/pkg/tools/context_management.go
+++ b/pkg/tools/context_management.go
@@ -215,6 +215,9 @@ func (t *ContextManagementTool) Execute(ctx context.Context, params map[string]a
 			result.WriteString("No truncate_ids provided, skipped truncation.\n")
 		}
 
+		// Clean up truncate_ids from the assistant message that called this tool
+		t.cleanupContextManagementInput(agentCtx)
+
 		// Record decision
 		agentCtx.ContextMgmtState.RecordDecision(turn, "truncate", wasReminded)
 		traceevent.Log(ctx, traceevent.CategoryTool, "context_decision_truncate",
@@ -431,6 +434,77 @@ func (t *ContextManagementTool) filterAlreadyTruncated(ctx context.Context, agen
 	}
 
 	return filteredIDs
+}
+
+// CleanupContextManagementInput removes the truncate_ids parameter from the assistant message
+// that called the context_management tool.
+//
+// This public method is exported for testing purposes. It's called automatically during
+// Execute() when a truncate operation is performed.
+//
+// The cleanup prevents these IDs from wasting context space after truncation has been
+// executed, and avoids misleading the LLM into thinking they're still usable.
+func (t *ContextManagementTool) CleanupContextManagementInput(agentCtx *agentctx.AgentContext) {
+	t.cleanupContextManagementInput(agentCtx)
+}
+
+// cleanupContextManagementInput removes truncate_ids parameter from the assistant message
+// that called context_management tool. This prevents these IDs from wasting context space
+// after the truncation has been executed, and avoids misleading LLM into thinking they're still usable.
+func (t *ContextManagementTool) cleanupContextManagementInput(agentCtx *agentctx.AgentContext) {
+	// Get the current tool call ID (the context_management call)
+	currentCallID := agentCtx.CurrentToolCallID
+	if currentCallID == "" {
+		slog.Warn("[ContextManagement] cleanupContextManagementInput: no current tool call ID")
+		return
+	}
+
+	// Find the assistant message that made this tool call
+	for i := len(agentCtx.Messages) - 1; i >= 0; i-- {
+		msg := agentCtx.Messages[i]
+		if msg.Role != "assistant" {
+			continue
+		}
+
+		toolCalls := msg.ExtractToolCalls()
+		found := false
+		for _, tc := range toolCalls {
+			if tc.ID == currentCallID && tc.Name == "context_management" {
+				found = true
+				break
+			}
+		}
+
+		if found {
+			// Found the assistant message with the context_management call
+			// Remove truncate_ids from its arguments
+			cleanedContent := []agentctx.ContentBlock{}
+
+			for _, block := range msg.Content {
+				if tc, ok := block.(agentctx.ToolCallContent); ok && tc.ID == currentCallID && tc.Name == "context_management" {
+					// Remove truncate_ids from arguments
+					newArgs := make(map[string]any)
+					for k, v := range tc.Arguments {
+						if k != "truncate_ids" {
+							newArgs[k] = v
+						}
+					}
+					tc.Arguments = newArgs
+					cleanedContent = append(cleanedContent, tc)
+					slog.Debug("[ContextManagement] Removed truncate_ids from tool call input",
+						"tool_call_id", currentCallID)
+				} else {
+					cleanedContent = append(cleanedContent, block)
+				}
+			}
+
+			agentCtx.Messages[i].Content = cleanedContent
+			return
+		}
+	}
+
+	slog.Warn("[ContextManagement] cleanupContextManagementInput: assistant message not found",
+		"tool_call_id", currentCallID)
 }
 
 // findLatestToolCall finds the most recent tool call ID for a given tool name.

--- a/pkg/tools/context_management_test.go
+++ b/pkg/tools/context_management_test.go
@@ -10,6 +10,23 @@ import (
 func TestLLMContextDecisionFiltersAlreadyTruncated(t *testing.T) {
 	// Create test messages
 	messages := []agentctx.AgentMessage{
+		func() agentctx.AgentMessage {
+			msg := agentctx.NewAssistantMessage()
+			msg.Content = []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call_cm_test",
+					Type: "toolCall",
+					Name: "context_management",
+					Arguments: map[string]any{
+						"decision":     "truncate",
+						"reasoning":    "Test filtering of already truncated outputs",
+						"truncate_ids": "call_1,call_2,call_3,call_4",
+					},
+				},
+			}
+			return msg
+		}(),
+
 		// Regular tool output (not truncated)
 		agentctx.NewToolResultMessage("call_1", "read", []agentctx.ContentBlock{
 			agentctx.TextContent{Type: "text", Text: "large content 1"},
@@ -39,7 +56,7 @@ func TestLLMContextDecisionFiltersAlreadyTruncated(t *testing.T) {
 	// Test IsTruncatedAgentToolTag function
 	for _, msg := range messages {
 		if msg.Role != "toolResult" {
-			t.Errorf("Expected role toolResult, got %s", msg.Role)
+			continue
 		}
 		text := msg.ExtractText()
 		isTruncated := agentctx.IsTruncatedAgentToolTag(text)
@@ -50,14 +67,15 @@ func TestLLMContextDecisionFiltersAlreadyTruncated(t *testing.T) {
 
 	// Create agent context
 	agentCtx := &agentctx.AgentContext{
-		Messages:          messages,
-		ContextMgmtState:  agentctx.DefaultContextMgmtState(),
-		LLMContext:        nil,
+		Messages:         messages,
+		ContextMgmtState: agentctx.DefaultContextMgmtState(),
+		LLMContext:       nil,
 	}
 
 	// Wrap with agent context - this is what AgentLoop does when executing tools
 	ctx := context.Background()
 	ctx = agentctx.WithToolExecutionAgentContext(ctx, agentCtx)
+	ctx = agentctx.WithToolExecutionCallID(ctx, "call_cm_test")
 
 	params := map[string]any{
 		"decision":     "truncate",
@@ -103,5 +121,85 @@ func TestLLMContextDecisionFiltersAlreadyTruncated(t *testing.T) {
 				t.Errorf("Message %s should still be truncated but is not: %s", msg.ToolCallID, content)
 			}
 		}
+	}
+}
+
+func TestContextManagementTruncateCleansOnlyCurrentToolCallArguments(t *testing.T) {
+	olderAssistant := agentctx.NewAssistantMessage()
+	olderAssistant.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:   "call_cm_old",
+			Type: "toolCall",
+			Name: "context_management",
+			Arguments: map[string]any{
+				"decision":     "truncate",
+				"reasoning":    "old call",
+				"truncate_ids": "old_1",
+			},
+		},
+	}
+
+	currentAssistant := agentctx.NewAssistantMessage()
+	currentAssistant.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:   "call_cm_new",
+			Type: "toolCall",
+			Name: "context_management",
+			Arguments: map[string]any{
+				"decision":     "truncate",
+				"reasoning":    "current call",
+				"truncate_ids": "call_1,call_2",
+			},
+		},
+	}
+
+	agentCtx := &agentctx.AgentContext{
+		Messages: []agentctx.AgentMessage{
+			olderAssistant,
+			currentAssistant,
+			agentctx.NewToolResultMessage("call_1", "read", []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "content 1"},
+			}, false),
+			agentctx.NewToolResultMessage("call_2", "grep", []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "content 2"},
+			}, false),
+		},
+		ContextMgmtState: agentctx.DefaultContextMgmtState(),
+	}
+
+	tool := NewContextManagementTool(nil)
+
+	execCtx := agentctx.WithToolExecutionAgentContext(context.Background(), agentCtx)
+	execCtx = agentctx.WithToolExecutionCallID(execCtx, "call_cm_new")
+
+	_, err := tool.Execute(execCtx, map[string]any{
+		"decision":     "truncate",
+		"reasoning":    "clean only current tool call",
+		"truncate_ids": "call_1,call_2",
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	olderCalls := agentCtx.Messages[0].ExtractToolCalls()
+	if len(olderCalls) != 1 {
+		t.Fatalf("expected 1 tool call in older assistant message, got %d", len(olderCalls))
+	}
+	if _, exists := olderCalls[0].Arguments["truncate_ids"]; !exists {
+		t.Fatal("expected older context_management call to keep truncate_ids")
+	}
+
+	currentCalls := agentCtx.Messages[1].ExtractToolCalls()
+	if len(currentCalls) != 1 {
+		t.Fatalf("expected 1 tool call in current assistant message, got %d", len(currentCalls))
+	}
+	if _, exists := currentCalls[0].Arguments["truncate_ids"]; exists {
+		t.Fatal("expected current context_management call to remove truncate_ids")
+	}
+	if got := currentCalls[0].Arguments["decision"]; got != "truncate" {
+		t.Fatalf("expected decision to be preserved, got %#v", got)
+	}
+	if got := currentCalls[0].Arguments["reasoning"]; got != "current call" {
+		t.Fatalf("expected reasoning to be preserved, got %#v", got)
 	}
 }

--- a/pkg/tools/context_management_test.go
+++ b/pkg/tools/context_management_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
@@ -201,5 +202,97 @@ func TestContextManagementTruncateCleansOnlyCurrentToolCallArguments(t *testing.
 	}
 	if got := currentCalls[0].Arguments["reasoning"]; got != "current call" {
 		t.Fatalf("expected reasoning to be preserved, got %#v", got)
+	}
+}
+
+func TestContextManagementConcurrentTruncateCallsKeepBothCleanups(t *testing.T) {
+	assistant := agentctx.NewAssistantMessage()
+	assistant.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:   "call_cm_1",
+			Type: "toolCall",
+			Name: "context_management",
+			Arguments: map[string]any{
+				"decision":     "truncate",
+				"reasoning":    "cleanup first",
+				"truncate_ids": "call_1",
+			},
+		},
+		agentctx.ToolCallContent{
+			ID:   "call_cm_2",
+			Type: "toolCall",
+			Name: "context_management",
+			Arguments: map[string]any{
+				"decision":     "truncate",
+				"reasoning":    "cleanup second",
+				"truncate_ids": "call_2",
+			},
+		},
+	}
+
+	agentCtx := &agentctx.AgentContext{
+		Messages: []agentctx.AgentMessage{
+			assistant,
+			agentctx.NewToolResultMessage("call_1", "read", []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "content 1"},
+			}, false),
+			agentctx.NewToolResultMessage("call_2", "grep", []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "content 2"},
+			}, false),
+		},
+		ContextMgmtState: agentctx.DefaultContextMgmtState(),
+	}
+	agentCtx.ContextMgmtState.SetCurrentTurn(1)
+
+	tool := NewContextManagementTool(nil)
+
+	runCall := func(callID, truncateIDs string) error {
+		execCtx := agentctx.WithToolExecutionAgentContext(context.Background(), agentCtx)
+		execCtx = agentctx.WithToolExecutionCallID(execCtx, callID)
+		_, err := tool.Execute(execCtx, map[string]any{
+			"decision":     "truncate",
+			"reasoning":    "concurrent cleanup",
+			"truncate_ids": truncateIDs,
+		})
+		return err
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errs <- runCall("call_cm_1", "call_1")
+	}()
+	go func() {
+		defer wg.Done()
+		errs <- runCall("call_cm_2", "call_2")
+	}()
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Execute failed: %v", err)
+		}
+	}
+
+	toolCalls := agentCtx.Messages[0].ExtractToolCalls()
+	if len(toolCalls) != 2 {
+		t.Fatalf("expected 2 context_management tool calls, got %d", len(toolCalls))
+	}
+	for _, tc := range toolCalls {
+		if _, exists := tc.Arguments["truncate_ids"]; exists {
+			t.Fatalf("expected truncate_ids removed for %s", tc.ID)
+		}
+	}
+
+	for _, msg := range agentCtx.Messages[1:] {
+		if msg.Role != "toolResult" {
+			continue
+		}
+		if !agentctx.IsTruncatedAgentToolTag(msg.ExtractText()) {
+			t.Fatalf("expected tool result %s to be truncated", msg.ToolCallID)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

The `context_management` tool includes `truncate_ids` parameter in its input when truncating tool outputs. After truncation operation completes, these IDs:

1. **Are no longer valid** - The tool outputs have already been removed
2. **Waste context space** - Long ID lists accumulate over time (e.g., "call-1,call-2,call-3,...,call-20")
3. **Mislead LLM** - The model may attempt to truncate already-removed IDs again

## Solution

Automatically remove `truncate_ids` parameter from the assistant message that called `context_management` after the truncate operation is executed.

## Implementation

1. **Added `CurrentToolCallID` field to `AgentContext`** (pkg/context/context.go)
   - Tracks the tool call ID currently being executed
   - Allows `context_management` to identify its own invocation

2. **Set/clear `CurrentToolCallID` during tool execution** (pkg/agent/loop.go)
   ```go
   agentCtx.CurrentToolCallID = plan.normalized.ID
   // ... execute tool ...
   agentCtx.CurrentToolCallID = ""
   ```

3. **Added cleanup logic** (pkg/tools/context_management.go)
   - `cleanupContextManagementInput()` removes `truncate_ids` from the assistant message's tool call arguments
   - `CleanupContextManagementInput()` exported version for testing
   - Automatically called in the `decision="truncate"` branch

## Benefits

- ✅ **Saves context space** - No accumulated ID lists from multiple truncate calls
- ✅ **Prevents confusion** - LLM won't try to truncate already-removed IDs
- ✅ **Solves cumulative problem** - Multiple truncate operations don't pile up invalid IDs
- ✅ **Transparent** - Cleanup happens automatically, no LLM intervention needed

## Testing

- All existing tests pass
- Code compiles successfully
- Feature verified in isolated worktree

## Example

**Before:**
```json
{
  "tool_call_id": "call-1",
  "tool_name": "context_management",
  "arguments": {
    "decision": "truncate",
    "reasoning": "...",
    "truncate_ids": "call-100,call-101,call-102,call-103,call-104,call-105"
  }
}
```

**After:**
```json
{
  "tool_call_id": "call-1",
  "tool_name": "context_management",
  "arguments": {
    "decision": "truncate",
    "reasoning": "..."
  }
}
```

## Changes

- `pkg/agent/loop.go`: 8 lines added
- `pkg/context/context.go`: 4 lines added
- `pkg/tools/context_management.go`: 74 lines added

Total: 86 insertions, 0 deletions