### PR TITLE
Fix: /resume <index> resolves numeric index to session ID

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -913,6 +913,25 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 			return nil, fmt.Errorf("session id is required")
 		}
 
+		// Resolve numeric index to session ID
+		if idx, err := strconv.Atoi(id); err == nil {
+			sessions, listErr := sessionMgr.ListSessions()
+			if listErr != nil {
+				return nil, fmt.Errorf("failed to list sessions: %w", listErr)
+			}
+			// Reverse to match display order (index 0 = oldest, as shown in renderSessions)
+			// ListSessions returns newest-first; renderSessions shows index 0 = oldest
+			reversed := make([]session.SessionMeta, len(sessions))
+			for i, s := range sessions {
+				reversed[len(sessions)-1-i] = s
+			}
+			if idx < 0 || idx >= len(reversed) {
+				return nil, fmt.Errorf("invalid session index %d (valid range: 0-%d)", idx, len(reversed)-1)
+			}
+			id = reversed[idx].ID
+			slog.Info("Resolved session index to ID", "index", idx, "id", id)
+		}
+
 		// Treat absolute or relative path as session file
 		if strings.Contains(id, string(os.PathSeparator)) || strings.HasSuffix(id, ".jsonl") {
 			sessionPath, err := normalizeSessionPath(id)


### PR DESCRIPTION
## Workpad

```text
geniusdeMBP:/Users/genius/.symphony/workspaces/7bbc0167-ec6e-42e5-bdbf-bc6fad3bb8db@cf471ae
```

### Plan

- [x] 1. Reproduce and understand the issue
  - [x] 1.1 Read switch_session handler in rpc_handlers.go
  - [x] 1.2 Read list_sessions handler to understand order
  - [x] 1.3 Read ListSessions() to understand sort order
  - [x] 1.4 Read renderSessions to understand display order
  - [x] 1.5 Read win client switchSessionFromInput as reference
- [ ] 2. Implement the fix
  - [ ] 2.1 Add numeric index resolution in switch_session handler
- [ ] 3. Verify
  - [ ] 3.1 `go build ./cmd/ai` compiles
  - [ ] 3.2 `go test ./cmd/ai/ -v` passes
  - [ ] 3.3 `go test ./pkg/session/ -v` passes
- [ ] 4. Commit, push, create PR
- [ ] 5. Self-review

### Acceptance Criteria

- [ ] `/resume 2` resolves numeric index to session ID using same order as displayed by `/resume`
- [ ] Index 0 = oldest session (matching display order)
- [ ] Out-of-range index returns clear error
- [ ] No changes outside `cmd/ai/rpc_handlers.go`
- [ ] All tests pass

### Validation

- [ ] targeted tests: `go build ./cmd/ai && go test ./cmd/ai/ -v && go test ./pkg/session/ -v`

### Notes

- ListSessions() returns newest-first (sorted by UpdatedAt desc)
- list_sessions handler reverses to get oldest-first display (index 0 = oldest)
- renderSessions shows index 0, 1, 2... matching the reversed list
- Fix needs to apply same reversal when resolving index