### PR TITLE
fix(run): make /model list models and support index selection

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -1945,16 +1945,63 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	// /model-select → same logic as /model
 	registerAlias("model-select", "Select a model", "model")
 
-	// /model — no args: cycle model; with args: set model
-	server.RegisterSlash("model", "Set or cycle the active model", func(args string) (any, error) {
+	// /model — no args: list models and mark current; with args: select model by index or id
+	server.RegisterSlash("model", "List models or set the active model", func(args string) (any, error) {
 		arg := strings.TrimSpace(args)
 		if arg == "" {
-			h, ok := server.GetSlashHandler("cycle_model")
-			if !ok {
-				return nil, fmt.Errorf("unknown command: cycle_model")
+			specs, modelsPath, err := loadModelSpecs(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("load models from %s: %w", modelsPath, err)
 			}
-			return h("")
+			specs = filterModelSpecsWithKeys(specs)
+			if len(specs) == 0 {
+				authPath, _ := config.GetDefaultAuthPath()
+				return nil, fmt.Errorf("no models available (missing API keys?). Set provider keys or update %s", authPath)
+			}
+
+			models := make([]rpc.ModelInfo, 0, len(specs))
+			currentIndex := -1
+			for i, spec := range specs {
+				models = append(models, modelInfoFromSpec(spec))
+				if spec.Provider == model.Provider && spec.ID == model.ID {
+					currentIndex = i
+				}
+			}
+
+			return map[string]any{
+				"models":       models,
+				"currentIndex": currentIndex,
+				"current": map[string]any{
+					"provider": model.Provider,
+					"id":       model.ID,
+				},
+			}, nil
 		}
+
+		if idx, err := strconv.Atoi(arg); err == nil {
+			specs, modelsPath, err := loadModelSpecs(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("load models from %s: %w", modelsPath, err)
+			}
+			specs = filterModelSpecsWithKeys(specs)
+			if len(specs) == 0 {
+				authPath, _ := config.GetDefaultAuthPath()
+				return nil, fmt.Errorf("no models available (missing API keys?). Set provider keys or update %s", authPath)
+			}
+			if idx < 0 || idx >= len(specs) {
+				return nil, fmt.Errorf("model index out of range")
+			}
+			arg = fmt.Sprintf("%s %s", specs[idx].Provider, specs[idx].ID)
+		} else if strings.Contains(arg, "/") {
+			parts := strings.SplitN(arg, "/", 2)
+			provider := strings.TrimSpace(parts[0])
+			modelID := strings.TrimSpace(parts[1])
+			if provider == "" || modelID == "" {
+				return nil, fmt.Errorf("invalid model selector: %s", arg)
+			}
+			arg = fmt.Sprintf("%s %s", provider, modelID)
+		}
+
 		h, ok := server.GetSlashHandler("set_model")
 		if !ok {
 			return nil, fmt.Errorf("unknown command: set_model")

--- a/pkg/run/conv.go
+++ b/pkg/run/conv.go
@@ -531,6 +531,11 @@ func parseResponseEvent(evt map[string]any) *FormattedEvent {
 		return renderSessions(dataJSON)
 	}
 
+	// /model (list), /get_available_models → {models: [...]}
+	if _, hasModels := dataRaw["models"]; hasModels {
+		return renderModelList(dataJSON)
+	}
+
 	// /model, /cycle_model → {model: {...}, thinkingLevel: ...}
 	if _, hasModel := dataRaw["model"]; hasModel {
 		return renderModel(dataJSON)
@@ -894,6 +899,62 @@ func renderModel(dataJSON []byte) *FormattedEvent {
 	provider := result.Model.Provider
 	id := result.Model.ID
 	return &FormattedEvent{Kind: KindMeta, Text: fmt.Sprintf("Model: %s/%s (%s)", provider, name, id)}
+}
+
+// renderModelList renders /model (no args) and /get_available_models output.
+func renderModelList(dataJSON []byte) *FormattedEvent {
+	var payload struct {
+		Models       []rpc.ModelInfo `json:"models"`
+		CurrentIndex *int            `json:"currentIndex,omitempty"`
+		Current      *struct {
+			Provider string `json:"provider"`
+			ID       string `json:"id"`
+		} `json:"current,omitempty"`
+	}
+	if err := json.Unmarshal(dataJSON, &payload); err != nil {
+		return fallbackJSON(dataJSON)
+	}
+	if len(payload.Models) == 0 {
+		return &FormattedEvent{Kind: KindMeta, Text: "no models available"}
+	}
+
+	currentIndex := -1
+	if payload.CurrentIndex != nil {
+		currentIndex = *payload.CurrentIndex
+	} else if payload.Current != nil {
+		for i, m := range payload.Models {
+			if m.Provider == payload.Current.Provider && m.ID == payload.Current.ID {
+				currentIndex = i
+				break
+			}
+		}
+	}
+
+	maxID := 0
+	for _, m := range payload.Models {
+		id := fmt.Sprintf("%s/%s", m.Provider, m.ID)
+		if len(id) > maxID {
+			maxID = len(id)
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("Available Models\n")
+	for i, m := range payload.Models {
+		ref := fmt.Sprintf("%s/%s", m.Provider, m.ID)
+		name := m.Name
+		if name == "" {
+			name = m.ID
+		}
+		current := ""
+		if i == currentIndex {
+			current = " [current]"
+		}
+		b.WriteString(fmt.Sprintf("%d: %-*s - %s%s\n", i, maxID, ref, name, current))
+	}
+	b.WriteString("Usage: /model <index>\n")
+
+	return &FormattedEvent{Kind: KindMeta, Text: strings.TrimRight(b.String(), "\n")}
 }
 
 // renderSettings renders /show settings output, matching ai-win showSettings.

--- a/pkg/run/conv_test.go
+++ b/pkg/run/conv_test.go
@@ -191,6 +191,26 @@ func TestParseEvent_Response_Commands(t *testing.T) {
 	}
 }
 
+func TestParseEvent_Response_ModelList(t *testing.T) {
+	input := `{"type":"response","command":"prompt","success":true,"data":{"models":[{"provider":"zai","id":"glm-4.5","name":"GLM 4.5"},{"provider":"openai","id":"gpt-4.1","name":"GPT-4.1"}],"currentIndex":1}}`
+	evt := ParseEvent(input)
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if evt.Kind != KindMeta {
+		t.Fatalf("expected KindMeta, got %s", evt.Kind)
+	}
+	if !strings.Contains(evt.Text, "Available Models") {
+		t.Fatalf("expected model list header, got: %s", evt.Text)
+	}
+	if !strings.Contains(evt.Text, "1: openai/gpt-4.1 - GPT-4.1 [current]") {
+		t.Fatalf("expected current marker on selected model, got: %s", evt.Text)
+	}
+	if !strings.Contains(evt.Text, "Usage: /model <index>") {
+		t.Fatalf("expected usage hint, got: %s", evt.Text)
+	}
+}
+
 func TestParseEvent_AgentEnd_Success(t *testing.T) {
 	evt := ParseEvent(`{"type":"agent_end","messages":[]}`)
 	if evt == nil {
@@ -468,7 +488,6 @@ func TestParseEvent_WhitespaceAroundJSON(t *testing.T) {
 		t.Fatalf("expected KindMeta, got %s", evt.Kind)
 	}
 }
-
 // --- Tests for thinking content filtering ---
 
 func TestParseEvent_ThinkingDelta_EmptyString(t *testing.T) {


### PR DESCRIPTION
## Summary
- change `/model` to list available models when called without args
- mark the currently active model in the returned list
- support `/model N` index-based selection (0-based), aligned with claw-style flow
- keep compatibility for `/model provider/model-id`
- update `ai run` response rendering to display model list output
- add parser test for model list rendering

## Validation
- go test ./pkg/run ./cmd/ai
