### PR TITLE
Fix: [BUG] Every toolResult message is duplicated in messages.jsonl

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -549,14 +549,9 @@ func runInnerLoop(
 			agentCtx.AgentState.ToolCallsSinceLastTrigger += len(toolResults)
 		}
 
-		// Append messages to journal if checkpoint manager is available
-		if checkpointMgr != nil {
-			for _, result := range toolResults {
-				if err := checkpointMgr.AppendMessage(result); err != nil {
-					slog.Warn("[Loop] Failed to append tool result to journal", "error", err)
-				}
-			}
-		}
+		// Note: toolResult persistence is handled by the sessionWriter (via tool_execution_end
+		// events) in all modes (RPC, headless, json). We do NOT write toolResults to the journal
+		// here to avoid duplicating each message in messages.jsonl.
 
 		// Create checkpoint after update_llm_context tool execution
 		if checkpointMgr != nil && checkpointMgr.ShouldCheckpoint() && hasToolResultNamed(toolResults, "update_llm_context") {


### PR DESCRIPTION
## Problem

Every toolResult message was written exactly TWICE to messages.jsonl.

## Root Cause

Two independent writers appended to the same messages.jsonl file:

1. **Writer 1 (Journal via checkpointMgr)**: `pkg/agent/loop.go` called `checkpointMgr.AppendMessage(result)` for each tool result, writing to the journal.
2. **Writer 2 (SessionWriter via events)**: All mode handlers (RPC, headless, json) called `sessionWriter.Append(sess, *event.Result)` on `tool_execution_end` events, writing to the session.

Both targeted the same `messages.jsonl` file, causing duplication.

## Fix

Removed the redundant `checkpointMgr.AppendMessage` block for toolResults in `pkg/agent/loop.go`. The sessionWriter (via event handlers) is the sole writer for toolResults in all execution modes.

## Verification

- ✅ `go build ./...` passes
- ✅ `go test ./pkg/agent/ -v` — all tests pass
- ✅ `go test ./pkg/session/ ./pkg/context/ -v` — all tests pass
- ✅ Checkpoint functionality (CreateSnapshot) remains unaffected