### PR TITLE
Fix: [BUG] ai watch TUI long lines overflow viewport with no word-wrap or horizontal scroll

### DIFF
--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -451,6 +451,12 @@ func (m runModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Enter input mode.
 			m.inputMode = true
 			return m, nil
+		case "left", "h":
+			m.viewport.ScrollLeft(scrollStep)
+			return m, nil
+		case "right", "l":
+			m.viewport.ScrollRight(scrollStep)
+			return m, nil
 		}
 	}
 

--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	ansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/tiancaiamao/ai/pkg/run"
 )
@@ -154,25 +155,53 @@ func newWatchModel(eventsPath, runID string, sinceOffset int64, machineMode bool
 	return m
 }
 
+// scrollStep is the number of columns to scroll horizontally.
+const scrollStep = 6
+
+// wrapContent wraps the raw content string to the given width,
+// preserving ANSI escape codes. Each line is wrapped independently.
+func wrapContent(raw string, width int) string {
+	if width <= 0 {
+		return raw
+	}
+	lines := strings.Split(raw, "\n")
+	var b strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if line == "" {
+			continue
+		}
+		b.WriteString(ansi.Wrap(line, width, ""))
+	}
+	return b.String()
+}
+
+// syncContent applies word-wrapping to the raw content and pushes it
+// to the viewport, then scrolls to the bottom.
+func (m *watchModel) syncContent() {
+	if !m.ready {
+		return
+	}
+	wrapped := wrapContent(m.content.String(), m.width)
+	m.viewport.SetContent(wrapped)
+	m.viewport.GotoBottom()
+}
+
 func (m *watchModel) appendContent(text string) {
 	m.endInline()
 	m.content.WriteString(text)
 	m.content.WriteString("\n")
 	m.lines++
-	if m.ready {
-		m.viewport.SetContent(m.content.String())
-		m.viewport.GotoBottom()
-	}
+	m.syncContent()
 }
 
 // appendInline appends text to the current line without a newline.
 // Used for streaming deltas (thinking, text) that build up a single line.
 func (m *watchModel) appendInline(text string) {
 	m.content.WriteString(text)
-	if m.ready {
-		m.viewport.SetContent(m.content.String())
-		m.viewport.GotoBottom()
-	}
+	m.syncContent()
 }
 
 // ensureRole transitions the streaming role, matching ai-win's writeStream.
@@ -229,10 +258,7 @@ func (m *watchModel) endInline() {
 		m.lines++
 		m.inlineActive = false
 		m.currentRole = ""
-		if m.ready {
-			m.viewport.SetContent(m.content.String())
-			m.viewport.GotoBottom()
-		}
+		m.syncContent()
 	}
 }
 
@@ -249,6 +275,12 @@ func (m watchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "q", "ctrl+c":
 			return m, tea.Quit
+		case "left", "h":
+			m.viewport.ScrollLeft(scrollStep)
+			return m, nil
+		case "right", "l":
+			m.viewport.ScrollRight(scrollStep)
+			return m, nil
 		}
 
 	case tea.WindowSizeMsg:
