### PR TITLE
fix: prevent infinite context management loop

### DIFF
--- a/pkg/agent/agent_new.go
+++ b/pkg/agent/agent_new.go
@@ -57,6 +57,9 @@ type AgentNew struct {
 	skillsExtra         string
 	projectContextExtra string
 	customSystemPrompt  string // Custom system prompt from --system-prompt flag (headless mode)
+
+	// Loop detection (persistent across executeConversationLoop calls)
+	loopDetector *loopDetector
 }
 
 // ModelSpec wraps the model specification from config.
@@ -101,6 +104,7 @@ func NewAgentNew(sessionDir, sessionID string, model *ModelSpec, apiKey string, 
 		thinkingLevel:  "high", // Default thinking level
 		eventEmitter:   eventEmitter,
 		allTools:       allTools,
+		loopDetector:   newLoopDetector(defaultMaxDuplicateCalls),
 	}
 
 	// Update context window in snapshot

--- a/pkg/agent/e2e_helpers.go
+++ b/pkg/agent/e2e_helpers.go
@@ -107,6 +107,7 @@ func ResumeAgentForE2E(
 		apiKey:         apiKey,
 		allTools:       loadAllTools(),
 		triggerChecker: agentctx.NewTriggerChecker(),
+		loopDetector:   newLoopDetector(defaultMaxDuplicateCalls),
 	}
 
 	return ag, nil

