### PR TITLE
Fix: Change default no-arg behavior to print help instead of starting server

### DIFF
--- a/cmd/ai/main.go
+++ b/cmd/ai/main.go
@@ -44,9 +44,15 @@ func main() {
 	// Save original binary path before we mutate os.Args.
 	binPath := os.Args[0]
 
-	// If no arguments at all, or first arg looks like a flag, fall back to
-	// deprecated --mode based dispatch for backward compatibility.
-	if len(os.Args) < 2 || strings.HasPrefix(os.Args[1], "-") {
+	// If no arguments at all, print help text.
+	if len(os.Args) < 2 {
+		printUsage()
+		return
+	}
+
+	// If first arg looks like a flag, fall back to deprecated --mode
+	// based dispatch for backward compatibility.
+	if strings.HasPrefix(os.Args[1], "-") {
 		deprecatedModeDispatch()
 		return
 	}


### PR DESCRIPTION
## Workpad

```
hostname:/Users/genius/.symphony/workspaces/434df8be-04ff-4c06-b7df-77663938c657@<short-sha>
```

### Plan

- [x] 1. Investigate current behavior in `cmd/ai/main.go`
  - [x] 1.1 Found: `deprecatedModeDispatch()` called when `len(os.Args) < 2` or first arg starts with `-`
  - [x] 1.2 Found: deprecation warning printed, then RPC server starts
- [ ] 2. Implement fix: separate no-arg case from flag case in `main()`
  - [ ] 2.1 When `len(os.Args) < 2`: call `printUsage()` directly, no deprecation warning
  - [ ] 2.2 When first arg starts with `-`: still go through `deprecatedModeDispatch()` for backward compat
- [ ] 3. Add/update tests for no-arg behavior
- [ ] 4. Run all tests to verify nothing breaks
- [ ] 5. Commit, push, create PR

### Acceptance Criteria

- [ ] `ai` (no args) prints help text (same as `ai -h`)
- [ ] `ai serve` still starts the RPC server normally
- [ ] `ai -h` / `ai --help` still works
- [ ] No deprecation warning for the no-arg case (since it now shows help)
- [ ] Existing tests pass

### Validation

- [ ] targeted tests: `go test ./cmd/ai/... -v`
- [ ] manual: `go run ./cmd/ai` (should print help)
- [ ] manual: `go run ./cmd/ai -h` (should print help)
- [ ] manual: `go run ./cmd/ai --help` (should print help)

### Notes

- Root cause: `main()` routes `len(os.Args) < 2` to `deprecatedModeDispatch()` which prints warning + starts server
- Fix: Separate no-arg case from flag case; no-arg → printUsage(), flag → deprecatedModeDispatch()