### PR TITLE
Fix: [BUG] Compaction LLM 500 error is not retryable, causing unrecoverable failure

### DIFF
--- a/pkg/compact/context_management.go
+++ b/pkg/compact/context_management.go
@@ -201,28 +201,67 @@ func (c *ContextManager) CompactWithCtx(parent context.Context, agentCtx *agentc
 		tools = context_mgmt.GetContextManagementTools(agentCtx)
 	}
 
-	// 3. Call LLM
+	// 3. Call LLM with retry for transient errors
 	llmMessages := append([]llm.LLMMessage{{
 		Role:    "system",
 		Content: c.systemPrompt,
 	}}, messages...)
 
-	stream := llm.StreamLLM(
-		parent,
-		c.model,
-		llm.LLMContext{
-			Messages: llmMessages,
-			Tools:    c.convertToolsToLLM(tools),
-		},
-		c.apiKey,
-		2*time.Minute,
-	)
+	const maxRetries = 3
+	var toolCalls []llm.ToolCall
+	var lastErr error
 
-	// 4. Extract tool calls from stream
-	toolCalls, err := c.extractToolCalls(parent, stream)
-	if err != nil {
-		slog.Error("[CtxMgmt] LLM call failed", "error", err)
-		return nil, fmt.Errorf("context management LLM call failed: %w", err)
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		// Respect context cancellation between retries.
+		if err := parent.Err(); err != nil {
+			slog.Error("[CtxMgmt] Context cancelled before LLM attempt", "attempt", attempt, "error", err)
+			return nil, fmt.Errorf("context management LLM call failed: %w", err)
+		}
+
+		stream := llm.StreamLLM(
+			parent,
+			c.model,
+			llm.LLMContext{
+				Messages: llmMessages,
+				Tools:    c.convertToolsToLLM(tools),
+			},
+			c.apiKey,
+			2*time.Minute,
+		)
+
+		// 4. Extract tool calls from stream
+		var err error
+		toolCalls, err = c.extractToolCalls(parent, stream)
+		if err == nil {
+			lastErr = nil
+			break
+		}
+
+		lastErr = err
+		if !llm.IsRetryableError(err) {
+			slog.Error("[CtxMgmt] LLM call failed (non-retryable)", "attempt", attempt, "error", err)
+			return nil, fmt.Errorf("context management LLM call failed: %w", err)
+		}
+
+		if attempt < maxRetries {
+			backoff := time.Duration(attempt) * 2 * time.Second
+			slog.Warn("[CtxMgmt] LLM call failed (retryable), retrying",
+				"attempt", attempt,
+				"max_retries", maxRetries,
+				"backoff", backoff,
+				"error", err,
+			)
+			select {
+			case <-parent.Done():
+				return nil, fmt.Errorf("context management LLM call failed: %w", parent.Err())
+			case <-time.After(backoff):
+			}
+		}
+	}
+
+	if lastErr != nil {
+		slog.Error("[CtxMgmt] LLM call failed after all retries", "attempts", maxRetries, "error", lastErr)
+		return nil, fmt.Errorf("context management LLM call failed: %w", lastErr)
 	}
 
 	// 5. Execute tool calls and track results

