### PR TITLE
Fix: [BUG] bash tool 误导性错误信息：worktree 删除后报 fork/exec /bin/sh: no such file or directory

### DIFF
--- a/pkg/tools/bash.go
+++ b/pkg/tools/bash.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os/exec"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -173,10 +174,16 @@ func (t *BashTool) Execute(ctx context.Context, args map[string]any) ([]agentctx
 	// Start the command
 	startTime := time.Now()
 	if err := cmd.Start(); err != nil {
+		msg := fmt.Sprintf("Failed to start command: %v", err)
+		if cmd.Dir != "" {
+			if _, statErr := os.Stat(cmd.Dir); statErr != nil {
+				msg = fmt.Sprintf("Failed to start command: working directory %q does not exist (error: %v). Use change_workspace to switch to a valid directory.", cmd.Dir, err)
+			}
+		}
 		return []agentctx.ContentBlock{
 			agentctx.TextContent{
 				Type: "text",
-				Text: fmt.Sprintf("Failed to start command: %v", err),
+				Text: msg,
 			},
 		}, nil
 	}

--- a/pkg/tools/grep.go
+++ b/pkg/tools/grep.go
@@ -96,6 +96,17 @@ func (t *GrepTool) Execute(ctx context.Context, args map[string]any) ([]agentctx
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		// Check if the working directory was deleted (e.g., git worktree removed)
+		if cmd.Dir != "" {
+			if _, statErr := os.Stat(cmd.Dir); statErr != nil {
+				return []agentctx.ContentBlock{
+					agentctx.TextContent{
+						Type: "text",
+						Text: fmt.Sprintf("Failed to run grep: working directory %q does not exist. Use change_workspace to switch to a valid directory.", cmd.Dir),
+					},
+				}, nil
+			}
+		}
 		// Grep returns exit code 1 when no matches found, which is not an error
 		if len(output) == 0 {
 			return []agentctx.ContentBlock{


### PR DESCRIPTION
## Summary

Fixes a misleading error message when the agent's working directory (e.g., a git worktree) is deleted externally.

### Problem
When agent runs in a git worktree that gets removed, all bash/grep tool calls fail with:
`fork/exec /bin/sh: no such file or directory`

This is completely misleading — the real issue is that `cmd.Dir` (the working directory) no longer exists, not that `/bin/sh` is missing.

### Root Cause
Go's `exec.CommandContext` flow: fork → child: `chdir(cmd.Dir)` → exec. When `chdir` fails (ENOENT), Go formats the error as `fork/exec /bin/sh: no such file or directory`.

### Fix
- **bash.go**: In `cmd.Start()` error path, check if `cmd.Dir` exists. If not, return a clear message: `working directory \...\ does not exist. Use change_workspace to switch to a valid directory.`
- **grep.go**: Same check in `cmd.CombinedOutput()` error path.

### Testing
- All existing tests pass (`go test ./pkg/tools/... -v`)
- Manual smoke test verified: deleting the CWD produces the new helpful message instead of the misleading one

### Files Changed
- `pkg/tools/bash.go` — Added `os.Stat` check on `cmd.Dir` when `cmd.Start()` fails
- `pkg/tools/grep.go` — Added `os.Stat` check on `cmd.Dir` when `cmd.CombinedOutput()` fails