### PR TITLE
fix: close stdin pipe before cmd.Wait() to prevent ai run hang on quit

### DIFF
--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -134,6 +134,10 @@ func runSubcommand(binPath string) {
 	}
 
 	// TUI exited — clean up subprocess.
+	// Close stdin pipe first so the internal goroutine in cmd.Wait() can exit.
+	// Without this, cmd.Wait() blocks forever on the pipe reader goroutine.
+	stdinWriter.Close()
+
 	cmd.Process.Signal(syscall.SIGINT)
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
@@ -148,7 +152,6 @@ func runSubcommand(binPath string) {
 			<-done
 		}
 	}
-	stdinWriter.Close()
 	eventsFile.Close()
 
 	// Update final status.


### PR DESCRIPTION
## Problem

When running `ai run`, after the agent finishes and the user presses `q` to quit, the TUI screen clears (alt screen exits) but the `ai run` process hangs forever and never exits.

## Root Cause

`cmd.Stdin` is set to an `io.PipeReader`. Go's `exec.Cmd` internally starts a goroutine that copies data from the PipeReader to the subprocess stdin pipe. When `cmd.Wait()` is called, it waits for this goroutine to finish.

However, `stdinWriter` (the PipeWriter end) was only closed **after** `cmd.Wait()`, creating a deadlock:
- `cmd.Wait()` blocks waiting for the pipe-copy goroutine to finish
- The pipe-copy goroutine blocks on `PipeReader.Read()` waiting for data
- Nobody closes `stdinWriter` to unblock the Read

## Fix

Move `stdinWriter.Close()` to **before** `cmd.Process.Signal(SIGINT)` and `cmd.Wait()`. This ensures the PipeReader receives EOF, the internal goroutine exits, and `cmd.Wait()` can return.

## Testing

- Reproduced the hang with `sample` showing the process blocked in `pthread_cond_wait`/`read`
- Verified the fix: `ai run --input "say hello"` → agent completes → press `q` → process exits cleanly
- All existing tests pass (`go test ./cmd/ai/ ./pkg/run/`)