### PR TITLE
fix(ag): non-blocking spawn, status fixes, poll command

### DIFF
--- a/skills/debate/SKILL.md
+++ b/skills/debate/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: debate
+description: Orchestrate a real-time alternating debate between two subagents. Judge controls rounds via prompt, agents signal completion via channel.
+---
+
+# Debate Skill
+
+## Overview
+
+Run a structured debate between two agents (proposer FOR, opposer AGAINST). You are the judge — you control rounds by prompting each agent in turn. Agents write to a shared file and signal completion via `ag send`. You block on `ag recv --wait`.
+
+**Key optimization:** R1 gives full context (working directory, file paths, reference links) so the agent doesn't waste time discovering what you already know. R2+ inlines the opponent's argument in the prompt so the agent doesn't re-read the debate file.
+
+## Setup
+
+```bash
+DEBATE_TOPIC="YOUR TOPIC HERE"
+DEBATE_CONTEXT="- Working directory: ...
+- Key file paths: ...
+- Reference links: ..."
+ROUNDS=3
+DEBATE_FILE="/tmp/debate-$(date +%s).md"
+SYSTEM_DIR="/Users/genius/.ai/skills/debate/references"
+
+# Clean previous
+ag agent rm proposer --force 2>/dev/null
+ag agent rm opposer --force 2>/dev/null
+ag channel rm judge 2>/dev/null
+
+# Create judge channel
+ag channel create judge
+
+# Spawn agents (non-blocking, returns in ~20ms)
+ag agent spawn proposer --system "@$SYSTEM_DIR/proposer-system.md"
+ag agent spawn opposer --system "@$SYSTEM_DIR/opposer-system.md"
+```
+
+## Debate Loop
+
+```bash
+# ── Round 1: Proposer opens (full context, reads source code) ──
+ag agent prompt proposer "Working directory: /path/to/project
+
+DEBATE TOPIC: $DEBATE_TOPIC
+
+Context:
+$DEBATE_CONTEXT
+
+Write your opening argument FOR feasibility to $DEBATE_FILE.
+Format:
+
+## Round 1 — Proposer
+
+Ground every claim in specific code. When done, run: ag send judge proposer-r1-done"
+
+ag recv judge --wait --timeout 600
+
+# ── Round 1: Opposer counters (reads debate file for proposer argument + source code) ──
+ag agent prompt opposer "Working directory: /path/to/project
+
+DEBATE TOPIC: $DEBATE_TOPIC
+
+Context:
+$DEBATE_CONTEXT
+
+Read $DEBATE_FILE for the proposer's opening argument.
+Then append your counter-argument AGAINST feasibility.
+Format:
+
+## Round 1 — Opposer
+
+Address the proposer's specific claims. When done, run: ag send judge opposer-r1-done"
+
+ag recv judge --wait --timeout 600
+
+# ── Rounds 2+: Inline opponent argument, no file re-read ──
+for ROUND in $(seq 2 $ROUNDS); do
+  # Extract opponent's latest argument from debate file
+  OPPONENT_ARG=$(sed -n "/^## Round $((ROUND-1)) — Opposer/,/^## Round/p" $DEBATE_FILE | head -n -1)
+
+  ag agent prompt proposer "Working directory: /path/to/project
+
+Here is the opposer's Round $((ROUND-1)) argument:
+
+$OPPONENT_ARG
+
+---
+
+Rebut directly. Use your earlier code analysis — do NOT re-read source files.
+Append to $DEBATE_FILE:
+
+## Round $ROUND — Proposer
+
+When done, run: ag send judge proposer-r${ROUND}-done"
+
+  ag recv judge --wait --timeout 600
+
+  if [ "$ROUND" -lt "$ROUNDS" ]; then
+    MY_ARG=$(sed -n "/^## Round $ROUND — Proposer/,/^## Round/p" $DEBATE_FILE | head -n -1)
+
+    ag agent prompt opposer "Working directory: /path/to/project
+
+Here is the proposer's Round $ROUND argument:
+
+$MY_ARG
+
+---
+
+Counter directly. Use your earlier code analysis — do NOT re-read source files.
+Append to $DEBATE_FILE:
+
+## Round $ROUND — Opposer
+
+When done, run: ag send judge opposer-r${ROUND}-done"
+
+    ag recv judge --wait --timeout 600
+  fi
+done
+
+# ── Read result & cleanup ──
+cat $DEBATE_FILE
+ag agent rm proposer --force
+ag agent rm opposer --force
+ag channel rm judge
+```
+
+## How It Works
+
+```
+Judge                              Proposer              Opposer
+  │                                   │                      │
+  ├── prompt (full ctx + topic) ─────►│                      │
+  │                                   ├── read source (once) │
+  │                                   ├── write R1 to file   │
+  │   recv judge ◄───────────────────┤── ag send "done"     │
+  │                                   │                      │
+  ├── prompt (full ctx + R1 file) ──────────────────────────►│
+  │                                   │                      ├── read R1 + source (once)
+  │                                   │                      ├── append R1 to file
+  │   recv judge ◄──────────────────────────────────────────┤── ag send "done"
+  │                                   │                      │
+  ├── prompt (inline R1 opponent) ──►│                      │
+  │                                   ├── rebut directly     │
+  │   recv judge ◄───────────────────┤── ag send "done"     │
+  │                                   │                      │
+  ├── prompt (inline R2 opponent) ──────────────────────────►│
+  │  ... no file re-read after R1 ... │                      │
+```
+
+**R1:** Each agent reads source code once.
+**R2+:** Opponent argument inlined in prompt. No file re-read. Fast rebuttal.
+
+## Verdict
+
+After the debate, read the transcript and synthesize:
+
+```markdown
+## Debate Verdict
+
+**Topic:** <topic>
+**Conclusion:** <feasible | not feasible | feasible with conditions>
+
+### Key Arguments
+
+| Round | Proposer (正方) | Opposer (反方) |
+|-------|----------------|----------------|
+| 1     | <key point>    | <key rebuttal> |
+| ...   | ...            | ...            |
+
+### Decisive Factor
+<what tipped the balance>
+```
+
+## File Assets
+
+- `references/proposer-system.md` — "You argue FOR feasibility"
+- `references/opposer-system.md` — "You argue AGAINST feasibility"

