### PR TITLE
Fix: trace files named sessunknown because SetSessionID never called

### DIFF
--- a/claw/pkg/adapter/adapter.go
+++ b/claw/pkg/adapter/adapter.go
@@ -608,6 +608,13 @@ func (a *AgentLoop) createSession(sessionKey string) (*Session, error) {
 		sess = session.NewSession("") // 无持久化
 	}
 
+	// Set session ID on trace handler so trace files are named correctly
+	if handler := traceevent.GetHandler(); handler != nil {
+		if fh, ok := handler.(*traceevent.FileHandler); ok {
+			fh.SetSessionID(sess.GetID())
+		}
+	}
+
 	// 创建 agent context
 	agentCtx := agentctx.NewAgentContext(a.systemPrompt)
 


### PR DESCRIPTION
## Bug

12% of trace files were named `pidXXXXX-sessunknown.N.perfetto.json` instead of containing the actual session ID.

## Root Cause

`FileHandler.SetSessionID()` was never called in production code — only in tests.

## Fix

Added `SetSessionID()` call in `createSession()` (the single convergence point where session ID becomes available), right after the session is loaded/created. This covers both the `setupTracing()` (startup) and `ensureTraceHandler()` (on-demand) code paths.

## Changes

- `claw/pkg/adapter/adapter.go` — add 7 lines to set trace handler session ID after session creation

## Verification

- `go test ./pkg/traceevent/... -v` — all 40 tests pass
- `go build ./cmd/aiclaw` — builds successfully