### PR TITLE
Fix: compaction_start event sent after Compact() completes instead of before

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -302,11 +302,31 @@ func runInnerLoop(
 
 		turnCount++
 
-		// Try each compactor in order (first trigger wins)
+		// Try each compactor in order (first trigger wins).
+		// Emit compaction_start BEFORE executing Compact() so the user sees
+		// immediate feedback instead of waiting for the full compaction to complete.
 		var compacted *agentctx.CompactionResult
 		var compactErr error
+		var compactionStarted bool
+		var before int
+		var compactionSpan *traceevent.Span
 		for _, c := range config.Compactors {
 			if c.ShouldCompact(ctx, agentCtx) {
+				if !compactionStarted {
+					before = len(agentCtx.RecentMessages)
+					compactionSpan = traceevent.StartSpan(ctx, "compaction", traceevent.CategoryEvent,
+						traceevent.Field{Key: "source", Value: "pre_llm_threshold"},
+						traceevent.Field{Key: "auto", Value: true},
+						traceevent.Field{Key: "before_messages", Value: before},
+						traceevent.Field{Key: "trigger", Value: "pre_llm_threshold"},
+					)
+					stream.Push(NewCompactionStartEvent(CompactionInfo{
+						Auto:    true,
+						Before:  before,
+						Trigger: "pre_llm_threshold",
+					}))
+					compactionStarted = true
+				}
 				slog.Info("[Loop] Pre-LLM compaction triggered", "compactor", fmt.Sprintf("%T", c))
 				compacted, compactErr = c.Compact(agentCtx)
 				if compactErr == nil {
@@ -318,25 +338,29 @@ func runInnerLoop(
 		}
 
 		// Process compaction result
-		if compacted != nil {
+		if compactionStarted {
 			if compactErr != nil {
-				// Compaction returned result but error is non-nil - skip this result
-				slog.Warn("[Loop] Skipping compaction result due to error", "error", compactErr)
-				compacted = nil
-			} else {
-				before := len(agentCtx.RecentMessages)
-				compactionSpan := traceevent.StartSpan(ctx, "compaction", traceevent.CategoryEvent,
-					traceevent.Field{Key: "source", Value: "pre_llm_threshold"},
-					traceevent.Field{Key: "auto", Value: true},
-					traceevent.Field{Key: "before_messages", Value: before},
-					traceevent.Field{Key: "trigger", Value: "pre_llm_threshold"},
-				)
-				stream.Push(NewCompactionStartEvent(CompactionInfo{
+				// Compaction triggered but all compactors failed
+				slog.Warn("[Loop] Compaction triggered but all compactors failed", "error", compactErr)
+				compactionSpan.AddField("error", true)
+				compactionSpan.AddField("error_message", compactErr.Error())
+				compactionSpan.End()
+				stream.Push(NewCompactionEndEvent(CompactionInfo{
+					Auto:    true,
+					Before:  before,
+					Error:   compactErr.Error(),
+					Trigger: "pre_llm_threshold",
+				}))
+			} else if compacted == nil {
+				// ShouldCompact returned true but Compact returned nil result without error
+				slog.Warn("[Loop] Compaction triggered but returned nil result")
+				compactionSpan.End()
+				stream.Push(NewCompactionEndEvent(CompactionInfo{
 					Auto:    true,
 					Before:  before,
 					Trigger: "pre_llm_threshold",
 				}))
-
+			} else {
 				// Note: Compactor now directly modifies agentCtx.RecentMessages
 				// We just need to update the summary.
 				// Compact events are already appended via OnCompactEvent in the tools.


### PR DESCRIPTION
## Workpad

```text
geniusdeMBP:/Users/genius/.symphony/workspaces/04c1e8a7-977a-4fa4-b84e-f1ebbda910f3@677e2eb
```

### Plan

- [x] 1. Reproduce/confirm the bug in `pkg/agent/loop.go`
  - [x] 1.1 Identify the pre-LLM threshold compaction path (lines ~306-370)
  - [x] 1.2 Confirm `CompactionStartEvent` is pushed after `c.Compact()` returns
- [x] 2. Implement the fix
  - [x] 2.1 Capture `before` count before compaction loop
  - [x] 2.2 Push `CompactionStartEvent` before first `c.Compact()` call
  - [x] 2.3 Create `compactionSpan` before first `c.Compact()` call
  - [x] 2.4 Handle error/nil-result edge cases properly
- [x] 3. Validate
  - [x] 3.1 `go build ./pkg/agent/...` compiles
  - [x] 3.2 `go test ./pkg/agent/... -v` passes (38.8s, all green)
- [ ] 4. Commit, push, create PR
- [ ] 5. Self-review

### Acceptance Criteria

- [x] Context management triggers `compaction_start` event BEFORE `Compact()` executes
- [x] Compact completes and end event still displays normally
- [x] `Before` count reflects message count BEFORE compaction
- [x] `go test ./pkg/agent/... -v` passes
- [x] Recovery compaction path (context_limit_recovery) already correct — not changed

### Validation

- [x] targeted tests: `go test ./pkg/agent/... -v -count=1`

### Notes

- The root cause was that in `runInnerLoop()`, the pre-LLM threshold compaction path called `c.Compact()` synchronously (30-120s), then pushed both start and end events together.
- Fix: Move start event emission (and `before` capture, span creation) to just before the first `c.Compact()` call.
- Added proper error handling for the case where `ShouldCompact` returns true but all compactors fail, or compact returns nil.
- The context_limit_recovery path was already correct (start before compact) — no changes needed there.

### Confusions

- None. The bug description was very precise and matched the code exactly.