### PR TITLE
fix(ag): 5 bug fixes from TODO.md

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -27,7 +27,7 @@ const (
 	defaultRetryBaseDelay              = 1 * time.Second
 	defaultRateLimitBaseDelay          = 3 * time.Second // Longer base delay for rate limit
 	defaultLoopMaxConsecutiveToolCalls = 6
-	defaultLoopMaxToolCallsPerName     = 60
+		defaultLoopMaxToolCallsPerName     = 15
 	defaultMalformedToolCallRecoveries = 2
 	defaultEmptyResponseMaxRetries    = 2
 	defaultRuntimeMetaHeartbeatTurns   = 6

--- a/skills/ag/cmd/agent_client.go
+++ b/skills/ag/cmd/agent_client.go
@@ -118,7 +118,9 @@ func Kill(id string) error {
 func killAIAgent(id string) error {
 	meta, err := aiAdapter.GetStatus(id)
 	if err == nil && meta.PID > 0 {
-		_ = syscall.Kill(meta.PID, syscall.SIGTERM)
+		// Kill the entire process group so child processes (e.g. ai serve,
+		// codex exec) are also terminated, not just the direct child.
+		_ = syscall.Kill(-meta.PID, syscall.SIGTERM)
 	}
 	return writeAIKilledActivity(id)
 }
@@ -209,6 +211,12 @@ func Rm(id string) error {
 			}
 		}
 	}
+
+	// Clean up claim lock on the task with the same ID, so another agent
+	// can re-claim it. Only remove the lock file, not the task directory.
+	lockPath := filepath.Join(storage.BaseDir, "tasks", id, ".claim-lock")
+	_ = os.Remove(lockPath)
+
 	return os.RemoveAll(agentDir)
 }
 

--- a/skills/ag/cmd/agent_operations.go
+++ b/skills/ag/cmd/agent_operations.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/genius/ag/internal/agent"
@@ -47,16 +48,14 @@ func spawnWithRawBackend(id, system, input, cwd, backendName string) error {
 		cmd.Dir = cwd
 	}
 
-			// For codex backend, propagate full environment including any proxy settings.
-	// Codex needs proxy to reach chatgpt.com in restricted networks.
-	if backendName == "codex" {
+				// Propagate full environment and apply per-backend env overrides.
+	// os.Environ() preserves existing vars; appended vars override earlier ones
+	// (Go's os.Getenv returns the last match), so backends.yaml values take
+	// precedence if a user has conflicting env vars set.
+	if len(be.Env) > 0 {
 		cmd.Env = os.Environ()
-		// Default to local proxy if user hasn't set one.
-		if os.Getenv("HTTP_PROXY") == "" && os.Getenv("http_proxy") == "" {
-			cmd.Env = append(cmd.Env, "HTTP_PROXY=http://127.0.0.1:8119")
-		}
-		if os.Getenv("HTTPS_PROXY") == "" && os.Getenv("https_proxy") == "" {
-			cmd.Env = append(cmd.Env, "HTTPS_PROXY=http://127.0.0.1:8119")
+		for _, envVar := range be.Env {
+			cmd.Env = append(cmd.Env, envVar)
 		}
 	}
 
@@ -71,7 +70,9 @@ func spawnWithRawBackend(id, system, input, cwd, backendName string) error {
 		cmd.Args = append(cmd.Args, prompt)
 	}
 
-				// Create output file for direct write by the process.
+					cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// Create output file for direct write by the process.
 	// Use os.File directly (not io.Writer) so exec.Cmd uses OS-level dup2
 	// instead of goroutines — this survives Process.Release().
 	outputPath := filepath.Join(agentDir, "output")

--- a/skills/ag/cmd/ai_adapter.go
+++ b/skills/ag/cmd/ai_adapter.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"bufio"
 	"encoding/json"
-		"fmt"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/genius/ag/internal/storage"
@@ -63,12 +64,15 @@ func (a *AIAdapter) SpawnWithAIServe(id, system, input, cwd string) error {
 	// 设置 agent 名称以便识别
 	cmd.Args = append(cmd.Args, "--name", "ag-agent-"+id)
 
-	// 将 stdout pipe 用于读取 run ID，stderr 丢弃到 os.DevNull
+		// 将 stdout pipe 用于读取 run ID，stderr 丢弃到 os.DevNull
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("create stdout pipe: %w", err)
 	}
 	cmd.Stderr = nil // discard stderr
+
+	// Create process group so child processes can be killed together.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 			if err := cmd.Start(); err != nil {
 		return fmt.Errorf("ai serve failed: %w", err)

--- a/skills/ag/internal/agent/agent.go
+++ b/skills/ag/internal/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/genius/ag/internal/storage"
@@ -77,6 +78,20 @@ func List() ([]AgentEntry, error) {
 			result = append(result, AgentEntry{ID: id, Status: "unknown"})
 			continue
 		}
+
+		// Lazy status reconciliation: if activity.json says "running" but the
+		// process is dead, update the status so callers see the real state.
+		if activity.Status == "running" && activity.Pid > 0 {
+			if !isProcessAlive(activity.Pid) {
+				activity.Status = "done"
+				if activity.FinishedAt == 0 {
+					activity.FinishedAt = time.Now().Unix()
+				}
+				actPath := filepath.Join(AgentDir(id), "activity.json")
+				_ = storage.AtomicWriteJSON(actPath, activity)
+			}
+		}
+
 		result = append(result, AgentEntry{
 			ID:        id,
 			Status:    string(activity.Status),
@@ -85,6 +100,15 @@ func List() ([]AgentEntry, error) {
 		})
 	}
 	return result, nil
+}
+
+// isProcessAlive checks if a process with the given PID is still running.
+func isProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
 }
 
 // ReadActivity reads activity.json for an agent.

