### PR TITLE
fix: remove duplicate message events in -mode win

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -510,7 +510,7 @@ func (s *AgentNewServer) Prompt(ctx context.Context, message string) error {
 		}
 		s.mu.Unlock()
 
-		assistantMessage, toolResults := s.emitPostTurnEvents(beforeCount)
+		assistantMessage, toolResults := s.collectPostTurnResults(beforeCount)
 		s.emitEvent(agent.NewTurnEndEvent(assistantMessage, toolResults))
 		s.emitEvent(agent.NewAgentEndEvent(nil))
 
@@ -531,7 +531,7 @@ func (s *AgentNewServer) Prompt(ctx context.Context, message string) error {
 	}
 	s.mu.Unlock()
 
-	assistantMessage, toolResults := s.emitPostTurnEvents(beforeCount)
+	assistantMessage, toolResults := s.collectPostTurnResults(beforeCount)
 	s.emitEvent(agent.NewTurnEndEvent(assistantMessage, toolResults))
 	s.emitEvent(agent.NewAgentEndEvent(nil))
 
@@ -612,7 +612,11 @@ func (s *AgentNewServer) traceAssistantMessageUpdate(update agent.AssistantMessa
 	}
 }
 
-func (s *AgentNewServer) emitPostTurnEvents(beforeCount int) (*agentctx.AgentMessage, []agentctx.AgentMessage) {
+// collectPostTurnResults extracts the last assistant message and tool results from
+// new messages added during this turn. It does NOT emit any events — those are
+// already streamed in real-time by the agent loop (pkg/agent/loop_normal.go).
+// The returned values are used by NewTurnEndEvent.
+func (s *AgentNewServer) collectPostTurnResults(beforeCount int) (*agentctx.AgentMessage, []agentctx.AgentMessage) {
 	snapshot := s.agent.GetSnapshot()
 	if snapshot == nil {
 		return nil, nil
@@ -629,46 +633,11 @@ func (s *AgentNewServer) emitPostTurnEvents(beforeCount int) (*agentctx.AgentMes
 	for _, msg := range newMessages {
 		switch msg.Role {
 		case "assistant":
-			s.emitEvent(agent.NewMessageStartEvent(msg))
-
-			// Emit thinking_delta event
-			if thinking := msg.ExtractThinking(); thinking != "" {
-				s.emitEvent(agent.NewMessageUpdateEvent(msg, agent.AssistantMessageEvent{
-					Type:  "thinking_delta",
-					Delta: thinking,
-				}))
-			}
-
-			// Emit text_delta event
-			if text := msg.ExtractText(); text != "" {
-				s.emitEvent(agent.NewMessageUpdateEvent(msg, agent.AssistantMessageEvent{
-					Type:  "text_delta",
-					Delta: text,
-				}))
-			}
-
-			// Emit toolcall_delta events
-			toolCalls := msg.ExtractToolCalls()
-			for _, tc := range toolCalls {
-				s.emitEvent(agent.NewMessageUpdateEvent(msg, agent.AssistantMessageEvent{
-					Type:  "toolcall_delta",
-					Delta: fmt.Sprintf("[toolcall %s]", tc.Name),
-				}))
-			}
-
-			s.emitEvent(agent.NewMessageEndEvent(msg))
-
 			msgCopy := msg
 			lastAssistant = &msgCopy
 		case "toolResult":
 			msgCopy := msg
 			toolResults = append(toolResults, msgCopy)
-			s.emitEvent(agent.NewToolExecutionEndEvent(
-				msgCopy.ToolCallID,
-				msgCopy.ToolName,
-				&msgCopy,
-				msgCopy.IsError,
-			))
 		}
 	}
 


### PR DESCRIPTION
## Problem

在 `-mode win` 下，LLM 的每条消息都会被渲染两次（文本重复显示）。

## Root Cause

`emitPostTurnEvents` 在 turn 结束后重新发送了 `message_start`、`message_update`、`message_end`、`tool_execution_end` 等事件。但这些事件已经由 `pkg/agent/loop_normal.go` 中的 `processLLMResponse` 和 `executeToolsFromMessage` 实时流式发送过了。Win UI 收到两套相同事件，导致重复渲染。

## Fix

1. 将 `emitPostTurnEvents` 重命名为 `collectPostTurnResults`（语义更清晰：只收集数据，不发送事件）
2. 删除函数内所有 `s.emitEvent()` 调用
3. 保留返回值提取逻辑（`lastAssistant`、`toolResults`），`NewTurnEndEvent` 仍需这些参数

## Verification

- `go build ./cmd/ai` ✅
- `go test ./cmd/ai -v` ✅ (all 8 tests pass)
- `go test -short ./pkg/agent` ✅