### PR TITLE
fix: handle nested properties tool args and tighten anthropic schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ No `Makefile` is used in this repo.
 - Respect context cancellation through loop/tool execution paths.
 - Keep behavior compatible with session persistence format in `pkg/session/`.
 - Prefer minimal, targeted changes; avoid broad refactors unless requested.
+- Never push directly to `main`. Always push to a feature branch and open/update a PR for review.
 
 ## Runtime/Storage Notes
 

--- a/pkg/agent/tool_call_normalize.go
+++ b/pkg/agent/tool_call_normalize.go
@@ -1,8 +1,9 @@
 package agent
 
 import (
-	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"encoding/json"
 	"fmt"
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -13,8 +14,9 @@ var toolCallSeq uint64
 func normalizeToolCall(tc agentctx.ToolCallContent) agentctx.ToolCallContent {
 	normalized := tc
 	normalized.Name = normalizeToolCallName(tc.Name)
+	normalized.Arguments = unwrapPropertiesArguments(tc.Arguments)
 	if isGenericToolName(normalized.Name) {
-		if inferredName, inferredArgs, ok := inferToolFromArgs(tc.Arguments); ok {
+		if inferredName, inferredArgs, ok := inferToolFromArgs(normalized.Arguments); ok {
 			normalized.Name = inferredName
 			normalized.Arguments = inferredArgs
 		}
@@ -53,7 +55,7 @@ func isGenericToolName(name string) bool {
 }
 
 func inferToolFromArgs(args map[string]any) (string, map[string]any, bool) {
-	argSource := args
+	argSource := unwrapPropertiesArguments(args)
 	if argSource == nil {
 		argSource = map[string]any{}
 	}
@@ -133,6 +135,7 @@ func sanitizeToolCallID(id string) string {
 
 func coerceToolArguments(toolName string, args map[string]any) (map[string]any, error) {
 	name := normalizeToolCallName(toolName)
+	args = unwrapPropertiesArguments(args)
 	if args == nil {
 		args = map[string]any{}
 	}
@@ -227,4 +230,35 @@ func getMapArg(args map[string]any, keys ...string) map[string]any {
 		}
 	}
 	return nil
+}
+
+func unwrapPropertiesArguments(args map[string]any) map[string]any {
+	if args == nil {
+		return nil
+	}
+
+	props, ok := args["properties"]
+	if !ok {
+		return args
+	}
+
+	switch p := props.(type) {
+	case map[string]any:
+		if len(p) == 0 {
+			return args
+		}
+		return p
+	case string:
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
+			return args
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err == nil && len(parsed) > 0 {
+			return parsed
+		}
+		return args
+	default:
+		return args
+	}
 }

--- a/pkg/agent/tool_call_normalize_test.go
+++ b/pkg/agent/tool_call_normalize_test.go
@@ -55,3 +55,48 @@ func TestNormalizeToolCallInfersGenericWrapperName(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeToolCallUnwrapsPropertiesStringForWrite(t *testing.T) {
+	got := normalizeToolCall(agentctx.ToolCallContent{
+		Name: "write",
+		Arguments: map[string]any{
+			"properties": `{"path":"/tmp/a.txt","content":"hello world"}`,
+		},
+	})
+
+	args, err := coerceToolArguments(got.Name, got.Arguments)
+	if err != nil {
+		t.Fatalf("coerceToolArguments returned error: %v", err)
+	}
+
+	if args["path"] != "/tmp/a.txt" {
+		t.Fatalf("expected path=/tmp/a.txt, got %v", args["path"])
+	}
+	if args["content"] != "hello world" {
+		t.Fatalf("expected content=hello world, got %v", args["content"])
+	}
+}
+
+func TestNormalizeToolCallUnwrapsPropertiesMapForWrite(t *testing.T) {
+	got := normalizeToolCall(agentctx.ToolCallContent{
+		Name: "write",
+		Arguments: map[string]any{
+			"properties": map[string]any{
+				"path":    "/tmp/b.txt",
+				"content": "abc",
+			},
+		},
+	})
+
+	args, err := coerceToolArguments(got.Name, got.Arguments)
+	if err != nil {
+		t.Fatalf("coerceToolArguments returned error: %v", err)
+	}
+
+	if args["path"] != "/tmp/b.txt" {
+		t.Fatalf("expected path=/tmp/b.txt, got %v", args["path"])
+	}
+	if args["content"] != "abc" {
+		t.Fatalf("expected content=abc, got %v", args["content"])
+	}
+}

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -461,19 +461,12 @@ func buildAnthropicRequest(model Model, llmCtx LLMContext) map[string]any {
 	if len(llmCtx.Tools) > 0 {
 		tools := []map[string]any{}
 		for _, tool := range llmCtx.Tools {
-			// Get input_schema from tool parameters
-			inputSchema := map[string]any{}
-			if tool.Function.Parameters != nil {
-				inputSchema = tool.Function.Parameters
-			}
+			inputSchema := normalizeAnthropicInputSchema(tool.Function.Parameters)
 
 			tools = append(tools, map[string]any{
-				"name":        tool.Function.Name,
-				"description": tool.Function.Description,
-				"input_schema": map[string]any{
-					"type":       "object",
-					"properties": inputSchema,
-				},
+				"name":         tool.Function.Name,
+				"description":  tool.Function.Description,
+				"input_schema": inputSchema,
 			})
 		}
 		reqBody["tools"] = tools
@@ -490,6 +483,33 @@ func resolveAnthropicMaxTokens(model Model) int {
 		return model.MaxTokens
 	}
 	return defaultAnthropicMaxTokens
+}
+
+func normalizeAnthropicInputSchema(params map[string]any) map[string]any {
+	if params == nil {
+		return map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		}
+	}
+
+	if _, ok := params["type"]; ok {
+		return params
+	}
+	if _, ok := params["properties"]; ok {
+		return params
+	}
+	if _, ok := params["required"]; ok {
+		return params
+	}
+	if _, ok := params["additionalProperties"]; ok {
+		return params
+	}
+
+	return map[string]any{
+		"type":       "object",
+		"properties": params,
+	}
 }
 
 // convertToolResultContent converts tool result content to Anthropic format

--- a/pkg/llm/anthropic_request_test.go
+++ b/pkg/llm/anthropic_request_test.go
@@ -38,3 +38,45 @@ func TestBuildAnthropicRequestUsesLargeDefaultMaxTokens(t *testing.T) {
 		t.Fatalf("expected max_tokens=%d, got %d", defaultAnthropicMaxTokens, got)
 	}
 }
+
+func TestBuildAnthropicRequestKeepsSchemaWithoutDoubleWrapping(t *testing.T) {
+	req := buildAnthropicRequest(Model{ID: "test-model"}, LLMContext{
+		Messages: []LLMMessage{{Role: "user", Content: "hello"}},
+		Tools: []LLMTool{
+			{
+				Type: "function",
+				Function: ToolFunction{
+					Name:        "write",
+					Description: "write file",
+					Parameters: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"path": map[string]any{"type": "string"},
+						},
+						"required": []string{"path"},
+					},
+				},
+			},
+		},
+	})
+
+	tools, ok := req["tools"].([]map[string]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("expected one tool schema, got %#v", req["tools"])
+	}
+	inputSchema, ok := tools[0]["input_schema"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected input_schema map, got %#v", tools[0]["input_schema"])
+	}
+
+	props, ok := inputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected input_schema.properties map, got %#v", inputSchema["properties"])
+	}
+	if _, hasNestedProperties := props["properties"]; hasNestedProperties {
+		t.Fatalf("unexpected nested properties in input_schema: %#v", inputSchema)
+	}
+	if _, ok := props["path"]; !ok {
+		t.Fatalf("expected path in input_schema.properties, got %#v", props)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix tool calls where arguments arrive as nested `properties` payloads (string or map), so required fields like `path/content` are correctly extracted.
- Normalize Anthropic `input_schema` handling to avoid double-wrapping JSON Schema under `properties`, reducing malformed nested arguments.
- Add explicit repository guardrail: never push directly to `main`; always use a feature branch + PR.

## Why
Trace `pid44408-sess1d35cedd-fa7e-4452-b1eb-1bcc9432eda0.1.perfetto.json` showed repeated `tool_call_invalid_args` with `missing path/content` while the inner payload already contained both fields under `properties`.

## Tests
- `go test ./pkg/agent -run "TestNormalizeToolCall|TestExecuteToolCallsReportsMaxTokensTruncationClearly|TestStreamAssistantResponse_LengthStopReasonProducesTruncationGuidance" -v`
- `go test ./pkg/llm -run "TestBuildAnthropicRequest" -v`
