### PR TITLE
Fix: Improve auto-compaction feedback messages for mini compaction

### DIFF
--- a/internal/winai/interpreter.go
+++ b/internal/winai/interpreter.go
@@ -1831,6 +1831,26 @@ func (p *AiInterpreter) handleCompactionEvent(start bool, info *agent.Compaction
 		return
 	}
 
+	// For mini compaction, show truncation details
+	if info != nil && info.Type == "mini" {
+		msg := fmt.Sprintf("ai: %s done ", label)
+		if info.TruncatedCount > 0 {
+			msg += fmt.Sprintf("(%d messages truncated", info.TruncatedCount)
+			if info.TokensBefore > 0 && info.TokensAfter > 0 {
+				msg += fmt.Sprintf(", %d -> %d tokens", info.TokensBefore, info.TokensAfter)
+			}
+			msg += ")"
+			if info.LLMContextUpdated {
+				msg += " (LLM context updated)"
+			}
+		} else {
+			msg += "(no action needed)"
+		}
+		p.writeStatus(msg)
+		return
+	}
+
+	// For major compaction, show message count change
 	if info != nil && info.Before > 0 && info.After > 0 {
 		p.writeStatus(fmt.Sprintf("ai: %s done (%d -> %d messages)", label, info.Before, info.After))
 		return

--- a/pkg/agent/event.go
+++ b/pkg/agent/event.go
@@ -77,11 +77,18 @@ const (
 
 // CompactionInfo describes a compaction event.
 type CompactionInfo struct {
+	Type    string `json:"type,omitempty"`    // "major" or "mini"
 	Auto    bool   `json:"auto,omitempty"`
 	Before  int    `json:"before,omitempty"`
 	After   int    `json:"after,omitempty"`
 	Error   string `json:"error,omitempty"`
 	Trigger string `json:"trigger,omitempty"`
+
+	// Mini compaction specific fields
+	TokensBefore       int  `json:"tokens_before,omitempty"`       // Token count before compaction (mini only)
+	TokensAfter        int  `json:"tokens_after,omitempty"`        // Token count after compaction (mini only)
+	TruncatedCount     int  `json:"truncated_count,omitempty"`     // Number of messages truncated (mini only)
+	LLMContextUpdated  bool `json:"llm_context_updated,omitempty"` // Whether LLM context was updated (mini only)
 }
 
 // LoopGuardInfo describes why tool-loop protection interrupted a turn.

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tiancaiamao/ai/pkg/prompt"
 	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -348,10 +347,15 @@ func runInnerLoop(
 				compactionSpan.AddField("after_messages", after)
 				compactionSpan.End()
 				stream.Push(NewCompactionEndEvent(CompactionInfo{
-					Auto:    true,
-					Before:  before,
-					After:   after,
-					Trigger: "pre_llm_threshold",
+					Type:              compacted.Type,
+					Auto:              true,
+					Before:            before,
+					After:             after,
+					Trigger:           "pre_llm_threshold",
+					TokensBefore:      compacted.TokensBefore,
+					TokensAfter:       compacted.TokensAfter,
+					TruncatedCount:    compacted.TruncatedCount,
+					LLMContextUpdated: compacted.LLMContextUpdated,
 				}))
 
 				// Create checkpoint after compaction to preserve AgentState for resume
@@ -418,10 +422,15 @@ func runInnerLoop(
 					compactionSpan.AddField("after_messages", len(agentCtx.RecentMessages))
 					compactionSpan.End()
 					stream.Push(NewCompactionEndEvent(CompactionInfo{
-						Auto:    true,
-						Before:  before,
-						After:   len(agentCtx.RecentMessages),
-						Trigger: "context_limit_recovery",
+						Type:              func() string { if recoveryCompacted != nil { return recoveryCompacted.Type }; return "" }(),
+						Auto:              true,
+						Before:            before,
+						After:             len(agentCtx.RecentMessages),
+						Trigger:           "context_limit_recovery",
+						TokensBefore:      func() int { if recoveryCompacted != nil { return recoveryCompacted.TokensBefore }; return 0 }(),
+						TokensAfter:       func() int { if recoveryCompacted != nil { return recoveryCompacted.TokensAfter }; return 0 }(),
+						TruncatedCount:    func() int { if recoveryCompacted != nil { return recoveryCompacted.TruncatedCount }; return 0 }(),
+						LLMContextUpdated: func() bool { if recoveryCompacted != nil { return recoveryCompacted.LLMContextUpdated }; return false }(),
 					}))
 
 					// Create checkpoint after compaction to preserve AgentState for resume
@@ -1630,86 +1639,6 @@ func selectMessagesForLLM(agentCtx *agentctx.AgentContext) ([]agentctx.AgentMess
 	return agentCtx.RecentMessages, "all_available_messages_no_runtime_clip"
 }
 
-func hasSuccessfulLLMContextWrite(messages []agentctx.AgentMessage, overviewPath string) bool {
-	targetAbs := normalizePathForContains(overviewPath)
-	targetRel := normalizePathForContains(filepath.ToSlash(filepath.Join(agentctx.LLMContextDir, agentctx.OverviewFile)))
-	allowRelativeFallback := targetAbs == "" && targetRel != ""
-	if targetAbs == "" && !allowRelativeFallback {
-		return false
-	}
-
-	for _, msg := range messages {
-		if msg.Role != "toolResult" || msg.IsError {
-			continue
-		}
-		tool := strings.ToLower(strings.TrimSpace(msg.ToolName))
-		if tool != "write" && tool != "edit" {
-			continue
-		}
-		body := normalizePathForContains(msg.ExtractText())
-		if body == "" {
-			continue
-		}
-		if targetAbs != "" && strings.Contains(body, targetAbs) {
-			return true
-		}
-		if allowRelativeFallback && strings.Contains(body, targetRel) {
-			return true
-		}
-	}
-	return false
-}
-
-func normalizeLLMContextContent(content string) string {
-	content = strings.ReplaceAll(content, "\r\n", "\n")
-	content = strings.TrimSpace(content)
-	lines := strings.Split(content, "\n")
-	normalized := make([]string, 0, len(lines))
-	for _, line := range lines {
-		normalized = append(normalized, strings.TrimRight(line, " \t"))
-	}
-	return strings.Join(normalized, "\n")
-}
-
-func normalizePathForContains(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	value = filepath.Clean(value)
-	value = strings.ReplaceAll(value, "\\", "/")
-	return strings.ToLower(value)
-}
-
-// insertBeforeLastUserMessage inserts a message before the last user message in the slice.
-// If there are no user messages, it appends to the end.
-// This is used to place runtime_state close to the decision point for better LLM attention.
-func insertBeforeLastUserMessage(messages []llm.LLMMessage, msg llm.LLMMessage) []llm.LLMMessage {
-	if len(messages) == 0 {
-		return []llm.LLMMessage{msg}
-	}
-
-	// Find the last user message index
-	lastUserIdx := -1
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role == "user" {
-			lastUserIdx = i
-			break
-		}
-	}
-
-	// If no user message found, append to end
-	if lastUserIdx == -1 {
-		return append(messages, msg)
-	}
-
-	// Insert before the last user message
-	result := make([]llm.LLMMessage, 0, len(messages)+1)
-	result = append(result, messages[:lastUserIdx]...)
-	result = append(result, msg)
-	result = append(result, messages[lastUserIdx:]...)
-	return result
-}
 
 func buildRuntimeUserAppendix(llmContextContent, runtimeMetaSnapshot string) string {
 	sections := make([]string, 0, 3)
@@ -1955,6 +1884,33 @@ func hasToolResultNamed(results []agentctx.AgentMessage, toolName string) bool {
 }
 
 // EstimateMessageTokens estimates token count for a message.
+func insertBeforeLastUserMessage(messages []llm.LLMMessage, msg llm.LLMMessage) []llm.LLMMessage {
+	if len(messages) == 0 {
+		return []llm.LLMMessage{msg}
+	}
+
+	// Find the last user message index
+	lastUserIdx := -1
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" {
+			lastUserIdx = i
+			break
+		}
+	}
+
+	// If no user message found, append to end
+	if lastUserIdx == -1 {
+		return append(messages, msg)
+	}
+
+	// Insert before the last user message
+	result := make([]llm.LLMMessage, 0, len(messages)+1)
+	result = append(result, messages[:lastUserIdx]...)
+	result = append(result, msg)
+	result = append(result, messages[lastUserIdx:]...)
+	return result
+}
+
 // Deprecated: Use agentctx.EstimateMessageTokens instead.
 func EstimateMessageTokens(msg agentctx.AgentMessage) int {
 	return agentctx.EstimateMessageTokens(msg)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"strconv"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
@@ -1639,6 +1640,56 @@ func selectMessagesForLLM(agentCtx *agentctx.AgentContext) ([]agentctx.AgentMess
 	return agentCtx.RecentMessages, "all_available_messages_no_runtime_clip"
 }
 
+func hasSuccessfulLLMContextWrite(messages []agentctx.AgentMessage, overviewPath string) bool {
+	targetAbs := normalizePathForContains(overviewPath)
+	targetRel := normalizePathForContains(filepath.ToSlash(filepath.Join(agentctx.LLMContextDir, agentctx.OverviewFile)))
+	allowRelativeFallback := targetAbs == "" && targetRel != ""
+	if targetAbs == "" && !allowRelativeFallback {
+		return false
+	}
+
+	for _, msg := range messages {
+		if msg.Role != "toolResult" || msg.IsError {
+			continue
+		}
+		tool := strings.ToLower(strings.TrimSpace(msg.ToolName))
+		if tool != "write" && tool != "edit" {
+			continue
+		}
+		body := normalizePathForContains(msg.ExtractText())
+		if body == "" {
+			continue
+		}
+		if targetAbs != "" && strings.Contains(body, targetAbs) {
+			return true
+		}
+		if allowRelativeFallback && strings.Contains(body, targetRel) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeLLMContextContent(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.TrimSpace(content)
+	lines := strings.Split(content, "\n")
+	normalized := make([]string, 0, len(lines))
+	for _, line := range lines {
+		normalized = append(normalized, strings.TrimRight(line, " \t"))
+	}
+	return strings.Join(normalized, "\n")
+}
+
+func normalizePathForContains(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = filepath.Clean(value)
+	value = strings.ReplaceAll(value, "\\", "/")
+	return strings.ToLower(value)
+}
 
 func buildRuntimeUserAppendix(llmContextContent, runtimeMetaSnapshot string) string {
 	sections := make([]string, 0, 3)

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1038,6 +1038,7 @@ func (c *Compactor) Compact(ctx *agentctx.AgentContext) (*agentctx.CompactionRes
 		Summary:      summary,
 		TokensBefore: tokensBefore,
 		TokensAfter:  tokensAfter,
+		Type:         "major",
 	}, nil
 }
 

--- a/pkg/compact/llm_mini_compact.go
+++ b/pkg/compact/llm_mini_compact.go
@@ -208,8 +208,8 @@ func (c *LLMMiniCompactor) CompactWithCtx(parent context.Context, agentCtx *agen
 		return nil, fmt.Errorf("context management LLM call failed: %w", err)
 	}
 
-	// 5. Execute tool calls
-	c.executeToolCalls(parent, toolCalls, tools)
+	// 5. Execute tool calls and track results
+	truncatedCount, llmContextUpdated := c.executeToolCalls(parent, toolCalls, tools)
 
 	// 6. Reset trigger counters
 	agentCtx.AgentState.LastTriggerTurn = agentCtx.AgentState.TotalTurns
@@ -224,19 +224,26 @@ func (c *LLMMiniCompactor) CompactWithCtx(parent context.Context, agentCtx *agen
 	span.AddField("tokens_saved", tokensBefore-tokensAfter)
 	span.AddField("messages_after", len(agentCtx.RecentMessages))
 	span.AddField("tool_calls", len(toolCalls))
+	span.AddField("truncated_count", truncatedCount)
+	span.AddField("llm_context_updated", llmContextUpdated)
 
 	slog.Info("[LLMMini] Compact complete",
 		"tokens_before", tokensBefore,
 		"tokens_after", tokensAfter,
 		"saved", tokensBefore-tokensAfter,
 		"tool_calls", len(toolCalls),
+		"truncated", truncatedCount,
+		"llm_context_updated", llmContextUpdated,
 		"duration", duration,
 	)
 
 	return &agentctx.CompactionResult{
-		Summary:      fmt.Sprintf("LLM mini compact: %d tool calls executed", len(toolCalls)),
-		TokensBefore: tokensBefore,
-		TokensAfter:  tokensAfter,
+		Summary:           fmt.Sprintf("LLM mini compact: %d tool calls executed", len(toolCalls)),
+		TokensBefore:      tokensBefore,
+		TokensAfter:       tokensAfter,
+		Type:              "mini",
+		TruncatedCount:    truncatedCount,
+		LLMContextUpdated: llmContextUpdated,
 	}, nil
 }
 
@@ -508,7 +515,8 @@ func (c *LLMMiniCompactor) extractToolCalls(ctx context.Context, stream *llm.Eve
 }
 
 // executeToolCalls runs each tool call and logs the result.
-func (c *LLMMiniCompactor) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall, tools []context_mgmt.Tool) {
+// Returns the count of truncated messages and whether LLM context was updated.
+func (c *LLMMiniCompactor) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall, tools []context_mgmt.Tool) (truncatedCount int, llmContextUpdated bool) {
 	for _, tc := range toolCalls {
 		startTime := time.Now()
 		toolSpan := traceevent.StartSpan(ctx, "tool_execution", traceevent.CategoryTool,
@@ -593,7 +601,19 @@ func (c *LLMMiniCompactor) executeToolCalls(ctx context.Context, toolCalls []llm
 			traceevent.Field{Key: "duration_ms", Value: time.Since(startTime).Milliseconds()},
 			traceevent.Field{Key: "result", Value: resultText},
 		)
+
+		// Track truncations and LLM context updates
+		if tc.Function.Name == "truncate_messages" {
+			// Extract count from result text
+			var count int
+			if _, err := fmt.Sscanf(resultText, "Truncated %d messages.", &count); err == nil {
+				truncatedCount += count
+			}
+		} else if tc.Function.Name == "update_llm_context" {
+			llmContextUpdated = true
+		}
 	}
+	return truncatedCount, llmContextUpdated
 }
 
 // extractLatestUserRequest finds the most recent user message text from the

--- a/pkg/context/compactor.go
+++ b/pkg/context/compactor.go
@@ -16,4 +16,9 @@ type CompactionResult struct {
 	Summary      string // The generated summary
 	TokensBefore int    // Token count before compaction
 	TokensAfter  int    // Token count after compaction
+
+	// Mini compaction specific fields
+	Type              string // "major" or "mini"
+	TruncatedCount    int    // Number of messages truncated (mini only)
+	LLMContextUpdated bool   // Whether LLM context was updated (mini only)
 }


### PR DESCRIPTION
## Workpad

```text
MacBook-Pro:/Users/genius/.symphony/workspaces/35cdf9ca-d40a-4c21-87a6-ed7e711198c9@0000000
```

### Plan

- [x] 1. Extend CompactionResult structure
  - [x] 1.1 Add Type field ("major" or "mini")
  - [x] 1.2 Add TruncatedCount field (mini only)
  - [x] 1.3 Add LLMContextUpdated field (mini only)
- [x] 2. Track truncation in TruncateMessagesTool
  - [x] 2.1 Ensure count is returned (already implemented)
- [x] 3. Update LLMMiniCompactor to return detailed results
  - [x] 3.1 Track truncated message count
  - [x] 3.2 Track if update_llm_context was called
  - [x] 3.3 Set Type to "mini" in CompactionResult
  - [x] 3.4 Populate TruncatedCount and LLMContextUpdated
- [x] 4. Update CompactionInfo structure
  - [x] 4.1 Add Type field ("major" or "mini")
  - [x] 4.2 Add TruncatedCount field (mini only)
  - [x] 4.3 Add LLMContextUpdated field (mini only)
- [x] 5. Update feedback logic in interpreter
  - [x] 5.1 For mini compaction: show truncate count, token changes, LLM context update
  - [x] 5.2 For major compaction: keep existing message count feedback
- [x] 6. Update Compactor implementation to set Type="major"
  - [x] 6.1 Add Type field initialization in major compactor
- [x] 7. Update loop.go to propagate CompactionResult fields to CompactionInfo
- [x] 8. Test changes
  - [x] 8.1 Run existing tests: `go test ./pkg/... -v` - ALL PASS
- [ ] 9. Commit and push changes
- [ ] 10. Create PR and move to self-review

### Acceptance Criteria

- [x] Major compaction feedback unchanged: "auto-compaction done (50 -> 6 messages)"
- [x] Mini compaction with truncate: "auto-compaction done (15 messages truncated, 12000 -> 8500 tokens) (LLM context updated)"
- [x] Mini compaction without action: "auto-compaction done (no action needed)"
- [x] All existing tests pass

### Validation

- [x] Run existing tests: `go test ./pkg/... -v`

### Notes

- All tests pass successfully
- Changes:
  - pkg/context/compactor.go: Added Type, TruncatedCount, LLMContextUpdated fields
  - pkg/agent/event.go: Added Type, TokensBefore, TokensAfter, TruncatedCount, LLMContextUpdated fields
  - pkg/compact/llm_mini_compact.go: Modified executeToolCalls to track and return truncation/LLM context updates; Modified CompactWithCtx to populate new fields
  - pkg/compact/compact.go: Set Type="major" in CompactAgent
  - pkg/agent/loop.go: Propagate CompactionResult fields to CompactionInfo events
  - internal/winai/interpreter.go: Updated handleCompactionEvent to format mini compaction feedback differently