--- a/pkg/agent/loop_detector.go
+++ b/pkg/agent/loop_detector.go
@@ -1,0 +1,190 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+const defaultMaxDuplicateCalls = 7
+
+// loopDetector tracks tool call patterns to detect infinite loops.
+// Unlike a local-map approach, this is persistent on the AgentNew struct,
+// so it survives context management interruptions and trampoline re-entries.
+//
+// Detection strategy:
+//   - Track tool calls by NAME (not exact arguments), because LLMs often retry
+//     with slight parameter variations (different paths, slight rephrasings).
+//   - Count consecutive occurrences of the same tool name.
+//   - Reset the counter when a different tool is called.
+//   - Also detect oscillation between a small set of tools (A→B→A→B→...).
+type loopDetector struct {
+	// maxDuplicates is the threshold for consecutive same-name tool calls.
+	maxDuplicates int
+
+	// toolNameCount tracks consecutive occurrences of each tool name.
+	// Reset when a different tool name appears.
+	toolNameCount map[string]int
+
+	// lastToolNames is the ordered list of tool names from the last LLM response.
+	// Used to detect oscillation patterns.
+	lastToolNames []string
+
+	// oscillationCount tracks how many consecutive rounds have the same
+	// set of tool names (in any order). This catches A→B→A→B patterns.
+	oscillationCount int
+}
+
+// newLoopDetector creates a new loopDetector.
+func newLoopDetector(maxDuplicates int) *loopDetector {
+	if maxDuplicates <= 0 {
+		maxDuplicates = defaultMaxDuplicateCalls
+	}
+	return &loopDetector{
+		maxDuplicates:    maxDuplicates,
+		toolNameCount:    make(map[string]int),
+		lastToolNames:    nil,
+		oscillationCount: 0,
+	}
+}
+
+// check analyzes tool calls from an assistant message and returns an error
+// if an infinite loop is detected.
+//
+// It returns the list of tool names found (for logging) and an error if stuck.
+func (ld *loopDetector) check(assistantMsg *agentctx.AgentMessage) ([]string, error) {
+	toolCalls := assistantMsg.ExtractToolCalls()
+	if len(toolCalls) == 0 {
+		// No tool calls: reset tracking (pure text response = progress)
+		for k := range ld.toolNameCount {
+			delete(ld.toolNameCount, k)
+		}
+		ld.lastToolNames = nil
+		ld.oscillationCount = 0
+		return nil, nil
+	}
+
+	// Extract current tool names
+	currentNames := make([]string, 0, len(toolCalls))
+	for _, tc := range toolCalls {
+		currentNames = append(currentNames, tc.Name)
+	}
+
+	// --- Check 1: Consecutive same-name tool calls ---
+	ld.updateToolNameCounters(currentNames)
+
+	for name, count := range ld.toolNameCount {
+		if count >= ld.maxDuplicates {
+			return currentNames, fmt.Errorf(
+				"agent appears to be stuck in a loop: tool '%s' called %d times consecutively (limit: %d). "+
+					"Consider using a different approach or providing a final text response",
+				name, count, ld.maxDuplicates,
+			)
+		}
+	}
+
+	// --- Check 2: Oscillation detection (A→B→A→B pattern) ---
+	// Only check for oscillation when there are 2+ distinct tools.
+	// Single-tool oscillation is already caught by the name counter above.
+	if len(currentNames) >= 2 && ld.sameToolSet(ld.lastToolNames, currentNames) {
+		ld.oscillationCount++
+		halfMax := ld.maxDuplicates / 2
+		if halfMax < 3 {
+			halfMax = 3
+		}
+		if ld.oscillationCount >= halfMax {
+			return currentNames, fmt.Errorf(
+				"agent appears to be oscillating between tools: same tool set {%s} repeated %d times. "+
+					"Consider using a different approach or providing a final text response",
+				strings.Join(uniqueSorted(currentNames), ", "),
+				ld.oscillationCount,
+			)
+		}
+	} else {
+		ld.oscillationCount = 0
+	}
+
+	ld.lastToolNames = currentNames
+
+	slog.Info("[AgentNew] Loop detector check passed",
+		"tool_names", currentNames,
+		"name_counts", ld.toolNameCount,
+		"oscillation", ld.oscillationCount,
+	)
+
+	return currentNames, nil
+}
+
+// reset clears all loop detector state.
+// Called when the agent makes meaningful progress (e.g., produces a text response).
+// Nil-safe: no-op if the receiver is nil.
+func (ld *loopDetector) reset() {
+	if ld == nil {
+		return
+	}
+	for k := range ld.toolNameCount {
+		delete(ld.toolNameCount, k)
+	}
+	ld.lastToolNames = nil
+	ld.oscillationCount = 0
+}
+
+// updateToolNameCounters increments counters for present names and resets absent ones.
+func (ld *loopDetector) updateToolNameCounters(currentNames []string) {
+	present := make(map[string]bool, len(currentNames))
+	for _, name := range currentNames {
+		present[name] = true
+		ld.toolNameCount[name]++
+	}
+
+	for name := range ld.toolNameCount {
+		if !present[name] {
+			delete(ld.toolNameCount, name)
+		}
+	}
+}
+
+// sameToolSet checks if two slices contain the same set of tool names.
+func (ld *loopDetector) sameToolSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	setA := make(map[string]bool, len(a))
+	for _, s := range a {
+		setA[s] = true
+	}
+	for _, s := range b {
+		if !setA[s] {
+			return false
+		}
+	}
+	return true
+}
+
+// uniqueSorted returns unique sorted strings from a slice.
+func uniqueSorted(s []string) []string {
+	seen := make(map[string]bool, len(s))
+	for _, v := range s {
+		seen[v] = true
+	}
+	result := make([]string, 0, len(seen))
+	for v := range seen {
+		result = append(result, v)
+	}
+	return result
+}
+
+// buildToolCallSignature creates a unique signature for a tool call.
+// The signature is based on tool name and normalized parameters.
+func buildToolCallSignature(tc agentctx.ToolCallContent) string {
+	argsJSON := "{}"
+	if tc.Arguments != nil {
+		if bytes, err := json.Marshal(tc.Arguments); err == nil {
+			argsJSON = string(bytes)
+		}
+	}
+	return tc.Name + ":" + argsJSON
+}

