### PR TITLE
feat(read): guide model to search-first instead of sequential pagination

### DIFF
--- a/pkg/tools/read.go
+++ b/pkg/tools/read.go
@@ -41,7 +41,7 @@ func (t *ReadTool) Name() string {
 
 // Description returns the tool description.
 func (t *ReadTool) Description() string {
-	return "Read the contents of a file. Supports text files. Use offset and limit to read specific line ranges."
+		return "Read the contents of a file. Supports text files. Use offset and limit to read specific line ranges. For large or unfamiliar files, prefer grep to locate relevant sections first, then read targeted ranges with offset/limit rather than reading the entire file sequentially."
 }
 
 // Parameters returns the JSON Schema for the tool parameters.
@@ -151,9 +151,14 @@ func (t *ReadTool) Execute(ctx context.Context, args map[string]any) ([]agentctx
 		header = fmt.Sprintf("[%d lines above omitted. Use offset=1, limit=%d to read from start.]\n\n",
 			offset-1, offset-1)
 	}
-	if end < totalLines {
-		footer = fmt.Sprintf("\n\n[%d more lines below. Use offset=%d to continue reading.]",
-			totalLines-end, end+1)
+		if end < totalLines {
+		remaining := totalLines - end
+		footer = fmt.Sprintf("\n\n[%d more lines below. Use grep to find specific patterns, or offset=%d to continue reading.]",
+			remaining, end+1)
+		if remaining > 500 {
+			footer = fmt.Sprintf("\n\n[%d more lines below. Consider using grep to locate specific content, or offset=%d to continue reading.]",
+				remaining, end+1)
+		}
 	}
 
 	output = header + output + footer


### PR DESCRIPTION

## Problem

Subagents reading large files (2000+ lines) consume excessive tokens by reading page-by-page (offset=1→101→201→...). A single 2000-line file can trigger 20+ read calls.

Root cause: the read tool's truncation footer only offered one path forward: `use offset=X to continue reading`. Models dutifully followed this instruction.

## Changes

1. **Tool description** — added guidance to prefer grep for large/unfamiliar files before reading
2. **Truncation footer** — offers grep as the primary option, offset as fallback
3. **Stronger hint** for very large remaining content (>500 lines)

## Test plan
- [x] All existing read tests pass
- [x] `go build ./...` compiles cleanly