--- a/skills/ag/internal/backend/backend.go
+++ b/skills/ag/internal/backend/backend.go
@@ -31,6 +31,7 @@ type BackendConfig struct {
 	Args     []string `yaml:"args"`
 	Protocol Protocol `yaml:"protocol"`
 	Supports Supports `yaml:"supports"`
+	Env      []string `yaml:"env,omitempty"`
 }
 
 // BackendsConfig is the top-level structure for backends.yaml.


### PR DESCRIPTION
## Summary

Fixes all 5 items from TODO.md.

### Bug fixes

1. **claim-lock not cleaned on agent removal** — `Rm()` now removes `.ag/tasks/<id>/.claim-lock` so tasks can be re-claimed.
2. **Orphaned child processes** — `Setpgid=true` on spawn, `Kill(-pid)` on terminate. Kills entire process group.
3. **Reviewer infinite read loop** — `defaultLoopMaxToolCallsPerName` lowered from 60 → 15.
4. **Status shows "running" after completion** — Lazy reconciliation in `agent.List()`: checks PID liveness, updates stale `activity.json`.
5. **backends.yaml env field** — `BackendConfig.Env []string` replaces hardcoded codex proxy logic.

### Files changed

| File | Change |
|------|--------|
| `pkg/agent/loop.go` | `defaultLoopMaxToolCallsPerName` 60 → 15 |
| `skills/ag/cmd/agent_client.go` | claim-lock cleanup in `Rm()`, process-group kill in `killAIAgent()` |
| `skills/ag/cmd/agent_operations.go` | `Setpgid`, generic `be.Env` replaces hardcoded codex proxy |
| `skills/ag/cmd/ai_adapter.go` | `Setpgid` in `SpawnWithAIServe()` |
| `skills/ag/internal/agent/agent.go` | Lazy status reconciliation in `List()` |
| `skills/ag/internal/backend/backend.go` | `Env []string` field on `BackendConfig` |

### Test plan

- [x] `go build ./...` passes
- [x] `skills/ag: go test ./...` — all pass
- [x] `pkg/agent: go test ./...` — all pass (including `TestRegression004_MaxToolCallsPerName`)