### PR TITLE
Fix: [FEATURE] Improve context_management skip mechanism

### DIFF
--- a/pkg/tools/context_management.go
+++ b/pkg/tools/context_management.go
@@ -145,6 +145,9 @@ func (t *ContextManagementTool) Execute(ctx context.Context, params map[string]a
 	}
 
 	// Mark that LLM made a decision this turn (compliance tracking)
+	// Capture snapshot BEFORE MarkDecisionMade for accurate ratio calculation
+	// (MarkDecisionMade will increment ProactiveDecisions, affecting the ratio)
+	snapshot := agentCtx.ContextMgmtState.Snapshot()
 	agentCtx.ContextMgmtState.MarkDecisionMade()
 
 	turn, wasReminded := agentCtx.ContextMgmtState.GetTurnAndReminderStatus()
@@ -158,6 +161,8 @@ func (t *ContextManagementTool) Execute(ctx context.Context, params map[string]a
 		skipTurns := 10 // default
 		if st, ok := params["skip_turns"].(float64); ok {
 			skipTurns = int(st)
+		} else if st, ok := params["skip_turns"].(int); ok {
+			skipTurns = st
 		}
 		if skipTurns < 1 {
 			skipTurns = 1
@@ -165,19 +170,73 @@ func (t *ContextManagementTool) Execute(ctx context.Context, params map[string]a
 		if skipTurns > 30 {
 			skipTurns = 30
 		}
+		originalSkipTurns := skipTurns
 
-		agentCtx.ContextMgmtState.SetSkipUntil(turn, skipTurns, wasReminded)
-		result.WriteString(fmt.Sprintf("Deferred for %d turns.\n", skipTurns))
-		result.WriteString(fmt.Sprintf("Next reminder at turn %d.\n", turn+skipTurns))
+		// Calculate max skip based on proactive ratio (from pre-decision snapshot)
+		// maxSkip = proactiveDecisions - reminderNeeded, capped at 30, floored at 0
+		ratio := snapshot.ProactiveDecisions - snapshot.ReminderNeeded
+		maxSkip := ratio
+		if maxSkip > 30 {
+			maxSkip = 30
+		}
+		if maxSkip < 0 {
+			maxSkip = 0
+		}
 
-		// Record the skip decision so LastDecisionTurn is updated
-		agentCtx.ContextMgmtState.RecordDecision(turn, "skip", wasReminded)
+		if ratio <= 0 {
+			// Case 1: Deny skip when ratio <= 0
+			nextReminderTurn := agentCtx.ContextMgmtState.LastReminderTurn + snapshot.ReminderFrequency
+			if nextReminderTurn <= turn {
+				nextReminderTurn = turn + snapshot.ReminderFrequency
+			}
+			result.WriteString("⚠️ skip request denied\n\n")
+			result.WriteString(fmt.Sprintf("Since you are not proactive enough (ratio=%d), you are not allowed to skip %d turns.\n\n", ratio, skipTurns))
+			result.WriteString(fmt.Sprintf("You will still receive a remind within %d turns (turn %d).\n", snapshot.ReminderFrequency, nextReminderTurn))
+			result.WriteString("You must be more proactive before you receive the next remind.\n\n")
+			result.WriteString(fmt.Sprintf("Next reminder at: turn %d\n", nextReminderTurn))
+			result.WriteString(fmt.Sprintf("Current stats: proactive=%d, reminded=%d, ratio=%d, frequency=%d turns\n",
+				snapshot.ProactiveDecisions, snapshot.ReminderNeeded, ratio, snapshot.ReminderFrequency))
 
-		traceevent.Log(ctx, traceevent.CategoryTool, "context_decision_skip",
-			traceevent.Field{Key: "skip_turns", Value: skipTurns},
-			traceevent.Field{Key: "skip_until_turn", Value: turn + skipTurns},
-			traceevent.Field{Key: "was_reminded", Value: wasReminded},
-		)
+			// Don't call SetSkipUntil, skip is denied
+			traceevent.Log(ctx, traceevent.CategoryTool, "context_decision_skip_denied",
+				traceevent.Field{Key: "requested_skip_turns", Value: skipTurns},
+				traceevent.Field{Key: "ratio", Value: ratio},
+				traceevent.Field{Key: "was_reminded", Value: wasReminded},
+			)
+		} else if skipTurns > maxSkip {
+			// Case 2: Reduce skipTurns when over limit
+			skipTurns = maxSkip
+			agentCtx.ContextMgmtState.SetSkipUntil(turn, skipTurns, wasReminded)
+			result.WriteString(fmt.Sprintf("⚠️ skip_turns reduced from %d to %d\n\n", originalSkipTurns, skipTurns))
+			result.WriteString(fmt.Sprintf("Reason: Your proactive ratio is %d (max skip allowed: %d)\n", ratio, maxSkip))
+			result.WriteString("To skip more turns, make more proactive context management decisions.\n\n")
+			result.WriteString(fmt.Sprintf("Next reminder at: turn %d\n", turn+skipTurns))
+
+			// Record the skip decision so LastDecisionTurn is updated
+			agentCtx.ContextMgmtState.RecordDecision(turn, "skip", wasReminded)
+
+			traceevent.Log(ctx, traceevent.CategoryTool, "context_decision_skip_reduced",
+				traceevent.Field{Key: "requested_skip_turns", Value: originalSkipTurns},
+				traceevent.Field{Key: "actual_skip_turns", Value: skipTurns},
+				traceevent.Field{Key: "max_skip", Value: maxSkip},
+				traceevent.Field{Key: "ratio", Value: ratio},
+				traceevent.Field{Key: "skip_until_turn", Value: turn + skipTurns},
+				traceevent.Field{Key: "was_reminded", Value: wasReminded},
+			)
+		} else {
+			// Case 3: Allow skip within limit
+			agentCtx.ContextMgmtState.SetSkipUntil(turn, skipTurns, wasReminded)
+			result.WriteString(fmt.Sprintf("Skipping reminders for %d turns. Next reminder at turn %d.\n", skipTurns, turn+skipTurns))
+
+			// Record the skip decision so LastDecisionTurn is updated
+			agentCtx.ContextMgmtState.RecordDecision(turn, "skip", wasReminded)
+
+			traceevent.Log(ctx, traceevent.CategoryTool, "context_decision_skip",
+				traceevent.Field{Key: "skip_turns", Value: skipTurns},
+				traceevent.Field{Key: "skip_until_turn", Value: turn + skipTurns},
+				traceevent.Field{Key: "was_reminded", Value: wasReminded},
+			)
+		}
 
 	case "truncate":
 		truncatedCount := 0

--- a/pkg/tools/context_management_test.go
+++ b/pkg/tools/context_management_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
@@ -294,5 +295,381 @@ func TestContextManagementConcurrentTruncateCallsKeepBothCleanups(t *testing.T) 
 		if !agentctx.IsTruncatedAgentToolTag(msg.ExtractText()) {
 			t.Fatalf("expected tool result %s to be truncated", msg.ToolCallID)
 		}
+	}
+}
+
+// TestContextManagementSkipDenied tests that skip is denied when ratio <= 0
+func TestContextManagementSkipDenied(t *testing.T) {
+	assistant := agentctx.NewAssistantMessage()
+	assistant.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:   "call_cm_skip",
+			Type: "toolCall",
+			Name: "context_management",
+			Arguments: map[string]any{
+				"decision":     "skip",
+				"reasoning":    "Test skip denied",
+				"skip_turns":   30,
+			},
+		},
+	}
+
+	agentCtx := &agentctx.AgentContext{
+		Messages: []agentctx.AgentMessage{assistant},
+		ContextMgmtState: func() *agentctx.ContextMgmtState {
+			state := agentctx.DefaultContextMgmtState()
+			state.ProactiveDecisions = 0
+			state.ReminderNeeded = 5
+			state.ReminderFrequency = 10
+			state.CurrentTurn = 10
+			return state
+		}(),
+	}
+
+	tool := NewContextManagementTool(nil)
+
+	execCtx := agentctx.WithToolExecutionAgentContext(context.Background(), agentCtx)
+	execCtx = agentctx.WithToolExecutionCallID(execCtx, "call_cm_skip")
+
+	resultBlocks, err := tool.Execute(execCtx, map[string]any{
+		"decision":   "skip",
+		"reasoning":  "Test skip denied",
+		"skip_turns": 30.0,
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if len(resultBlocks) == 0 {
+		t.Fatal("Expected result blocks, got none")
+	}
+
+	resultText := ""
+	if tc, ok := resultBlocks[0].(agentctx.TextContent); ok {
+		resultText = tc.Text
+	}
+
+	// Check that skip was denied with proper message
+	// ratio = 0 - 5 = -5
+	if !strings.Contains(resultText, "⚠️ skip request denied") {
+		t.Errorf("Expected skip denied message, got: %s", resultText)
+	}
+	if !strings.Contains(resultText, "ratio=-5") {
+		t.Errorf("Expected ratio message, got: %s", resultText)
+	}
+	if !strings.Contains(resultText, "not allowed to skip 30 turns") {
+		t.Errorf("Expected turns message, got: %s", resultText)
+	}
+	if !strings.Contains(resultText, "within 10 turns (turn 20)") {
+		t.Errorf("Expected reminder timing message, got: %s", resultText)
+	}
+	if !strings.Contains(resultText, "You must be more proactive") {
+		t.Errorf("Expected proactive encouragement message, got: %s", resultText)
+	}
+
+	// Verify that skip was NOT actually applied
+	if agentCtx.ContextMgmtState.SkipUntilTurn != 0 {
+		t.Errorf("Expected SkipUntilTurn to remain 0, got: %d", agentCtx.ContextMgmtState.SkipUntilTurn)
+	}
+}
+
+// TestContextManagementSkipReduced tests that skip is reduced when skipTurns > maxSkip
+func TestContextManagementSkipReduced(t *testing.T) {
+	assistant := agentctx.NewAssistantMessage()
+	assistant.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:   "call_cm_skip",
+			Type: "toolCall",
+			Name: "context_management",
+			Arguments: map[string]any{
+				"decision":     "skip",
+				"reasoning":    "Test skip reduced",
+				"skip_turns":   20,
+			},
+		},
+	}
+
+	agentCtx := &agentctx.AgentContext{
+		Messages: []agentctx.AgentMessage{assistant},
+		ContextMgmtState: func() *agentctx.ContextMgmtState {
+			state := agentctx.DefaultContextMgmtState()
+			state.ProactiveDecisions = 5
+			state.ReminderNeeded = 3
+			state.ReminderFrequency = 10
+			state.CurrentTurn = 10
+			return state
+		}(),
+	}
+
+	tool := NewContextManagementTool(nil)
+
+	execCtx := agentctx.WithToolExecutionAgentContext(context.Background(), agentCtx)
+	execCtx = agentctx.WithToolExecutionCallID(execCtx, "call_cm_skip")
+
+	resultBlocks, err := tool.Execute(execCtx, map[string]any{
+		"decision":   "skip",
+		"reasoning":  "Test skip reduced",
+		"skip_turns": 20,
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if len(resultBlocks) == 0 {
+		t.Fatal("Expected result blocks, got none")
+	}
+
+	resultText := ""
+	if tc, ok := resultBlocks[0].(agentctx.TextContent); ok {
+		resultText = tc.Text
+	}
+
+	// Check that skip was reduced with proper message
+	if !strings.Contains(resultText, "⚠️ skip_turns reduced from 20 to 2") {
+		t.Errorf("Expected skip reduced message, got: %s", resultText)
+	}
+	if !strings.Contains(resultText, "ratio is 2") {
+		t.Errorf("Expected ratio message, got: %s", resultText)
+	}
+	if !strings.Contains(resultText, "max skip allowed: 2") {
+		t.Errorf("Expected max allowed message, got: %s", resultText)
+	}
+
+	// Verify that reduced skip was applied (maxSkip = 5 - 3 = 2)
+	if agentCtx.ContextMgmtState.SkipUntilTurn != 12 {
+		t.Errorf("Expected SkipUntilTurn to be 12, got: %d", agentCtx.ContextMgmtState.SkipUntilTurn)
+	}
+}
+
+// TestContextManagementSkipSuccess tests that skip succeeds when within limits
+func TestContextManagementSkipSuccess(t *testing.T) {
+	assistant := agentctx.NewAssistantMessage()
+	assistant.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:   "call_cm_skip",
+			Type: "toolCall",
+			Name: "context_management",
+			Arguments: map[string]any{
+				"decision":     "skip",
+				"reasoning":    "Test skip success",
+				"skip_turns":   5,
+			},
+		},
+	}
+
+	agentCtx := &agentctx.AgentContext{
+		Messages: []agentctx.AgentMessage{assistant},
+		ContextMgmtState: func() *agentctx.ContextMgmtState {
+			state := agentctx.DefaultContextMgmtState()
+			state.ProactiveDecisions = 10
+			state.ReminderNeeded = 2
+			state.ReminderFrequency = 10
+			state.CurrentTurn = 10
+			return state
+		}(),
+	}
+
+	tool := NewContextManagementTool(nil)
+
+	execCtx := agentctx.WithToolExecutionAgentContext(context.Background(), agentCtx)
+	execCtx = agentctx.WithToolExecutionCallID(execCtx, "call_cm_skip")
+
+	resultBlocks, err := tool.Execute(execCtx, map[string]any{
+		"decision":   "skip",
+		"reasoning":  "Test skip success",
+		"skip_turns": 5,
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if len(resultBlocks) == 0 {
+		t.Fatal("Expected result blocks, got none")
+	}
+
+	resultText := ""
+	if tc, ok := resultBlocks[0].(agentctx.TextContent); ok {
+		resultText = tc.Text
+	}
+
+	// Check that skip succeeded normally (no reduction since 5 <= 8)
+	if !strings.Contains(resultText, "Skipping reminders for 5 turns") {
+		t.Errorf("Expected success message, got: %s", resultText)
+	}
+	if !strings.Contains(resultText, "Next reminder at turn 15") {
+		t.Errorf("Expected next reminder message, got: %s", resultText)
+	}
+
+	// Verify that skip was applied
+	if agentCtx.ContextMgmtState.SkipUntilTurn != 15 {
+		t.Errorf("Expected SkipUntilTurn to be 15, got: %d", agentCtx.ContextMgmtState.SkipUntilTurn)
+	}
+}
+
+// TestContextManagementSkipExactMaxSkip tests that skip succeeds when skipTurns == maxSkip
+func TestContextManagementSkipExactMaxSkip(t *testing.T) {
+	assistant := agentctx.NewAssistantMessage()
+	assistant.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:   "call_cm_skip",
+			Type: "toolCall",
+			Name: "context_management",
+			Arguments: map[string]any{
+				"decision":     "skip",
+				"reasoning":    "Test skip exact max",
+				"skip_turns":   3,
+			},
+		},
+	}
+
+	agentCtx := &agentctx.AgentContext{
+		Messages: []agentctx.AgentMessage{assistant},
+		ContextMgmtState: func() *agentctx.ContextMgmtState {
+			state := agentctx.DefaultContextMgmtState()
+			state.ProactiveDecisions = 5
+			state.ReminderNeeded = 2
+			state.ReminderFrequency = 10
+			state.CurrentTurn = 10
+			return state
+		}(),
+	}
+
+	tool := NewContextManagementTool(nil)
+
+	execCtx := agentctx.WithToolExecutionAgentContext(context.Background(), agentCtx)
+	execCtx = agentctx.WithToolExecutionCallID(execCtx, "call_cm_skip")
+
+	resultBlocks, err := tool.Execute(execCtx, map[string]any{
+		"decision":   "skip",
+		"reasoning":  "Test skip exact max",
+		"skip_turns": 3,
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if len(resultBlocks) == 0 {
+		t.Fatal("Expected result blocks, got none")
+	}
+
+	resultText := ""
+	if tc, ok := resultBlocks[0].(agentctx.TextContent); ok {
+		resultText = tc.Text
+	}
+
+	// Check that skip succeeded normally (no reduction since 3 == 3)
+	if !strings.Contains(resultText, "Skipping reminders for 3 turns") {
+		t.Errorf("Expected success message, got: %s", resultText)
+	}
+
+	// Verify that skip was applied
+	if agentCtx.ContextMgmtState.SkipUntilTurn != 13 {
+		t.Errorf("Expected SkipUntilTurn to be 13, got: %d", agentCtx.ContextMgmtState.SkipUntilTurn)
+	}
+}
+
+// TestContextManagementSkipEdgeCases tests edge cases (zero proactive, max limits, etc.)
+func TestContextManagementSkipEdgeCases(t *testing.T) {
+	tests := []struct {
+		name               string
+		proactiveDecisions int
+		reminderNeeded     int
+		requestedSkip      int
+		expectedResult     string
+		expectedSkipUntil  int
+	}{
+		{
+			name:               "zero proactive, many reminders needed",
+			proactiveDecisions: 0,
+			reminderNeeded:     10,
+			requestedSkip:      15,
+			expectedResult:     "skip request denied",
+			expectedSkipUntil:  0,
+		},
+		{
+			name:               "equal proactive and reminders",
+			proactiveDecisions: 5,
+			reminderNeeded:     5,
+			requestedSkip:      10,
+			expectedResult:     "skip request denied",
+			expectedSkipUntil:  0,
+		},
+		{
+			name:               "max skip capped at 30",
+			proactiveDecisions: 50,
+			reminderNeeded:     0,
+			requestedSkip:      50,
+			expectedResult:     "Skipping reminders for 30 turns",
+			expectedSkipUntil:  40,
+		},
+		{
+			name:               "min skip capped at 1",
+			proactiveDecisions: 1,
+			reminderNeeded:     0,
+			requestedSkip:      0,
+			expectedResult:     "Skipping reminders for 1 turns",
+			expectedSkipUntil:  11,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assistant := agentctx.NewAssistantMessage()
+			assistant.Content = []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call_cm_skip",
+					Type: "toolCall",
+					Name: "context_management",
+					Arguments: map[string]any{
+						"decision":     "skip",
+						"reasoning":    tt.name,
+						"skip_turns":   tt.requestedSkip,
+					},
+				},
+			}
+
+			agentCtx := &agentctx.AgentContext{
+				Messages: []agentctx.AgentMessage{assistant},
+				ContextMgmtState: func() *agentctx.ContextMgmtState {
+					state := agentctx.DefaultContextMgmtState()
+					state.ProactiveDecisions = tt.proactiveDecisions
+					state.ReminderNeeded = tt.reminderNeeded
+					state.ReminderFrequency = 10
+					state.CurrentTurn = 10
+					return state
+				}(),
+			}
+
+			tool := NewContextManagementTool(nil)
+
+			execCtx := agentctx.WithToolExecutionAgentContext(context.Background(), agentCtx)
+			execCtx = agentctx.WithToolExecutionCallID(execCtx, "call_cm_skip")
+
+			resultBlocks, err := tool.Execute(execCtx, map[string]any{
+				"decision":   "skip",
+				"reasoning":  tt.name,
+				"skip_turns": tt.requestedSkip,
+			})
+			if err != nil {
+				t.Fatalf("Execute failed: %v", err)
+			}
+
+			if len(resultBlocks) == 0 {
+				t.Fatal("Expected result blocks, got none")
+			}
+
+			resultText := ""
+			if tc, ok := resultBlocks[0].(agentctx.TextContent); ok {
+				resultText = tc.Text
+			}
+
+			if !strings.Contains(resultText, tt.expectedResult) {
+				t.Errorf("Expected result to contain '%s', got: %s", tt.expectedResult, resultText)
+			}
+
+			if agentCtx.ContextMgmtState.SkipUntilTurn != tt.expectedSkipUntil {
+				t.Errorf("Expected SkipUntilTurn to be %d, got: %d", tt.expectedSkipUntil, agentCtx.ContextMgmtState.SkipUntilTurn)
+			}
+		})
 	}
 }