@@ -257,12 +289,13 @@ func (m watchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		headerHeight := 1 // status bar
 		if !m.ready {
 			m.viewport = viewport.New(msg.Width, msg.Height-headerHeight)
-			m.viewport.SetContent(m.content.String())
 			m.ready = true
 		} else {
 			m.viewport.Width = msg.Width
 			m.viewport.Height = msg.Height - headerHeight
 		}
+		// Re-wrap content to the new width.
+		m.syncContent()
 
 		case replayDone:
 		// Finished replaying history, switch to live mode.

--- a/cmd/ai/watch_test.go
+++ b/cmd/ai/watch_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWrapContent_PlainTextShortLine(t *testing.T) {
+	// Line shorter than width — no wrapping.
+	input := "hello world"
+	got := wrapContent(input, 80)
+	if got != input {
+		t.Errorf("expected %q, got %q", input, got)
+	}
+}
+
+func TestWrapContent_PlainTextLongLine(t *testing.T) {
+	// Line longer than width — should be wrapped.
+	input := strings.Repeat("abcdefghij ", 10) // 110 chars
+	got := wrapContent(input, 40)
+	for _, line := range strings.Split(got, "\n") {
+		// Each wrapped line should be at most ~40 visible chars.
+		// We allow some slack since word boundaries may not align exactly.
+		visible := stripAnsi(line)
+		if len(visible) > 50 {
+			t.Errorf("wrapped line too long (%d chars): %q", len(visible), visible)
+		}
+	}
+}
+
+func TestWrapContent_MultipleLines(t *testing.T) {
+	// Multiple short lines — should remain unchanged.
+	input := "line1\nline2\nline3"
+	got := wrapContent(input, 80)
+	if got != input {
+		t.Errorf("expected %q, got %q", input, got)
+	}
+}
+
+func TestWrapContent_EmptyString(t *testing.T) {
+	got := wrapContent("", 80)
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestWrapContent_ZeroWidth(t *testing.T) {
+	input := "some text"
+	got := wrapContent(input, 0)
+	if got != input {
+		t.Errorf("expected %q with zero width, got %q", input, got)
+	}
+}
+
+func TestWrapContent_WithANSI(t *testing.T) {
+	// ANSI styled text should be preserved and wrapped correctly.
+	// Simulate a styled line (lipgloss output).
+	styled := "\x1b[36m" + strings.Repeat("tool output line ", 10) + "\x1b[0m"
+	got := wrapContent(styled, 40)
+
+	// The result should still contain the ANSI codes.
+	if !strings.Contains(got, "\x1b[36m") {
+		t.Error("expected ANSI escape code \\x1b[36m to be preserved")
+	}
+	if !strings.Contains(got, "\x1b[0m") {
+		t.Error("expected ANSI reset \\x1b[0m to be preserved")
+	}
+
+	// Should have been wrapped into multiple lines.
+	if !strings.Contains(got, "\n") {
+		t.Error("expected wrapped content to contain newlines")
+	}
+}
+
+func TestWrapContent_MixedANSIAndPlain(t *testing.T) {
+	// Mix of styled and plain lines.
+	input := "plain line\n\x1b[31mred styled line that is quite long and should be wrapped at word boundaries\x1b[0m\nanother plain"
+	got := wrapContent(input, 30)
+
+	lines := strings.Split(got, "\n")
+	if len(lines) < 3 {
+		t.Errorf("expected at least 3 lines, got %d: %q", len(lines), got)
+	}
+}
+
+func TestWrapContent_CJKWideCharacters(t *testing.T) {
+	// CJK characters are double-width, wrapping should account for that.
+	input := strings.Repeat("你好世界", 10) // 40 wide chars = 80 visible columns
+	got := wrapContent(input, 40)
+
+	// Should have been wrapped.
+	if !strings.Contains(got, "\n") {
+		t.Error("expected CJK content to be wrapped")
+	}
+}
+
+func TestWrapContent_PreservesTrailingNewlines(t *testing.T) {
+	// Content ending with newline should be handled.
+	input := "line1\nline2\n"
+	got := wrapContent(input, 80)
+	// The trailing newline produces an empty string after split, which is skipped.
+	if !strings.HasPrefix(got, "line1\nline2") {
+		t.Errorf("expected preserved content, got %q", got)
+	}
+}
+
+// stripAnsi removes ANSI escape sequences for measuring visible width.
+func stripAnsi(s string) string {
+	var result []byte
+	inEscape := false
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\x1b' {
+			inEscape = true
+			continue
+		}
+		if inEscape {
+			if (s[i] >= 'a' && s[i] <= 'z') || (s[i] >= 'A' && s[i] <= 'Z') {
+				inEscape = false
+			}
+			continue
+		}
+		result = append(result, s[i])
+	}
+	return string(result)
+}


### PR DESCRIPTION
## Workpad

```text
hostname:worktree@5bbf304
```

### Plan

- [ ] 1. Add ANSI-aware word-wrap helper function (`wrapLines`)
  - [ ] 1.1 Use `muesli/ansi` to measure visible width (strip ANSI for measurement)
  - [ ] 1.2 Wrap at word boundaries, preserve ANSI codes
- [ ] 2. Modify `watchModel` to use wrapped content for viewport
  - [ ] 2.1 Store raw content in `content *strings.Builder` (unchanged)
  - [ ] 2.2 Apply wrapping before `SetContent` calls
  - [ ] 2.3 Re-wrap on `WindowSizeMsg`
- [ ] 3. Add horizontal scroll key bindings
  - [ ] 3.1 `left`/`right` arrows for `watchModel.Update()`
  - [ ] 3.2 `left`/`right` arrows for `runModel.Update()` (normal mode only)
- [ ] 4. Tests
  - [ ] 4.1 Unit test for `wrapLines` with plain text
  - [ ] 4.2 Unit test for `wrapLines` with ANSI-styled text
  - [ ] 4.3 Unit test for `wrapLines` with CJK wide characters
- [ ] 5. Validation
  - [ ] `go vet ./cmd/ai/`
  - [ ] `go test ./cmd/ai/ -v`
  - [ ] `go build ./cmd/ai/`

### Acceptance Criteria

- [ ] Long lines wrap at viewport width automatically
- [ ] ANSI styling preserved after wrapping
- [ ] Horizontal scroll (left/right arrows) works as fallback
- [ ] Terminal resize re-wraps content
- [ ] Existing keybindings (q, ctrl+c, i) still work
- [ ] No regressions in `go test ./...`

### Validation

- [ ] targeted tests: `go test ./cmd/ai/ -v -run TestWrap`
- [ ] build check: `go build ./cmd/ai/`
- [ ] full regression: `go test ./... -count=1`

### Notes

- 2025-01-XX: Started implementation. Key insight: use raw content storage + wrap on SetContent. `muesli/ansi` already in go.sum. `charmbracelet/x/ansi` also available (newer, better API).