--- a/pkg/agent/loop_detector_test.go
+++ b/pkg/agent/loop_detector_test.go
@@ -1,0 +1,191 @@
+package agent
+
+import (
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+// helper: create an assistant message with tool calls
+func makeAssistantWithToolCalls(toolNames ...string) *agentctx.AgentMessage {
+	calls := make([]agentctx.ContentBlock, len(toolNames))
+	for i, name := range toolNames {
+		calls[i] = agentctx.ToolCallContent{
+			ID:   "call_" + name,
+			Name: name,
+		}
+	}
+	return &agentctx.AgentMessage{
+		Role:    "assistant",
+		Content: calls,
+	}
+}
+
+// helper: create a text-only assistant message (no tool calls)
+func makeTextAssistant() *agentctx.AgentMessage {
+	return &agentctx.AgentMessage{
+		Role: "assistant",
+		Content: []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "Hello!"},
+		},
+	}
+}
+
+func TestLoopDetector_SameToolRepeated(t *testing.T) {
+	ld := newLoopDetector(3) // low threshold for testing
+
+	// Call "bash" 3 times → should trigger
+	for i := 0; i < 3; i++ {
+		_, err := ld.check(makeAssistantWithToolCalls("bash"))
+		if i < 2 && err != nil {
+			t.Fatalf("unexpected error on call %d: %v", i+1, err)
+		}
+	}
+	_, err := ld.check(makeAssistantWithToolCalls("bash"))
+	if err == nil {
+		t.Fatal("expected loop detection error after 3 consecutive calls")
+	}
+}
+
+func TestLoopDetector_DifferentToolsResets(t *testing.T) {
+	ld := newLoopDetector(3)
+
+	// Call "bash" twice
+	ld.check(makeAssistantWithToolCalls("bash"))
+	ld.check(makeAssistantWithToolCalls("bash"))
+
+	// Call "read" once — should reset bash counter
+	_, err := ld.check(makeAssistantWithToolCalls("read"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// bash counter should be gone now; calling bash 2 more times should be fine
+	ld.check(makeAssistantWithToolCalls("bash"))
+	_, err = ld.check(makeAssistantWithToolCalls("bash"))
+	if err != nil {
+		t.Fatalf("bash counter was not reset: %v", err)
+	}
+}
+
+func TestLoopDetector_TextResponseResets(t *testing.T) {
+	ld := newLoopDetector(3)
+
+	// Call "bash" twice
+	ld.check(makeAssistantWithToolCalls("bash"))
+	ld.check(makeAssistantWithToolCalls("bash"))
+
+	// Text response resets
+	_, err := ld.check(makeTextAssistant())
+	if err != nil {
+		t.Fatalf("unexpected error on text response: %v", err)
+	}
+
+	// bash counter should be gone now
+	ld.check(makeAssistantWithToolCalls("bash"))
+	_, err = ld.check(makeAssistantWithToolCalls("bash"))
+	if err != nil {
+		t.Fatalf("bash counter was not reset after text response: %v", err)
+	}
+}
+
+func TestLoopDetector_OscillationDetection(t *testing.T) {
+	ld := newLoopDetector(7) // default threshold
+
+	// Oscillate between bash and git for 4 rounds
+	// oscillationCount threshold = 7/2 = 3
+	for i := 0; i < 3; i++ {
+		_, err := ld.check(makeAssistantWithToolCalls("bash", "git"))
+		if err != nil {
+			t.Fatalf("unexpected error on oscillation round %d: %v", i+1, err)
+		}
+	}
+
+	// 4th oscillation should trigger
+	_, err := ld.check(makeAssistantWithToolCalls("bash", "git"))
+	if err == nil {
+		t.Fatal("expected oscillation detection error")
+	}
+}
+
+func TestLoopDetector_OscillationBreaksOnDifferentSet(t *testing.T) {
+	ld := newLoopDetector(7)
+
+	// Oscillate between bash and git for 2 rounds
+	ld.check(makeAssistantWithToolCalls("bash", "git"))
+	ld.check(makeAssistantWithToolCalls("bash", "git"))
+
+	// Different set → resets oscillation
+	_, err := ld.check(makeAssistantWithToolCalls("bash", "read"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be able to oscillate bash+git for 2 more rounds
+	ld.check(makeAssistantWithToolCalls("bash", "git"))
+	_, err = ld.check(makeAssistantWithToolCalls("bash", "git"))
+	if err != nil {
+		t.Fatalf("oscillation was not reset: %v", err)
+	}
+}
+
+func TestLoopDetector_Reset(t *testing.T) {
+	ld := newLoopDetector(3)
+
+	// Call "bash" twice
+	ld.check(makeAssistantWithToolCalls("bash"))
+	ld.check(makeAssistantWithToolCalls("bash"))
+
+	// Reset
+	ld.reset()
+
+	// bash counter should be gone; calling 2 more times should be fine
+	ld.check(makeAssistantWithToolCalls("bash"))
+	_, err := ld.check(makeAssistantWithToolCalls("bash"))
+	if err != nil {
+		t.Fatalf("reset did not clear counters: %v", err)
+	}
+}
+
+func TestLoopDetector_PersistsAcrossCheckCalls(t *testing.T) {
+	ld := newLoopDetector(5)
+
+	// Simulate the bug scenario: context management interrupts,
+	// but the detector persists because it's on AgentNew, not local.
+	for i := 0; i < 4; i++ {
+		_, err := ld.check(makeAssistantWithToolCalls("git_worktree_list"))
+		if err != nil {
+			t.Fatalf("unexpected error on call %d: %v", i+1, err)
+		}
+	}
+
+	// 5th call should trigger
+	_, err := ld.check(makeAssistantWithToolCalls("git_worktree_list"))
+	if err == nil {
+		t.Fatal("expected loop detection on 5th consecutive call")
+	}
+}
+
+func TestBuildToolCallSignature(t *testing.T) {
+	tc := agentctx.ToolCallContent{
+		ID:   "call_123",
+		Name: "bash",
+		Arguments: map[string]any{
+			"command": "ls",
+		},
+	}
+	sig := buildToolCallSignature(tc)
+	if sig != `bash:{"command":"ls"}` {
+		t.Fatalf("unexpected signature: %s", sig)
+	}
+
+	// Nil arguments
+	tc2 := agentctx.ToolCallContent{
+		ID:   "call_456",
+		Name: "read",
+	}
+	sig2 := buildToolCallSignature(tc2)
+	if sig2 != "read:{}" {
+		t.Fatalf("unexpected signature for nil args: %s", sig2)
+	}
+}

--- a/pkg/agent/loop_normal.go
+++ b/pkg/agent/loop_normal.go
@@ -24,10 +24,6 @@ import (
 // - ExecutionMode: ModeDone (complete), ModeContextMgmt (need context management), ModeError
 // - error: any error that occurred
 func (a *AgentNew) executeConversationLoop(ctx context.Context) (ExecutionMode, error) {
-	// Track duplicate tool call signatures to detect infinite loops
-	const maxDuplicateCalls = 7
-	duplicateSignatureCount := make(map[string]int) // signature -> consecutive count
-
 	for cycle := 0; ; cycle++ {
 		// Check for context cancellation at the start of each cycle
 		// This allows steer/follow-up to interrupt before LLM call
@@ -129,10 +125,11 @@ func (a *AgentNew) executeConversationLoop(ctx context.Context) (ExecutionMode, 
 			"cycle", cycle+1,
 		)
 
-		// Check for duplicate tool call signatures (same tool + parameters repeated)
-		// This detects infinite loops where the agent keeps calling the same tool with same args
-		if err := a.checkDuplicateToolSignatures(assistantMsg, duplicateSignatureCount, maxDuplicateCalls); err != nil {
-			return ModeError, err
+		// Check for duplicate tool call patterns (same tool repeated or oscillation).
+		// Uses persistent loopDetector on AgentNew, so detection survives
+		// context management interruptions and trampoline re-entries.
+		if _, loopErr := a.loopDetector.check(assistantMsg); loopErr != nil {
+			return ModeError, loopErr
 		}
 	}
 }
@@ -1536,69 +1533,4 @@ func appendToLastUserMessage(messages []llm.LLMMessage, runtimeState, llmContext
 	}
 
 	return messages
-}
-
-// checkDuplicateToolSignatures checks if the same tool call signature (name + parameters)
-// is repeated too many times consecutively, which indicates an infinite loop.
-func (a *AgentNew) checkDuplicateToolSignatures(
-	assistantMsg *agentctx.AgentMessage,
-	signatureCount map[string]int,
-	maxDuplicates int,
-) error {
-	toolCalls := assistantMsg.ExtractToolCalls()
-	if len(toolCalls) == 0 {
-		return nil
-	}
-
-	// Build signature for each tool call
-	// Signature is: toolName + sorted args hash
-	for _, tc := range toolCalls {
-		// Create signature from tool name and parameters
-		signature := buildToolCallSignature(tc)
-
-		// Increment consecutive count for this signature
-		signatureCount[signature]++
-
-		slog.Info("[AgentNew] Tool call signature tracked",
-			"signature", signature,
-			"tool", tc.Name,
-			"count", signatureCount[signature],
-			"max", maxDuplicates,
-		)
-
-		// Check if we've exceeded the max duplicates
-		if signatureCount[signature] >= maxDuplicates {
-			return fmt.Errorf("agent appears to be stuck in a loop: tool call '%s' repeated %d times consecutively",
-				tc.Name, maxDuplicates)
-		}
-	}
-
-	// Reset counts for signatures that weren't in this batch
-	// This ensures we only count CONSECUTIVE duplicates
-	currentSignatures := make(map[string]bool)
-	for _, tc := range toolCalls {
-		signature := buildToolCallSignature(tc)
-		currentSignatures[signature] = true
-	}
-
-	for sig := range signatureCount {
-		if !currentSignatures[sig] {
-			delete(signatureCount, sig)
-		}
-	}
-
-	return nil
-}
-
-// buildToolCallSignature creates a unique signature for a tool call.
-// The signature is based on tool name and normalized parameters.
-func buildToolCallSignature(tc agentctx.ToolCallContent) string {
-	// Convert arguments to a stable string representation
-	argsJSON := "{}"
-	if tc.Arguments != nil {
-		if bytes, err := json.Marshal(tc.Arguments); err == nil {
-			argsJSON = string(bytes)
-		}
-	}
-	return tc.Name + ":" + argsJSON
 }

--- a/pkg/agent/resume.go
+++ b/pkg/agent/resume.go
@@ -79,7 +79,7 @@ func LoadSession(ctx context.Context, sessionDir string, model *ModelSpec, apiKe
 		agentctx.LogSnapshotReconstructed(ctx, latestCheckpoint.Path, len(entries), len(snapshot.RecentMessages))
 	}
 
-	// 7. Create agent
+	// Create agent
 	agent := &AgentNew{
 		snapshot:       snapshot,
 		sessionDir:     sessionDir,
@@ -91,6 +91,7 @@ func LoadSession(ctx context.Context, sessionDir string, model *ModelSpec, apiKe
 		eventEmitter:   eventEmitter,
 		allTools:       tools.GetAllTools(),
 		thinkingLevel:  "high", // Default; caller should override via SetThinkingLevel
+		loopDetector:   newLoopDetector(defaultMaxDuplicateCalls),
 	}
 
 	// Update context window if model provides it

--- a/pkg/agent/turn.go
+++ b/pkg/agent/turn.go
@@ -187,6 +187,14 @@ func (a *AgentNew) executeNormalStep(
 	a.snapshot.AgentState.TurnsSinceLastTrigger++
 	a.snapshot.AgentState.UpdatedAt = time.Now()
 
+	// If the agent produced a text response (ModeDone), it made progress.
+	// Reset the runaway counter so context management can work normally next time.
+	if nextMode == ModeDone {
+		a.snapshot.AgentState.ConsecutiveContextMgmtTriggers = 0
+		// Also reset loop detector since the agent made meaningful progress
+		a.loopDetector.reset()
+	}
+
 	return nextMode, msgAppended, err
 }
 
@@ -210,29 +218,57 @@ func (a *AgentNew) executeContextMgmtStep(ctx context.Context) (nextMode Executi
 		return ModeNormal, nil
 	}
 
+	// Runaway detection: if context management has been triggered too many times
+	// consecutively without progress, force compact instead of letting the LLM choose.
+	const maxConsecutiveTriggers = 3
+	a.snapshot.AgentState.ConsecutiveContextMgmtTriggers++
+
 	slog.Info("[AgentNew] Executing context management",
 		"urgency", urgency,
 		"reason", reason,
+		"consecutive_triggers", a.snapshot.AgentState.ConsecutiveContextMgmtTriggers,
 	)
 
 	traceevent.Log(ctx, traceevent.CategoryEvent, "context_management_decision",
 		traceevent.Field{Key: "action", Value: "execute"},
 		traceevent.Field{Key: "urgency", Value: urgency},
 		traceevent.Field{Key: "reason", Value: reason},
+		traceevent.Field{Key: "consecutive_triggers", Value: a.snapshot.AgentState.ConsecutiveContextMgmtTriggers},
 	)
 
 	// Execute context management
 	mgmtSpan := traceevent.StartSpan(ctx, "context_management", traceevent.CategoryEvent,
 		traceevent.Field{Key: "urgency", Value: urgency},
 		traceevent.Field{Key: "turn", Value: a.snapshot.AgentState.TotalTurns},
+		traceevent.Field{Key: "consecutive_triggers", Value: a.snapshot.AgentState.ConsecutiveContextMgmtTriggers},
 	)
 	ctx = mgmtSpan.Context()
 
-	if err := a.executeContextMgmtTools(ctx, urgency); err != nil {
-		mgmtSpan.AddField("error", true)
-		mgmtSpan.AddField("error_message", err.Error())
-		mgmtSpan.End()
-		return ModeError, fmt.Errorf("context management failed: %w", err)
+	if a.snapshot.AgentState.ConsecutiveContextMgmtTriggers >= maxConsecutiveTriggers {
+		// Force compact: the LLM's truncate choices are not making progress
+		slog.Warn("[AgentNew] Runaway context management detected, forcing compact",
+			"consecutive_triggers", a.snapshot.AgentState.ConsecutiveContextMgmtTriggers,
+			"max", maxConsecutiveTriggers,
+		)
+		traceevent.Log(ctx, traceevent.CategoryEvent, "context_management_decision",
+			traceevent.Field{Key: "action", Value: "force_compact"},
+			traceevent.Field{Key: "reason", Value: "runaway_detection"},
+			traceevent.Field{Key: "consecutive_triggers", Value: a.snapshot.AgentState.ConsecutiveContextMgmtTriggers},
+		)
+
+		if err := a.performCompaction(ctx); err != nil {
+			mgmtSpan.AddField("error", true)
+			mgmtSpan.AddField("error_message", err.Error())
+			mgmtSpan.End()
+			return ModeError, fmt.Errorf("forced compaction failed: %w", err)
+		}
+	} else {
+		if err := a.executeContextMgmtTools(ctx, urgency); err != nil {
+			mgmtSpan.AddField("error", true)
+			mgmtSpan.AddField("error_message", err.Error())
+			mgmtSpan.End()
+			return ModeError, fmt.Errorf("context management failed: %w", err)
+		}
 	}
 
 	mgmtSpan.AddField("action_taken", true)
@@ -246,10 +282,10 @@ func (a *AgentNew) executeContextMgmtStep(ctx context.Context) (nextMode Executi
 
 	slog.Info("[AgentNew] Context management completed",
 		"urgency", urgency,
+		"consecutive_triggers", a.snapshot.AgentState.ConsecutiveContextMgmtTriggers,
 	)
 
 	// Return to Normal mode to continue processing
-	// (or if user message was already processed, this might be the final step)
 	return ModeNormal, nil
 }
 

--- a/pkg/context/agent_state.go
+++ b/pkg/context/agent_state.go
@@ -20,6 +20,11 @@ type AgentState struct {
 	TurnsSinceLastTrigger      int // Turns elapsed since last trigger (legacy)
 	ToolCallsSinceLastTrigger  int // Tool calls elapsed since last trigger
 
+	// Runaway detection: counts consecutive context management triggers without progress.
+	// Reset when the agent produces a text response (no tool calls).
+	// If this exceeds a threshold, force compact instead of truncate.
+	ConsecutiveContextMgmtTriggers int
+
 	// Active tool calls (for pairing protection)
 	ActiveToolCalls []string
 
@@ -59,19 +64,20 @@ func (a *AgentState) Clone() *AgentState {
 	copy(activeToolCalls, a.ActiveToolCalls)
 
 	return &AgentState{
-		WorkspaceRoot:            a.WorkspaceRoot,
-		CurrentWorkingDir:        a.CurrentWorkingDir,
-		TotalTurns:               a.TotalTurns,
-		TokensUsed:               a.TokensUsed,
-		TokensLimit:              a.TokensLimit,
-		LastLLMContextUpdate:     a.LastLLMContextUpdate,
-		LastCheckpoint:           a.LastCheckpoint,
-		LastTriggerTurn:          a.LastTriggerTurn,
-		TurnsSinceLastTrigger:    a.TurnsSinceLastTrigger,
-		ToolCallsSinceLastTrigger: a.ToolCallsSinceLastTrigger,
-		ActiveToolCalls:          activeToolCalls,
-		SessionID:                a.SessionID,
-		CreatedAt:                a.CreatedAt,
-		UpdatedAt:                a.UpdatedAt,
+		WorkspaceRoot:                 a.WorkspaceRoot,
+		CurrentWorkingDir:             a.CurrentWorkingDir,
+		TotalTurns:                    a.TotalTurns,
+		TokensUsed:                    a.TokensUsed,
+		TokensLimit:                   a.TokensLimit,
+		LastLLMContextUpdate:          a.LastLLMContextUpdate,
+		LastCheckpoint:                a.LastCheckpoint,
+		LastTriggerTurn:               a.LastTriggerTurn,
+		TurnsSinceLastTrigger:         a.TurnsSinceLastTrigger,
+		ToolCallsSinceLastTrigger:     a.ToolCallsSinceLastTrigger,
+		ConsecutiveContextMgmtTriggers: a.ConsecutiveContextMgmtTriggers,
+		ActiveToolCalls:               activeToolCalls,
+		SessionID:                     a.SessionID,
+		CreatedAt:                     a.CreatedAt,
+		UpdatedAt:                     a.UpdatedAt,
 	}
 }

--- a/pkg/tools/context_mgmt/truncate_messages.go
+++ b/pkg/tools/context_mgmt/truncate_messages.go
@@ -76,7 +76,26 @@ func (t *TruncateMessagesTool) Execute(ctx context.Context, params map[string]an
 	}
 
 	if len(validIDs) == 0 {
-		return nil, fmt.Errorf("no valid tool call IDs provided")
+		// Provide helpful error message with available IDs so the LLM can retry correctly.
+		// This typically happens after compaction removes old messages whose IDs are stale.
+		availableIDs := t.getAvailableToolCallIDs()
+		if len(availableIDs) == 0 {
+			return nil, fmt.Errorf("no valid tool call IDs provided, and no truncatable messages exist. Consider using compact_messages instead")
+		}
+		// Show up to 10 available IDs to avoid overwhelming the context
+		showIDs := availableIDs
+		if len(showIDs) > 10 {
+			showIDs = showIDs[:10]
+		}
+		return nil, fmt.Errorf("no valid tool call IDs provided. The provided IDs may have been removed by a previous compaction. Available truncatable tool call IDs: %s%s. Consider using compact_messages if these IDs are not suitable",
+			strings.Join(showIDs, ", "),
+			func() string {
+				if len(availableIDs) > 10 {
+					return fmt.Sprintf(" (and %d more)", len(availableIDs)-10)
+				}
+				return ""
+			}(),
+		)
 	}
 
 	// Apply truncate
@@ -109,6 +128,23 @@ func (t *TruncateMessagesTool) isValidToolCallID(id string) bool {
 		}
 	}
 	return false
+}
+
+// getAvailableToolCallIDs returns IDs of tool results that can be truncated.
+// These are non-truncated, non-protected tool result messages.
+func (t *TruncateMessagesTool) getAvailableToolCallIDs() []string {
+	protectedStart := len(t.snapshot.RecentMessages) - agentctx.RecentMessagesKeep
+	if protectedStart < 0 {
+		protectedStart = 0
+	}
+
+	var ids []string
+	for i, msg := range t.snapshot.RecentMessages {
+		if msg.Role == "toolResult" && !msg.Truncated && i < protectedStart {
+			ids = append(ids, msg.ToolCallID)
+		}
+	}
+	return ids
 }
 
 // applyTruncate marks messages as truncated and records to journal.


### PR DESCRIPTION
## Problem

Session `44ed3ae6` entered an infinite context management loop, producing 170+ messages without making progress. Root cause was three interacting issues in the context management trampoline:

1. **Loop detection resets on trampoline re-entry** — the old `checkDuplicateToolSignatures` used local variables inside `executeConversationLoop`, so state was lost every time the trampoline re-entered the normal loop.
2. **`truncate_messages` retries stale IDs** — when the LLM provides tool call IDs that no longer exist, the tool retries up to 75 times without helpful feedback.
3. **No runaway context management detection** — no mechanism to detect that context management itself has become stuck.

## Fix: Three-Layer Defense

### Layer 1 — Persistent Loop Detector (`loop_detector.go`)
- New `loopDetector` struct lives on `AgentNew`, persists across trampoline re-entries
- **Tool-name-based signatures** — catches semantic loops where LLM varies parameters slightly (e.g., truncating different IDs each time)
- **Oscillation detection** — catches A→B→A→B patterns (threshold = `maxDuplicates/2`, min 3)
- Threshold: 7 consecutive same-tool calls triggers loop break
- State resets only on real progress (`ModeDone` in normal mode)
- `reset()` is nil-safe

### Layer 2 — Better `truncate_messages` Error Handling
- New `getAvailableToolCallIDs()` helper enumerates valid truncatable IDs outside the protected zone
- When all provided IDs are invalid, returns a helpful error message listing up to 10 available IDs and suggests `compact_messages` as an alternative
- Prevents the LLM from blindly retrying stale IDs

### Layer 3 — Runaway Context Management Detection
- New `ConsecutiveContextMgmtTriggers` field in `AgentState` (persisted in checkpoints)
- Incremented on each context management trigger in the trampoline
- After **5 consecutive triggers** without progress, forces `compact_messages`
- Counter resets when normal mode produces a `ModeDone` response

## Files Changed

| File | Change |
|------|--------|
| `pkg/agent/loop_detector.go` | **NEW** — persistent loop detection struct |
| `pkg/agent/loop_detector_test.go` | **NEW** — 8 tests |
| `pkg/agent/loop_normal.go` | Removed old local detection (~65 lines), uses persistent `loopDetector` |
| `pkg/agent/agent_new.go` | Added `loopDetector` field, initialized in constructor |
| `pkg/agent/resume.go` | Initialize `loopDetector` in resume path |
| `pkg/agent/turn.go` | Runaway ctx mgmt detection in trampoline |
| `pkg/agent/e2e_helpers.go` | `ResumeAgentForE2E` initializes `loopDetector` |
| `pkg/context/agent_state.go` | Added `ConsecutiveContextMgmtTriggers` with Clone |
| `pkg/tools/context_mgmt/truncate_messages.go` | `getAvailableToolCallIDs()`, helpful error messages |

## Testing

```
✅ 8/8 TestLoopDetector* + TestBuildToolCallSignature
✅ 60+/60+ pkg/context tests
✅ go build ./... compiles cleanly
```