### PR TITLE
Fix: [BUG] LLMContext not injected when update_llm_context called without compact

### DIFF
--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -58,7 +58,6 @@ This means:
 │  │  LLMContext: string          — task state (LLM-managed)  │ │
 │  │  RecentMessages: []AgentMessage                          │ │
 │  │  AgentState: *AgentState     — system metadata           │ │
-│  │  PostCompactRecovery: bool   — signal for next turn      │ │
 │  └─────────────────────────────────────────────────────────┘ │
 │                           │                                   │
 │                           ▼                                   │
@@ -127,7 +126,7 @@ type AgentContext struct {
     AgentState     *AgentState    // System-maintained metadata
 
     LastCompactionSummary string
-    PostCompactRecovery   bool       // Inject LLMContext after compact
+    LLMContext       string      // Structured context content (injected when non-empty)
 
     OnCompactEvent func(*CompactEventDetail) error
 }
@@ -255,7 +254,7 @@ The heavy action. Delegates to the full `compact.Compactor` which:
 3. Replaces `RecentMessages` with: summary message + kept recent messages
 4. Preserves `LLMContext` — never overwritten (it is managed by the LLM via `update_llm_context`)
 
-After compact, `PostCompactRecovery=true` is set, causing the next turn to inject `LLMContext` content into the LLM messages so the agent recovers task continuity.
+After compact, `LLMContext` is injected into the next LLM call so the agent recovers task continuity.
 
 ### 6.4 no_action (`pkg/tools/context_mgmt/no_action.go`)
 
@@ -392,7 +391,7 @@ threshold = contextWindow - systemPromptTokens - 3000(tool defs) - ReserveTokens
 
 4. **Append-only journal, periodic snapshots** — `messages.jsonl` is append-only. Checkpoints provide efficient recovery points. Reconstruction replays journal entries after checkpoint.
 
-5. **Post-compact recovery** — After compaction, `PostCompactRecovery=true` causes the next LLM call to inject `LLMContext` content so the agent recovers task continuity immediately.
+5. **LLM Context injection** — `LLMContext` content is always injected into LLM requests when non-empty, so the agent maintains task continuity after compaction or context updates.
 
 6. **Protected recent messages** — The last 5 messages are never truncated, ensuring the agent always has its most recent context.
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -367,8 +367,6 @@ func runInnerLoop(
 				// We just need to update the summary.
 				// Compact events are already appended via OnCompactEvent in the tools.
 				agentCtx.LastCompactionSummary = compacted.Summary
-				// Set flag to inject LLMContext for recovery on next request
-				agentCtx.PostCompactRecovery = true
 				after := len(agentCtx.RecentMessages)
 				compactionSpan.AddField("after_messages", after)
 				compactionSpan.End()
@@ -449,8 +447,6 @@ func runInnerLoop(
 						agentCtx.LastCompactionSummary = recoveryCompacted.Summary
 						// Compact events are already appended via OnCompactEvent in the tools.
 					}
-					// Set flag to inject LLMContext for recovery on next request
-					agentCtx.PostCompactRecovery = true
 					compactionSpan.AddField("after_messages", len(agentCtx.RecentMessages))
 					compactionSpan.End()
 					stream.Push(NewCompactionEndEvent(CompactionInfo{
@@ -840,14 +836,13 @@ func streamAssistantResponse(
 	// injected BEFORE the last user message for better LLM attention.
 	// Placing runtime_state close to the decision point improves context management.
 	//
-	// LLMContext content is only injected after compact (PostCompactRecovery = true) for recovery.
+	// LLMContext content is always injected when non-empty.
 	// runtime_state telemetry is ALWAYS injected from turn 1 so path info is available immediately.
 
-	// Block A: LLMContext content injection — only after compact recovery.
+	// Block A: LLMContext content injection — whenever non-empty.
 	var llmContextContent string
-	if agentCtx.LLMContext != "" && agentCtx.PostCompactRecovery {
+	if agentCtx.LLMContext != "" {
 		llmContextContent = agentCtx.LLMContext
-		agentCtx.PostCompactRecovery = false
 	}
 
 	// Block B: runtime_state telemetry — always, from turn 1.

--- a/pkg/agent/loop_stream_integration_test.go
+++ b/pkg/agent/loop_stream_integration_test.go
@@ -281,8 +281,6 @@ Test task for post-compact recovery`
 
 	agentCtx := agentctx.NewAgentContext("static system prompt")
 	agentCtx.LLMContext = llmContextContent
-	// Simulate post-compact recovery state
-	agentCtx.PostCompactRecovery = true
 	agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("continue"))
 
 	config := &LoopConfig{
@@ -323,12 +321,7 @@ Test task for post-compact recovery`
 	}
 
 	if !foundLLMContext {
-		t.Fatalf("expected llm_context to be injected after compact (PostCompactRecovery=true)")
-	}
-
-	// Verify flag was reset
-	if agentCtx.PostCompactRecovery {
-		t.Fatalf("expected PostCompactRecovery to be reset to false after injection")
+		t.Fatalf("expected llm_context to be injected whenever LLMContext is non-empty")
 	}
 }
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -23,10 +23,6 @@ type AgentContext struct {
 	// Compaction state
 	LastCompactionSummary string `json:"lastCompactionSummary,omitempty"` // Last compaction summary for incremental updates
 
-	// PostCompactRecovery indicates that overview.md should be injected for recovery after compact.
-	// Set after compact completes, reset after injection.
-	PostCompactRecovery bool `json:"-"`
-
 	// OnMessagesChanged is called when messages are modified (e.g., after compact).
 	// This allows persistence to session storage.
 	OnMessagesChanged func() error `json:"-"`


### PR DESCRIPTION
## Bug Fix

LLMContext was only injected into the next LLM request when `PostCompactRecovery == true`, but this flag was only set after compact operations. When Context Manager calls `update_llm_context` independently (without compact), the content was stored but never injected — silently discarded.

## Changes

- **`pkg/context/context.go`**: Remove `PostCompactRecovery` field from `AgentContext`
- **`pkg/agent/loop.go`**: Remove `PostCompactRecovery` gate — inject LLMContext whenever non-empty
- **`pkg/agent/loop_stream_integration_test.go`**: Update test to verify injection without the flag
- **`docs/context-management.md`**: Update documentation to reflect new behavior

## Verification

```bash
go test ./pkg/agent/ -v -run TestStreamAssistantResponse_LLMContextInjectedAfterCompact  # PASS
go test ./pkg/agent/ -v  # All 45+ tests PASS
go build ./...  # Clean build
```