### PR TITLE
Fix: allow empty newText in edit tool for deletion operations

### DIFF
--- a/pkg/agent/tool_call_normalize.go
+++ b/pkg/agent/tool_call_normalize.go
@@ -79,7 +79,7 @@ func inferToolFromArgs(args map[string]any) (string, map[string]any, bool) {
 	path := getStringArg(argSource, "path", "file")
 	content := getStringArg(argSource, "content", "text")
 	oldText := getStringArg(argSource, "oldText", "old_text", "old")
-	newText := getStringArg(argSource, "newText", "new_text", "new")
+	newText, newTextOk := getOptionalStringArg(argSource, "newText", "new_text", "new")
 
 	switch {
 	case command != "":
@@ -95,7 +95,7 @@ func inferToolFromArgs(args map[string]any) (string, map[string]any, bool) {
 		return "grep", inferred, true
 	case path != "" && content != "":
 		return "write", map[string]any{"path": path, "content": content}, true
-	case path != "" && oldText != "" && newText != "":
+	case path != "" && oldText != "" && newTextOk:
 		return "edit", map[string]any{"path": path, "oldText": oldText, "newText": newText}, true
 	case path != "":
 		return "read", map[string]any{"path": path}, true
@@ -157,8 +157,8 @@ func coerceToolArguments(toolName string, args map[string]any) (map[string]any, 
 	case "edit":
 		path := getStringArg(args, "path", "file")
 		oldText := getStringArg(args, "oldText", "old_text", "old")
-		newText := getStringArg(args, "newText", "new_text", "new")
-		if path == "" || oldText == "" || newText == "" {
+		newText, newTextOk := getOptionalStringArg(args, "newText", "new_text", "new")
+		if path == "" || oldText == "" || !newTextOk {
 			return nil, fmt.Errorf("missing path/oldText/newText")
 		}
 		return map[string]any{
@@ -193,6 +193,26 @@ func coerceToolArguments(toolName string, args map[string]any) (map[string]any, 
 	default:
 		return args, nil
 	}
+}
+
+// getOptionalStringArg returns (value, true) if any key exists (even if value is empty string),
+// or ("", false) if no key is present. Unlike getStringArg, it does NOT treat empty string as
+// missing, which is essential for edit's newText where "" means deletion.
+func getOptionalStringArg(args map[string]any, keys ...string) (string, bool) {
+	for _, key := range keys {
+		v, ok := args[key]
+		if !ok {
+			continue
+		}
+		switch val := v.(type) {
+		case string:
+			return val, true
+		default:
+			coerced := fmt.Sprint(val)
+			return coerced, true
+		}
+	}
+	return "", false
 }
 
 func getStringArg(args map[string]any, keys ...string) string {

--- a/pkg/agent/tool_call_normalize_test.go
+++ b/pkg/agent/tool_call_normalize_test.go
@@ -77,6 +77,143 @@ func TestNormalizeToolCallUnwrapsPropertiesStringForWrite(t *testing.T) {
 	}
 }
 
+func TestCoercedToolArgs_EditEmptyNewText(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantErr bool
+		wantNew string
+	}{
+		{
+			name:    "empty newText should succeed (deletion)",
+			args:    map[string]any{"path": "/tmp/a.txt", "oldText": "remove me", "newText": ""},
+			wantErr: false,
+			wantNew: "",
+		},
+		{
+			name:    "missing newText key should fail",
+			args:    map[string]any{"path": "/tmp/a.txt", "oldText": "remove me"},
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only newText should succeed",
+			args:    map[string]any{"path": "/tmp/a.txt", "oldText": "remove me", "newText": "  "},
+			wantErr: false,
+			wantNew: "  ",
+		},
+		{
+			name:    "non-empty newText should succeed as before",
+			args:    map[string]any{"path": "/tmp/a.txt", "oldText": "old", "newText": "new"},
+			wantErr: false,
+			wantNew: "new",
+		},
+		{
+			name:    "missing path should fail",
+			args:    map[string]any{"oldText": "old", "newText": "new"},
+			wantErr: true,
+		},
+		{
+			name:    "missing oldText should fail",
+			args:    map[string]any{"path": "/tmp/a.txt", "newText": ""},
+			wantErr: true,
+		},
+		{
+			name:    "new_text alias with empty string should succeed",
+			args:    map[string]any{"path": "/tmp/a.txt", "oldText": "old", "new_text": ""},
+			wantErr: false,
+			wantNew: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := coerceToolArguments("edit", tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("coerceToolArguments() error=%v wantErr=%v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if got["newText"] != tt.wantNew {
+					t.Fatalf("expected newText=%q, got %q", tt.wantNew, got["newText"])
+				}
+				if got["path"] == "" || got["oldText"] == "" {
+					t.Fatalf("path and oldText should be preserved, got=%v", got)
+				}
+			}
+		})
+	}
+}
+
+func TestInferToolFromArgs_EditWithEmptyNewText(t *testing.T) {
+	// Verify that inferToolFromArgs correctly infers "edit" when newText is empty
+	name, args, ok := inferToolFromArgs(map[string]any{
+		"path": "/tmp/a.txt", "oldText": "old", "newText": "",
+	})
+	if !ok {
+		t.Fatalf("expected inference to succeed")
+	}
+	if name != "edit" {
+		t.Fatalf("expected tool=edit, got %q", name)
+	}
+	if args["newText"] != "" {
+		t.Fatalf("expected newText to be empty, got %q", args["newText"])
+	}
+}
+
+func TestGetOptionalStringArg(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      map[string]any
+		keys      []string
+		wantVal   string
+		wantFound bool
+	}{
+		{
+			name:      "key present with empty string",
+			args:      map[string]any{"newText": ""},
+			keys:      []string{"newText", "new_text"},
+			wantVal:   "",
+			wantFound: true,
+		},
+		{
+			name:      "key absent",
+			args:      map[string]any{"path": "x"},
+			keys:      []string{"newText", "new_text"},
+			wantVal:   "",
+			wantFound: false,
+		},
+		{
+			name:      "key present with whitespace",
+			args:      map[string]any{"newText": "  "},
+			keys:      []string{"newText"},
+			wantVal:   "  ",
+			wantFound: true,
+		},
+		{
+			name:      "alias key used",
+			args:      map[string]any{"new_text": "hello"},
+			keys:      []string{"newText", "new_text"},
+			wantVal:   "hello",
+			wantFound: true,
+		},
+		{
+			name:      "non-string value coerced",
+			args:      map[string]any{"newText": 42},
+			keys:      []string{"newText"},
+			wantVal:   "42",
+			wantFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, found := getOptionalStringArg(tt.args, tt.keys...)
+			if val != tt.wantVal || found != tt.wantFound {
+				t.Fatalf("getOptionalStringArg() = (%q, %v), want (%q, %v)", val, found, tt.wantVal, tt.wantFound)
+			}
+		})
+	}
+}
+
 func TestNormalizeToolCallUnwrapsPropertiesMapForWrite(t *testing.T) {
 	got := normalizeToolCall(agentctx.ToolCallContent{
 		Name: "write",


### PR DESCRIPTION
## Workpad

```
hostname:~/.symphony/workspaces/e8cd3650-6165-48a5-88f3-29ce0653b3c7@b0b787e
```

### Plan

- [x] 1. Reproduce the issue — confirm `coerceToolArguments("edit", ...)` rejects empty newText
- [x] 2. Add `getOptionalStringArg` function to `tool_call_normalize.go`
- [x] 3. Update `coerceToolArguments` edit case to allow empty newText
- [x] 4. Update `inferToolFromArgs` edit heuristic to allow empty newText
- [x] 5. Add test cases for empty newText scenarios
- [x] 6. Run tests and verify
- [x] 7. Commit, push, create PR
- [ ] 8. Self-review

### Acceptance Criteria

- [x] `coerceToolArguments("edit", {"path":"f","oldText":"x","newText":""})` succeeds
- [x] `coerceToolArguments("edit", {"path":"f","oldText":"x"})` (missing key) still fails
- [x] Existing tests continue to pass
- [x] `go build ./...` succeeds

### Validation

- [x] targeted tests: `go test ./pkg/agent/ -run "TestCoercedToolArgs_EditEmptyNewText|TestInferToolFromArgs_EditWithEmptyNewText|TestGetOptionalStringArg" -v`
- [x] full suite: `go test ./pkg/agent/ -v` — all PASS
- [x] build: `go build ./...` — success

### Files Changed

- `pkg/agent/tool_call_normalize.go` — added `getOptionalStringArg()`, updated edit coercion and inference
- `pkg/agent/tool_call_normalize_test.go` — added 3 new test functions (13 test cases total)

### Notes

- (t0) Read source, understood issue. `getStringArg` treats empty/whitespace-only as missing, blocking deletion via edit.
- (t1) Implemented fix: added `getOptionalStringArg`, updated edit coercion and inference heuristic.
- (t2) Added comprehensive test coverage: coercion, inference, and unit tests for `getOptionalStringArg`.
- (t3) All tests pass, build succeeds, committed and pushed.