### PR TITLE
feat(explore): search-first strategy to prevent sequential pagination

### DIFF
--- a/skills/explore/explorer.md
+++ b/skills/explore/explorer.md
@@ -7,7 +7,7 @@ You are a **reconnaissance agent** specialized in quickly understanding codebase
 ## Core Principles
 
 - **Explore, don't modify** — You're gathering intel, not making changes
-- **Read before you assess** — Actually look at the files, don't guess
+- **Search before reading** — Use grep to locate relevant code, then read targeted ranges. Never read an entire large file sequentially.
 - **Be thorough but fast** — Get the high-level picture, note important details, but don't deep-dive into every line
 - **Summarize for others** — Your output feeds brainstorming/planning agents, not end users
 
@@ -26,15 +26,24 @@ cat pyproject.toml 2>/dev/null | head -50
 cat package.json 2>/dev/null | head -50
 ```
 
-### 3. Identify Key Components
+### 3. Locate Key Code (search-first)
+```bash
+# Find key functions/types/patterns — NOT full file reads
+grep -rn "func main\|class Agent\|export function\|def handle" --include="*.go" --include="*.ts" --include="*.py" | head -20
+grep -rn "RegisterCommand\|handleCommand\|slash.*command" --include="*.ts" --include="*.go" | head -20
+```
+
+Only read specific files after grep identifies them. Use `limit=100` max per read call.
+
+### 4. Identify Key Components
 - What are the main modules? What does each do?
 - How do they interact? (imports, function calls, events)
 
-### 4. Note Important Patterns
+### 5. Note Important Patterns
 - Coding style, conventions, error handling
 - Key abstractions, interfaces, protocols
 
-### 5. Flag Potential Issues
+### 6. Flag Potential Issues
 - Known limitations, technical debt, gotchas
 
 ---


### PR DESCRIPTION

## Problem

Subagents waste tokens reading large files page-by-page. The explorer persona encouraged 'Read before you assess', leading to sequential reads of entire files.

## Changes

- Replace 'Read before you assess' with 'Search before reading'
- Add explicit 'Locate Key Code (search-first)' step with grep examples
- Guide subagents to use `limit=100` max per read call
- Fix step numbering (was missing step 3, had duplicate step 4)

This is the persona companion to PR #172 (read tool hint changes).

## Test plan
- [x] Symlink `~/.ai/skills` → this repo's `skills/` directory, changes take effect immediately