### PR DESCRIPTION
# Fix: [FEATURE] Improve context_management skip mechanism

## Summary
Implements issue #102: Limit skip_turns based on proactive ratio to prevent LLM from using skip to escape reminders.

## Problem
LLM tends to overuse the `skip` parameter in `context_management`, leading to tool output accumulation. When reminded, LLM responds with `skip` to avoid responsibility, creating an infinite loop.

## Solution
Implemented dynamic skip limit based on proactive ratio:
```
max_skip = proactiveDecisions - reminderNeeded
// Hard cap to prevent excessive accumulation
if max_skip > 30: max_skip = 30
if max_skip < 0: max_skip = 0
```

### Three Cases Handled

1. **ratio <= 0 (DENY)**: Skip request denied with clear error message explaining why and when the next reminder will trigger
2. **skipTurns > maxSkip (REDUCE)**: Skip reduced to maxSkip with warning message explaining the ratio and how to improve
3. **skipTurns <= maxSkip (SUCCESS)**: Skip allowed normally

## Implementation Changes

### pkg/tools/context_management.go
- Capture snapshot before `MarkDecisionMade()` for accurate ratio calculation
- Calculate `maxSkip` based on proactive ratio
- Handle three cases (deny, reduce, success) with appropriate messages
- Update trace event logging for new cases

### pkg/tools/context_management_test.go
- Added `TestContextManagementSkipDenied`: Test skip denial when ratio <= 0
- Added `TestContextManagementSkipReduced`: Test skip reduction when over limit
- Added `TestContextManagementSkipSuccess`: Test skip success when within limit
- Added `TestContextManagementSkipExactMaxSkip`: Test exact max skip scenario
- Added `TestContextManagementSkipEdgeCases`: Test edge cases (cap at 30, cap at 1, etc.)

## Acceptance Criteria
- ✅ LLM cannot skip when proactive ratio <= 0
- ✅ Skip is reduced to max_skip when over limit
- ✅ Max skip is capped at 30 even with high ratio
- ✅ Clear error messages explain denial/reduction
- ✅ All 5 unit tests pass

## Testing
```bash
go test ./pkg/tools -v -run TestContextManagementSkip
# All tests PASS
```

## Expected Outcome
- LLM cannot use skip to escape reminders when proactive score is poor
- Clear error messages explain why and how to improve
- Prevents infinite skip loops
- Context accumulation is controlled even with non-cooperative LLM
