### PR TITLE
fix: add http.Client.Timeout to trigger 2min timeout when server sends no response

### DIFF
--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -81,8 +81,10 @@ func StreamAnthropic(
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 		req.Header.Set("anthropic-version", "2023-06-01")
 
-		// Execute request
-		client := &http.Client{}
+// Execute request
+	client := &http.Client{
+			Timeout: 2 * time.Minute, // Timeout for waiting for response headers + body
+		}
 		resp, err := client.Do(req)
 		if err != nil {
 			if strings.Contains(err.Error(), "no such host") {


### PR DESCRIPTION


Problem:
- When LLM server connects but doesn't send response headers, current code blocks forever on client.Do(req)
- SetReadDeadline only applies to reading body, not waiting for headers
- 2-minute heartbeat timeout never triggers if no headers arrive
- Only triggers after 10-minute context.WithTimeout

Solution:
- Add Timeout: 2 * time.Minute to http.Client
- This triggers timeout when waiting for response headers + body
- SetReadDeadline remains for reading body chunks
- context.WithTimeout remains as 10-minute total timeout

Expected behavior:
- Server connects, no response headers: 2min timeout (instead of 10min)
- Server sends headers, no body: 2min timeout (SetReadDeadline)
- Server sends chunks every 1.9min: 10min timeout (context)

Fixes: #96 (regex-chess LLM timeout issue)