### PR TITLE
Test: Verify race condition fix for tool call pairing

### DIFF
--- a/WORKPAD.md
+++ b/WORKPAD.md
@@ -1,0 +1,38 @@
+## Workpad
+
+```
+tiancaiamao/ai:final-1774747669 @ bb8fffc
+```
+
+### Plan
+
+- [x] 1. Understand the race condition fix for tool call pairing
+  - [x] 1.1 Reviewed `ensureToolCallPairing` function in compact.go
+  - [x] 1.2 Reviewed the fix commit 34de5d2
+- [x] 2. Run existing tests to verify the fix
+  - [x] 2.1 Run `pkg/compact` tests - ALL PASS
+  - [x] 2.2 Run `pkg/agent` conversion tests - ALL PASS
+  - [x] 2.3 Full test suite with race detector - ALL PASS
+- [ ] 3. Create PR and complete review flow
+
+### Acceptance Criteria
+
+- [x] All compact.go tests pass
+- [x] All conversion tests pass
+- [x] No orphaned tool calls appear in test output
+- [x] Agent runs without race conditions (verified with `go test -race`)
+
+### Validation Results
+
+```
+pkg/compact: 15 tests PASS
+pkg/agent: 50+ tests PASS
+Full suite with race detector: ALL PASS (no race conditions detected)
+```
+
+### Notes
+
+- Race condition was in `ensureToolCallPairing` - it was hiding toolResults but not removing stale toolCalls from assistant messages
+- Fix: filter out tool_calls from assistant messages if their IDs are in oldMessages
+- The fix also archives tool_results whose tool_calls are in oldMessages
+- Key test: `TestEnsureToolCallPairing_AssistantWithOldToolCalls` verifies the fix


### PR DESCRIPTION
## Workpad

```
tiancaiamao/ai:final-1774747669 @ bb8fffc
```

### Plan

- [x] 1. Understand the race condition fix for tool call pairing
  - [x] 1.1 Reviewed `ensureToolCallPairing` function in compact.go
  - [x] 1.2 Reviewed the fix commit 34de5d2
- [x] 2. Run existing tests to verify the fix
  - [x] 2.1 Run `pkg/compact` tests - ALL PASS
  - [x] 2.2 Run `pkg/agent` conversion tests - ALL PASS
  - [x] 2.3 Full test suite with race detector - ALL PASS
- [ ] 3. Create PR and complete review flow

### Acceptance Criteria

- [x] All compact.go tests pass
- [x] All conversion tests pass
- [x] No orphaned tool calls appear in test output
- [x] Agent runs without race conditions (verified with `go test -race`)

### Validation Results

```
pkg/compact: 15 tests PASS
pkg/agent: 50+ tests PASS
Full suite with race detector: ALL PASS (no race conditions detected)
```

### Notes

- Race condition was in `ensureToolCallPairing` - it was hiding toolResults but not removing stale toolCalls from assistant messages
- Fix: filter out tool_calls from assistant messages if their IDs are in oldMessages
- The fix also archives tool_results whose tool_calls are in oldMessages
- Key test: `TestEnsureToolCallPairing_AssistantWithOldToolCalls` verifies the fix