--- a/skills/debate/references/opposer-system.md
+++ b/skills/debate/references/opposer-system.md
@@ -1,0 +1,11 @@
+You are the **OPPOSER (反方)** in a technical debate. You argue **AGAINST** feasibility.
+
+## Rules
+
+1. **Read actual source code** before arguing. Use `read`, `grep`, `bash` tools.
+2. **Ground every claim** in specific functions, data structures, line numbers, and code snippets.
+3. **Argue honestly** — if the code shows the idea is feasible, acknowledge it.
+4. **Respond to the proposer's specific points** — don't just list independent objections.
+5. **Write ONE round when prompted**, then stop. The judge controls turns.
+6. **Do NOT re-read source files you have already analyzed** — reference your earlier findings directly. Only read new files if a new specific question arises that requires it.
+7. **Speed matters.** Each round is timed. Faster rounds with strong arguments score higher with the judge.

--- a/skills/debate/references/proposer-system.md
+++ b/skills/debate/references/proposer-system.md
@@ -1,0 +1,11 @@
+You are the **PROPOSER (正方)** in a technical debate. You argue **FOR** feasibility.
+
+## Rules
+
+1. **Read actual source code** before arguing. Use `read`, `grep`, `bash` tools.
+2. **Ground every claim** in specific functions, data structures, line numbers, and code snippets.
+3. **Argue honestly** — if the code shows the idea is infeasible, acknowledge it.
+4. **Respond to the opponent's specific points** — don't just repeat your own.
+5. **Write ONE round when prompted**, then stop. The judge controls turns.
+6. **Do NOT re-read source files you have already analyzed** — reference your earlier findings directly. Only read new files if a new specific question arises that requires it.
+7. **Speed matters.** Each round is timed. Faster rounds with strong arguments score higher with the judge.


### PR DESCRIPTION
## Summary

- **Non-blocking spawn**: `SpawnWithAIServe` uses `cmd.Start()` + `ReadString` first line + `Process.Release()`, eliminating tmux dependency. Returns in ~20ms instead of blocking until `ai serve` exits.
- **Dead process detection**: `ag agent status` checks PID liveness via `kill(pid, 0)`. When `ai serve` is detached via `Release()`, it may not update `run.json` on exit — status now auto-corrects from `running` → `done`.
- **Status UX**: Shows `Run ID` and `Watch: ai watch <id>` in status output for direct observation.
- **`formatDuration` fix**: Was treating seconds as nanoseconds (showed "7ns" instead of "7s").
- **`--nth N` flag** on `ag agent conversation`: Get nth-from-last assistant message.
- **`ag agent poll`** new command: 3 modes — text search, `--event <type>`, `--quiesce N`.
- **Cleanup**: Removed stale `ai rpc` references → replaced by `ai serve`.

## Test Plan
- [x] `go test ./...` passes (all packages)
- [x] `ag agent spawn` returns in <25ms, no tmux
- [x] `ag agent status` shows correct PID, Run ID, Watch hint
- [x] Dead process auto-detected as `done`
- [x] Full 3-round debate validated with channel signaling