### PR TITLE
feat(rpc): support custom system prompt via --system-prompt flag

### DIFF
--- a/cmd/ai/main.go
+++ b/cmd/ai/main.go
@@ -70,7 +70,7 @@ func main() {
 
 	switch *mode {
 	case "rpc":
-		if err := runRPC(*sessionPathFlag, *debugAddr, os.Stdin, os.Stdout); err != nil {
+		if err := runRPC(*sessionPathFlag, *debugAddr, os.Stdin, os.Stdout, systemPrompt); err != nil {
 			slog.Error("rpc error", "error", err)
 			os.Exit(1)
 		}

--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -30,7 +30,7 @@ import (
 	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
 )
 
-func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Writer) error {
+func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Writer, customSystemPrompt string) error {
 	// Load configuration
 	configPath, err := config.GetDefaultConfigPath()
 	if err != nil {
@@ -248,6 +248,11 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 
 	// Build the full system prompt (used for agent and compactor)
 	buildSystemPrompt := func(currentSess *session.Session) string {
+		// Use custom system prompt if provided (e.g., via --system-prompt flag)
+		if customSystemPrompt != "" {
+			slog.Info("Using custom system prompt", "length", len(customSystemPrompt))
+			return customSystemPrompt
+		}
 		// Use workspace to get dynamic cwd for each prompt build
 		promptBuilder := prompt.NewBuilderWithWorkspace("", ws)
 		promptBuilder.SetTools(registry.All()).SetSkills(skillResult.Skills)

--- a/cmd/ai/win_handlers.go
+++ b/cmd/ai/win_handlers.go
@@ -45,7 +45,7 @@ func runWinAI(windowName string, sessionPath string, debugAddr string) error {
 
 	go func() {
 		defer rpcOutWriter.Close()
-		if err := runRPC(sessionPath, debugAddr, rpcInReader, rpcOutWriter); err != nil {
+		if err := runRPC(sessionPath, debugAddr, rpcInReader, rpcOutWriter, ""); err != nil {
 			slog.Error("rpc error", "error", err)
 		}
 	}()


### PR DESCRIPTION
## Summary

Enable `ai --mode rpc` to accept a custom system prompt via the `--system-prompt` CLI flag.

### Changes
- **`runRPC()`** now accepts `customSystemPrompt string` parameter
- When `customSystemPrompt` is non-empty, bypass the normal prompt builder and use it directly as the system prompt
- `win_handlers.go` passes empty string (no custom prompt for win mode)
- `main.go` passes the parsed `--system-prompt` flag value to `runRPC()`

### Motivation
The `ag` bridge needs to spawn agents with focused personas (e.g., explorer, reviewer). Previously, the system prompt was injected via stdin, which was unreliable. Now it can use:

```bash
ai --mode rpc --system-prompt @/path/to/persona.md
```

### Test plan
- [ ] Verify `ai --mode rpc` still works without `--system-prompt` (no behavior change)
- [ ] Verify `ai --mode rpc --system-prompt "custom prompt"` uses the custom prompt
- [ ] Verify `ai --mode rpc --system-prompt @file.md` loads file content
- [ ] Verify `ai --mode win` still works (empty customSystemPrompt passed)
- [ ] Verify ag bridge `--system` flag works end-to-end with this change