--- a/pkg/compact/context_management_test.go
+++ b/pkg/compact/context_management_test.go
@@ -3,8 +3,13 @@ package compact
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
@@ -273,4 +278,193 @@ func llmModelStub() llm.Model {
 // executeToolCallsForTest is a test helper that exposes executeToolCalls for testing
 func (c *ContextManager) executeToolCallsForTest(toolCalls []llm.ToolCall, tools []context_mgmt.Tool) (int, bool) {
 	return c.executeToolCalls(context.Background(), toolCalls, tools)
+}
+
+// sseResponse builds a Server-Sent Events response that returns an
+// LLM "no_action" tool call, which is the simplest valid context-mgmt response.
+func sseNoActionResponse() string {
+	// Simulate an OpenAI-compatible streaming response that calls no_action.
+	chunks := []string{
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_noaction","type":"function","function":{"name":"no_action","arguments":""}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+	}
+	return strings.Join(chunks, "\n\n") + "\n\n"
+}
+
+func TestCompactWithCtx_RetriesOn500ThenSucceeds(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			// First attempt: return 500
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, `{"error":{"message":"Operation failed"}}`)
+			return
+		}
+		// Second attempt: return success with no_action tool call
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, sseNoActionResponse())
+	}))
+	defer server.Close()
+
+	model := llm.Model{
+		ID:            "test-model",
+		ContextWindow: 200000,
+		BaseURL:       server.URL,
+		API:           "openai",
+	}
+
+	agentCtx := agentctx.NewAgentContext("system")
+	for i := 0; i < 10; i++ {
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("hello"))
+	}
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 20
+
+	ctxManager := NewContextManager(DefaultContextManagerConfig(), model, "test-key", 200000, "system", nil)
+
+	// Use short max retries and backoff via a child context with timeout
+	result, err := ctxManager.CompactWithCtx(context.Background(), agentCtx)
+
+	if err != nil {
+		t.Fatalf("expected success after retry, got error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Fatalf("expected 2 attempts (1 fail + 1 success), got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestCompactWithCtx_AllRetriesExhausted(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, `{"error":{"message":"Operation failed"}}`)
+	}))
+	defer server.Close()
+
+	model := llm.Model{
+		ID:            "test-model",
+		ContextWindow: 200000,
+		BaseURL:       server.URL,
+		API:           "openai",
+	}
+
+	agentCtx := agentctx.NewAgentContext("system")
+	for i := 0; i < 10; i++ {
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("hello"))
+	}
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 20
+
+	ctxManager := NewContextManager(DefaultContextManagerConfig(), model, "test-key", 200000, "system", nil)
+
+	result, err := ctxManager.CompactWithCtx(context.Background(), agentCtx)
+
+	if err == nil {
+		t.Fatal("expected error when all retries exhausted, got nil")
+	}
+	if result != nil {
+		t.Fatal("expected nil result on failure")
+	}
+	if !strings.Contains(err.Error(), "context management LLM call failed") {
+		t.Fatalf("error should wrap with context management prefix, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error should mention 500 status, got: %v", err)
+	}
+	if atomic.LoadInt32(&attempts) != 3 {
+		t.Fatalf("expected 3 attempts (all failed), got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestCompactWithCtx_NonRetryableErrorNotRetried(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		// 401 Unauthorized — non-retryable
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintf(w, `{"error":{"message":"Invalid API key"}}`)
+	}))
+	defer server.Close()
+
+	model := llm.Model{
+		ID:            "test-model",
+		ContextWindow: 200000,
+		BaseURL:       server.URL,
+		API:           "openai",
+	}
+
+	agentCtx := agentctx.NewAgentContext("system")
+	for i := 0; i < 10; i++ {
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("hello"))
+	}
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 20
+
+	ctxManager := NewContextManager(DefaultContextManagerConfig(), model, "test-key", 200000, "system", nil)
+
+	result, err := ctxManager.CompactWithCtx(context.Background(), agentCtx)
+
+	if err == nil {
+		t.Fatal("expected error for 401, got nil")
+	}
+	if result != nil {
+		t.Fatal("expected nil result on failure")
+	}
+	if atomic.LoadInt32(&attempts) != 1 {
+		t.Fatalf("expected 1 attempt (non-retryable), got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestCompactWithCtx_ContextCancellationStopsRetry(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, `{"error":{"message":"Operation failed"}}`)
+	}))
+	defer server.Close()
+
+	model := llm.Model{
+		ID:            "test-model",
+		ContextWindow: 200000,
+		BaseURL:       server.URL,
+		API:           "openai",
+	}
+
+	agentCtx := agentctx.NewAgentContext("system")
+	for i := 0; i < 10; i++ {
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("hello"))
+	}
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 20
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after first attempt completes (the backoff sleep will detect cancellation)
+	go func() {
+		time.Sleep(1 * time.Second)
+		cancel()
+	}()
+
+	ctxManager := NewContextManager(DefaultContextManagerConfig(), model, "test-key", 200000, "system", nil)
+
+	result, err := ctxManager.CompactWithCtx(ctx, agentCtx)
+
+	if err == nil {
+		t.Fatal("expected error due to context cancellation, got nil")
+	}
+	if result != nil {
+		t.Fatal("expected nil result on cancellation")
+	}
+	// Should have made at most 2 attempts (first fail, then cancelled during backoff)
+	n := atomic.LoadInt32(&attempts)
+	if n > 2 {
+		t.Fatalf("expected at most 2 attempts before cancellation, got %d", n)
+	}
 }

