### PR TITLE
feat(watch): add ctrl+f / ctrl+b keybindings for page down/up

### DIFF
--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -249,6 +249,12 @@ func (m watchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "q", "ctrl+c":
 			return m, tea.Quit
+		case "ctrl+f":
+			m.viewport.PageDown()
+			return m, nil
+		case "ctrl+b":
+			m.viewport.PageUp()
+			return m, nil
 		}
 
 	case tea.WindowSizeMsg:


### PR DESCRIPTION
## Summary

Adds `ctrl+f` (page down) and `ctrl+b` (page up) keybindings to the `ai watch` TUI.

These are standard Vim-style keybindings that users naturally expect to work alongside the existing `ctrl+u`/`ctrl+d` (half-page) and `f`/`b` (full-page) bindings.

## Changes

- `cmd/ai/watch.go`: Added `ctrl+f` → `viewport.PageDown()` and `ctrl+b` → `viewport.PageUp()` cases in the `watchModel.Update()` KeyMsg handler.

## Testing

- `go build ./cmd/ai` ✅
- `go test ./cmd/ai/` ✅ (all tests pass)
- Existing keybindings unaffected (q, ctrl+c, ctrl+u, ctrl+d, f, b, pgup, pgdown, space)