--- a/pkg/llm/errors.go
+++ b/pkg/llm/errors.go
@@ -131,6 +131,28 @@ func IsRateLimit(err error) bool {
 	return looksLikeRateLimit(err.Error())
 }
 
+// IsRetryableError reports whether an error represents a transient failure
+// that is worth retrying (HTTP 429, 500, 502, 503, 504).
+func IsRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Rate-limit errors are always retryable.
+	var rle *RateLimitError
+	if errors.As(err, &rle) {
+		return true
+	}
+	// Generic API errors: retry on server errors and 429.
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case 429, 500, 502, 503, 504:
+			return true
+		}
+	}
+	return false
+}
+
 // RetryAfter returns provider suggested retry delay for rate-limit errors.
 func RetryAfter(err error) time.Duration {
 	if err == nil {

--- a/pkg/llm/errors_test.go
+++ b/pkg/llm/errors_test.go
@@ -44,6 +44,35 @@ func TestIsContextLengthExceeded(t *testing.T) {
 	}
 }
 
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{"nil error", nil, false},
+		{"500 server error", &APIError{StatusCode: 500, Message: "internal"}, true},
+		{"502 bad gateway", &APIError{StatusCode: 502, Message: "bad gateway"}, true},
+		{"503 service unavailable", &APIError{StatusCode: 503, Message: "unavailable"}, true},
+		{"504 gateway timeout", &APIError{StatusCode: 504, Message: "timeout"}, true},
+		{"429 rate limit via APIError", &APIError{StatusCode: 429, Message: "rate limited"}, true},
+		{"429 via RateLimitError", &RateLimitError{StatusCode: 429, Message: "rate limited"}, true},
+		{"400 bad request", &APIError{StatusCode: 400, Message: "bad request"}, false},
+		{"401 unauthorized", &APIError{StatusCode: 401, Message: "unauthorized"}, false},
+		{"403 forbidden", &APIError{StatusCode: 403, Message: "forbidden"}, false},
+		{"404 not found", &APIError{StatusCode: 404, Message: "not found"}, false},
+		{"generic error", errors.New("something else"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsRetryableError(tt.err)
+			if got != tt.retryable {
+				t.Errorf("IsRetryableError(%v) = %v, want %v", tt.err, got, tt.retryable)
+			}
+		})
+	}
+}
+
 func TestClassifyAPIErrorRateLimit(t *testing.T) {
 	err := ClassifyAPIErrorWithRetryAfter(429, `{"error":{"message":"Rate limit reached"}}`, 3*time.Second)
 


### PR DESCRIPTION
## Problem

When auto-compaction triggers and the context management LLM call hits a 500 error from the API provider, the error propagates up without any retry. This makes a transient 500 error fatal to the compaction process, and the agent cannot recover.

## Changes

### 1. `pkg/llm/errors.go` — Add `IsRetryableError()` helper
- Identifies retryable errors by checking status codes 429, 500, 502, 503, 504
- Handles both `*APIError` and `*RateLimitError` types
- Non-retryable errors (400, 401, 403, 404, etc.) return false

### 2. `pkg/compact/context_management.go` — Add retry loop in `CompactWithCtx()`
- Wraps the `StreamLLM` + `extractToolCalls` call in a retry loop (max 3 attempts)
- Uses exponential backoff (2s, 4s) between retries
- Respects context cancellation between retries
- Only retries on retryable errors; non-retryable errors fail immediately
- Logs each retry attempt with attempt number, backoff, and error

### 3. Tests
- `pkg/llm/errors_test.go` — `TestIsRetryableError` with all status codes
- `pkg/compact/context_management_test.go` — 4 new tests:
  - `TestCompactWithCtx_RetriesOn500ThenSucceeds` — 500 on first, success on second
  - `TestCompactWithCtx_AllRetriesExhausted` — persistent 500, all 3 retries fail
  - `TestCompactWithCtx_NonRetryableErrorNotRetried` — 401 returns immediately
  - `TestCompactWithCtx_ContextCancellationStopsRetry` — cancellation during backoff

## Test Results

All existing tests pass + 4 new retry tests pass.