### PR TITLE
docs: update README.md and docs/ to reflect current codebase state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,263 @@
-# ai - RPC-First Agent Core (Go)
+# ai — AI Coding Agent (Go)
 
-`ai` 是一个 Go 实现的核心 Agent Loop，面向 `stdin/stdout` RPC 使用方式，适合编辑器集成。
+`ai` is a Go-based AI coding agent with an RPC-first architecture, designed for editor and CLI integration. It features a subcommand-based CLI, session persistence, LLM-driven context management, a pluggable skills system, and an agent orchestration runtime (`ag`).
 
-## 构建与运行
-
-```bash
-cd /Users/genius/project/ai
-go build -o bin/ai ./cmd/ai
-```
+## Build & Install
 
 ```bash
-# 默认启动 win 模式,给 ad 编辑器使用(github.com/tiancaiamao/ad)
-./bin/ai
+go install ./cmd/ai
 ```
+
+This produces the `ai` binary. Requires Go 1.24+.
+
+## CLI Usage
+
+The `ai` binary uses subcommands:
 
 ```bash
-# 启动 RPC 模式
-export ZAI_API_KEY=your-zai-api-key
-./bin/ai --mode rpc
+ai <subcommand> [flags]
 ```
 
-加载指定会话文件：
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `run` | Start agent with interactive TUI (serves + watches in one process) |
+| `serve` | Start agent as a background daemon (foreground process, redirect I/O to files) |
+| `rpc` | Raw JSON-RPC mode over stdin/stdout (for programmatic integration) |
+| `ls` | List running and recent agent instances |
+| `watch` | Attach to a running serve instance (TUI) |
+| `send` | Send a message to a running agent instance |
+| `kill` | Stop a running agent instance |
+
+### Examples
 
 ```bash
-./bin/ai --mode rpc --session /abs/path/to/session.jsonl
+# Interactive TUI session
+ai run
+ai run --input "fix the bug in main.go"
+ai run --session /path/to/session-dir
+
+# Background daemon + attach
+ai serve --input "explain the architecture"
+ai watch
+ai send "what about error handling?"
+ai kill
+
+# RPC mode (for editor/tool integration)
+ai rpc < commands.jsonl
+
+# List runs
+ai ls
+ai ls --all --json
 ```
 
-## 环境变量
+### Flags
 
-- `ZAI_API_KEY`（必需）
-- `ZAI_BASE_URL`（可选，默认 `https://api.z.ai/api/coding/paas/v4`）
-- `ZAI_MODEL`（可选，默认 `glm-4.5-air`）
+**`run` / `serve`:**
+- `--session <path>` — Session directory path
+- `--system-prompt <text>` — Custom system prompt (`@file` to load from file)
+- `--max-turns <n>` — Maximum conversation turns (0 = unlimited)
+- `--timeout <duration>` — Total execution timeout (0 = unlimited)
+- `--input <text>` — Initial prompt to send after startup
 
-也可以在 `~/.ai/auth.json` 写入 API Key（优先级：环境变量 > auth.json）：
+**`serve` only:**
+- `--http <addr>` — Enable HTTP debug server (e.g., `:6060`)
+- `--name <text>` — Human-readable name for the run
+
+**`watch`:**
+- `--id <run-id>` — Run ID or prefix (auto-selects by cwd if omitted)
+
+**`send`:**
+- `--id <run-id>` — Run ID or prefix
+
+**`kill`:**
+- `--id <run-id>` — Run ID or prefix
+- `--force` — Send SIGKILL instead of graceful abort
+
+**`ls`:**
+- `--all` — Include finished runs
+- `--json` — JSON output
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ZAI_API_KEY` | Yes | — | API key for the LLM provider |
+| `ZAI_BASE_URL` | No | `https://api.z.ai/api/coding/paas/v4` | LLM API base URL |
+| `ZAI_MODEL` | No | `glm-4.5-air` | Model ID |
+| `ZAI_MAX_TOKENS` | No | Model default | Max output tokens |
+
+API key can also be stored in `~/.ai/auth.json`:
 
 ```json
 {
   "zai": {
     "type": "api_key",
-    "key": "your-zai-api-key"
+    "key": "your-api-key"
   }
 }
 ```
 
-## RPC 使用示例
+Priority: environment variables > `auth.json` > config defaults.
 
-```bash
-echo '{"type":"prompt","message":"Hello!"}' | ./bin/ai --mode rpc
-echo '{"type":"get_state"}' | ./bin/ai --mode rpc
-echo '{"type":"get_messages"}' | ./bin/ai --mode rpc
+## Configuration
+
+Config file: `~/.ai/config.json`
+
+```json
+{
+  "model": {
+    "id": "glm-4.5-air",
+    "provider": "zai",
+    "baseUrl": "https://api.z.ai/api/coding/paas/v4",
+    "api": "openai-completions"
+  },
+  "compactor": {
+    "maxMessages": 100,
+    "maxTokens": 100000,
+    "keepRecent": 10,
+    "reserveTokens": 16384,
+    "toolCallCutoff": 10
+  },
+  "concurrency": {
+    "maxConcurrentTools": 5,
+    "toolTimeout": 30,
+    "queueTimeout": 60
+  },
+  "toolOutput": {
+    "maxChars": 10000
+  },
+  "log": {
+    "level": "info",
+    "file": "~/.ai/ai-{pid}.log"
+  }
+}
 ```
 
-## 已实现的 RPC 命令
+## RPC Protocol
 
-- 基础交互：`prompt`, `steer`, `follow_up`, `abort`
-- 会话：`new_session`, `switch_session`, `delete_session`, `list_sessions`, `clear_session`
-- 状态与统计：`get_state`, `get_messages`, `get_session_stats`, `get_last_assistant_text`
-- 模型：`get_available_models`, `set_model`, `cycle_model`
-- 压缩与思考级别：`compact`, `set_auto_compaction`, `set_tool_call_cutoff`, `set_tool_summary_strategy`, `set_thinking_level`, `cycle_thinking_level`
-- 分叉：`get_fork_messages`, `fork`
-- 命令列表：`get_commands`（当前返回已加载的 skills）
+In `rpc` mode, `ai` reads JSON-RPC commands from stdin and writes responses/events to stdout.
 
-## 事件
+### Commands
 
-- `server_start`
-- `agent_start`, `agent_end`
-- `turn_start`, `turn_end`
-- `message_start`, `message_update`, `message_end`
-- `tool_execution_start`, `tool_execution_end`
+- `prompt` — Send a user message
+- `steer` — Inject mid-turn guidance
+- `follow_up` — Queue a follow-up message
+- `abort` — Cancel current turn
+- `ping` — Health check
 
-`message_update` 的 `assistantMessageEvent.type`：
-- `text_start`, `text_delta`, `text_end`
-- `toolcall_delta`
+### Events
 
-## 文件位置
+| Event | Description |
+|-------|-------------|
+| `server_start` | Server initialized |
+| `agent_start` / `agent_end` | Agent processing lifecycle |
+| `turn_start` / `turn_end` | Turn boundaries |
+| `message_start` / `message_update` / `message_end` | Streaming message chunks |
+| `tool_execution_start` / `tool_execution_end` | Tool invocations |
 
-- 配置：`~/.ai/config.json`
-- 日志：`~/.ai/ai.log`
-- 会话：`~/.ai/sessions/--<cwd>--/*.jsonl`（按工作目录隔离）
-- 全局技能：`~/.ai/skills/`
-- 项目技能：`.ai/skills/`
+`message_update` types: `text_start`, `text_delta`, `text_end`, `toolcall_delta`, `thinking_delta`.
 
-## 工具
+## Built-in Tools
 
-内置工具：`read`, `bash`, `write`, `grep`, `edit`
+| Tool | Description |
+|------|-------------|
+| `read` | Read file contents |
+| `write` | Write to file |
+| `edit` | Edit file by replacing text (supports fuzzy matching) |
+| `bash` | Execute shell commands (with timeout control) |
+| `grep` | Search file contents (ripgrep or grep) |
+| `change_workspace` | Change working directory |
+| `context_management` | LLM-driven context truncation/compaction |
 
-## 备注
+## Skills System
 
-- 不带参数默认启动 win 模式；RPC 模式用 `--mode rpc`。
-- `ai` 采用 OpenAI 兼容的 Chat Completions 协议对接 ZAI。
+Skills are Markdown files (with optional YAML frontmatter) loaded from:
+- `~/.ai/skills/` — Global skills
+- `.ai/skills/` — Project skills
 
-## 许可证
+Skills extend the agent's capabilities with domain-specific instructions, prompts, and scripts.
 
-与原项目保持一致（参考 [pi-mono](https://github.com/badlogic/pi-mono) 的核心实现）。
+### Key Skills
+
+| Skill | Description |
+|-------|-------------|
+| `ag` | Agent orchestration runtime — spawn, steer, and coordinate AI agents |
+| `brainstorm` | Explore user intent through conversation |
+| `plan` | Read design docs, produce task YAML with dependency DAG |
+| `implement` | Code-driven task execution with ag task scheduler |
+| `review` | Code review using codex-rs methodology |
+| `systematic-debugging` | Structured debugging workflow |
+| `github` | GitHub interaction via `gh` CLI |
+| `land` | Merge PRs with branch management |
+| `tmux` | Background process management |
+| `wf` | Gate tool for brainstorm → plan → implement flow |
+
+## Agent Orchestration (`ag`)
+
+`ag` is a companion CLI (built from `skills/ag/`) for orchestrating multiple AI agents:
+
+```bash
+# Build ag
+cd skills/ag && go install .
+
+# Spawn agents
+ag agent spawn worker-1 --input "fix authentication bug"
+ag agent spawn reviewer --system @reviewer.md --input "review the changes"
+
+# Monitor
+ag agent status worker-1
+ag agent output worker-1 --tail 50
+
+# Control
+ag agent steer worker-1 "also check error handling"
+ag agent kill worker-1
+
+# Task DAG scheduling
+ag task import-plan tasks.yml
+ag task next --claimant worker-1
+ag task done T001 --summary "completed"
+```
+
+Key features:
+- Bridge-per-agent architecture (no central daemon, no tmux dependency)
+- Multi-backend support (`ai` JSON-RPC, `codex` raw protocol)
+- Inter-agent communication via channels
+- Task DAG with dependency resolution
+
+See `skills/ag/SKILL.md` for full documentation.
+
+## File Locations
+
+| Path | Description |
+|------|-------------|
+| `~/.ai/config.json` | Configuration |
+| `~/.ai/auth.json` | API credentials |
+| `~/.ai/ai-{pid}.log` | Per-process logs |
+| `~/.ai/sessions/--<cwd>--/` | Session data (per git repo root) |
+| `~/.ai/skills/` | Global skills |
+| `.ai/skills/` | Project skills |
+| `~/.ai/traces/` | Perfetto-compatible trace files |
+| `~/.ai/runs/` | Run metadata for `ai serve`/`ai run` |
+
+## Tracing
+
+The agent writes Perfetto-compatible trace files to `~/.ai/traces/`. Events include tool execution, LLM calls, agent lifecycle, and log bridge output. Events are configurable via `pkg/traceevent/config.go`.
+
+## Session Persistence
+
+Sessions are stored as append-only JSONL files under `~/.ai/sessions/--<sanitized-path>--/`. Key properties:
+- Directory-based with `messages.jsonl` as the primary file
+- Header entry contains session ID and metadata
+- Fork support: branch conversations from any point
+- Checkpoint + journal: efficient recovery with periodic snapshots
+- Legacy format auto-migration on load
+
+## Architecture
+
+See [docs/architecture.md](docs/architecture.md) for detailed component diagrams and data flow.
+
+## License
+
+Consistent with the original project (see [pi-mono](https://github.com/badlogic/pi-mono)).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `ai` project is a Go-based AI agent system with RPC-first design, optimized for editor integration. The system uses a code-driven workflow engine for reliable task scheduling, with focused agent workers executing specific tasks.
+The `ai` project is a Go-based AI coding agent with RPC-first design, optimized for editor integration and multi-agent orchestration. The system uses a subcommand-based CLI, code-driven task scheduling, and focused agent workers.
 
 ## Architecture Philosophy
 
@@ -13,341 +13,242 @@ The `ai` project is a Go-based AI agent system with RPC-first design, optimized 
 - **Deterministic scheduling** (not agent-driven state machines)
 - **Human-in-the-loop checkpoints** (explicit in workflow templates)
 
-### Why Code-Driven?
-
-1. **Reliability**: Deterministic state machine, no LLM hallucinations in control flow
-2. **Performance**: No extra LLM calls for workflow decisions
-3. **Debuggability**: Clear code paths, easy to trace execution
-4. **Testability**: Can unit test workflow logic without LLM
-
 ## System Architecture
 
 ### Component Diagram
 
 ```
-┌─────────────────────────────────────────┐
-│              Editor / CLI Client        │
-└───────────────────┬─────────────────────┘
-                    │ JSON-RPC over stdin/stdout
-                    ▼
-┌─────────────────────────────────────────┐
-│          RPC Handlers (pkg/rpc/)        │
-│  - Request parsing                      │
-│  - Agent lifecycle management           │
-│  - Session persistence                 │
-└───────────────────┬─────────────────────┘
-                    │
-                    ▼
-┌─────────────────────────────────────────┐
-│         Agent Core (pkg/agent/)         │
-│                                         │
-│  ┌───────────────┐    ┌──────────────┐ │
-│  │ Agent Loop    │────│ Context      │ │
-│  │ (RunLoop)     │    │ Management   │ │
-│  └───────────────┘    └──────────────┘ │
-│         │                   │          │
-│         ▼                   ▼          │
-│  ┌───────────────┐    ┌──────────────┐ │
-│  │ Tool Executor │────│ Compactor    │ │
-│  │ Pool         │    │ (auto-compact)│ │
-│  └───────────────┘    └──────────────┘ │
-└───────────────────┬─────────────────────┘
-                    │
-                    ▼
-┌─────────────────────────────────────────┐
-│         Skills (~/.ai/skills/)          │
-│                                         │
-│  workflow/         orchestrate/          │
-│  subagent/         review/              │
-│  systematic-                             │
-│  debugging/                              │
-└─────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────┐
+│                    CLI / Editor / TUI Client                    │
+│  ai run (TUI)  |  ai serve + ai watch  |  ai rpc (stdin/stdout)│
+└──────────────────────────┬─────────────────────────────────────┘
+                           │ JSON-RPC over stdin/stdout
+                           │ Unix socket (run/serve)
+                           ▼
+┌────────────────────────────────────────────────────────────────┐
+│               cmd/ai — CLI Subcommands                          │
+│                                                                 │
+│  main.go          — Subcommand dispatch (run/serve/rpc/ls/...)  │
+│  rpc_handlers.go  — RPC server setup, session lifecycle         │
+│  run.go           — run/serve: subprocess + TUI (Bubble Tea)    │
+│  session_writer.go— Session persistence, compaction bridge      │
+│  watch.go         — Event stream TUI renderer                   │
+│  send.go          — Send messages to running agent via socket   │
+│  ls.go / kill.go  — List and terminate agent instances          │
+└──────────────────────────┬─────────────────────────────────────┘
+                           │
+                           ▼
+┌────────────────────────────────────────────────────────────────┐
+│                pkg/rpc — RPC Server                             │
+│  server.go  — JSON-RPC read/write loop                          │
+│  types.go   — Shared RPC types (commands, responses, events)    │
+└──────────────────────────┬─────────────────────────────────────┘
+                           │
+                           ▼
+┌────────────────────────────────────────────────────────────────┐
+│                pkg/agent — Agent Core                           │
+│                                                                 │
+│  ┌──────────────────┐    ┌──────────────────────────────────┐  │
+│  │ Agent (agent.go) │────│ Loop (loop.go)                    │  │
+│  │ - Lifecycle mgmt │    │ - Turn execution                  │  │
+│  │ - Event emission │    │ - Tool call routing               │  │
+│  │ - Stream control │    │ - LLM retry + error recovery      │  │
+│  │ - Config mgmt    │    │ - Runtime telemetry injection      │  │
+│  └──────────────────┘    └──────────────────────────────────┘  │
+│         │                          │                            │
+│         ▼                          ▼                            │
+│  ┌──────────────────┐    ┌──────────────────────────────────┐  │
+│  │ Executor Pool    │    │ Context Management                │  │
+│  │ (executor.go)    │    │ (via pkg/compact/)                │  │
+│  │ - Concurrency    │    │ - LLM-driven compaction           │  │
+│  │ - Tool dispatch  │    │ - Auto-compact on thresholds      │  │
+│  │ - Timeout guard  │    │ - Truncate / update / compact     │  │
+│  └──────────────────┘    └──────────────────────────────────┘  │
+│                                                                 │
+│  ┌──────────────────┐    ┌──────────────────────────────────┐  │
+│  │ Metrics          │    │ Tool Guards (tool_guard.go)        │  │
+│  │ (metrics.go)     │    │ - Max consecutive calls            │  │
+│  │ - Token rates    │    │ - Max calls per tool name          │  │
+│  │ - Turn tracking  │    │ - Malformed call recovery          │  │
+│  └──────────────────┘    └──────────────────────────────────┘  │
+└──────────────────────────┬─────────────────────────────────────┘
+                           │
+              ┌────────────┼────────────┐
+              ▼            ▼            ▼
+┌──────────────────┐ ┌──────────┐ ┌──────────────────┐
+│ pkg/tools        │ │ pkg/llm  │ │ pkg/context       │
+│ - bash           │ │ - OpenAI │ │ - AgentContext    │
+│ - read/write     │ │   compat │ │ - Messages        │
+│ - edit           │ │ - Stream │ │ - Checkpoint      │
+│ - grep           │ │ - Retry  │ │ - Journal         │
+│ - change_workspace│ │          │ │ - Compaction      │
+│ - context_mgmt/* │ │          │ │ - Reconstruction  │
+└──────────────────┘ └──────────┘ └──────────────────┘
 ```
 
-### Workflow & Orchestrate Architecture
+### Supporting Packages
+
+| Package | Responsibility |
+|---------|---------------|
+| `pkg/config` | Configuration loading, API key resolution, model specs |
+| `pkg/session` | Append-only JSONL session storage, fork support, lazy loading |
+| `pkg/prompt` | System prompt construction, skill expansion, thinking instructions |
+| `pkg/skill` | Skill discovery, loading (frontmatter parsing), formatting |
+| `pkg/compact` | Heavyweight LLM summarization + lightweight context management |
+| `pkg/traceevent` | Perfetto-compatible trace event recording and export |
+| `pkg/truncate` | Tool output truncation with head/tail preservation |
+| `pkg/modelselect` | Model selection and spec resolution |
+| `pkg/command` | Slash command registry |
+| `pkg/run` | Run metadata, socket server for `ai serve`/`ai run` |
+| `pkg/logger` | Structured logging with file rotation |
+| `pkg/version` | Version information |
+
+### Agent Orchestration (`ag`)
 
 ```
-┌─────────────────────────────────────────┐
-│         Workflow Skill (Frontend)      │
-│  - User commands: /workflow start, auto │
-│  - Template selection                   │
-│  - Status display                       │
-└────────────┬────────────────────────┘
-             │ Calls CLI
-             ▼
-┌─────────────────────────────────────────┐
-│    Orchestrate Runtime (Backend)       │
-│  - Code-driven state machine (Go)       │
-│  - Task scheduling from YAML templates  │
-│  - Dependency enforcement              │
-│  - Human checkpoint handling            │
-└────────────┬────────────────────────┘
-             │ Creates tasks
-             ▼
-┌─────────────────────────────────────────┐
-│         Agent Workers (Executors)       │
-│  - Receive task assignment              │
-│  - Execute task (may use tools/subagents)│
-│  - Output to .ai/team/outbox/           │
-│  - Report completion/failure            │
-└─────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────┐
+│              ag CLI (skills/ag/)                                │
+│  Standalone Go binary for multi-agent orchestration             │
+│                                                                 │
+│  ┌────────────────┐  ┌────────────────┐  ┌──────────────────┐ │
+│  │ Agent Lifecycle │  │ Task DAG       │  │ Channels         │ │
+│  │ - spawn         │  │ - import-plan  │  │ - create/send    │ │
+│  │ - steer/abort   │  │ - claim/next   │  │ - recv/wait      │ │
+│  │ - status/output │  │ - done/fail    │  │ - async messages │ │
+│  │ - kill          │  │ - dependencies │  │                  │ │
+│  └───────┬────────┘  └───────┬────────┘  └──────────────────┘ │
+│          │                   │                                  │
+│          ▼                   ▼                                  │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │         Bridge-per-Agent Architecture                     │  │
+│  │                                                           │  │
+│  │  ag bridge <id> (detached process)                        │  │
+│  │  ├── <backend command> (ai rpc / codex exec / ...)        │  │
+│  │  ├── StreamWriter → stream.log (real-time readable)       │  │
+│  │  ├── EventReader → activity.json (structured events)      │  │
+│  │  └── Unix socket → bridge.sock (control plane)            │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  Backends: ai (json-rpc), codex (raw), pluggable via config     │
+│  Storage: .ag/ directory (CWD-scoped)                           │
+└────────────────────────────────────────────────────────────────┘
 ```
-
-## Component Responsibilities
-
-### RPC Handlers (`pkg/rpc/`)
-
-**Purpose:** Interface between external clients and agent core.
-
-**Key Files:**
-- `rpc_handlers.go`: Main RPC handler functions
-- `types.go`: Shared RPC types
-
-**Key Handlers:**
-- `handlePrompt`: Main interaction entry point
-- `handleGetState`: Query agent state
-- `handleCompact`: Manual context compaction
-- `handleGetSessionStats`: Session metrics
-
-### Agent Loop (`pkg/agent/loop.go`)
-
-**Purpose:** Main agent execution loop.
-
-**Key Phases:**
-1. Build prompt (with context + tools)
-2. Call LLM (streaming)
-3. Execute tools (concurrent)
-4. Update context
-5. Auto-compact (if needed)
-6. Emit events
-
-**Guardrails:**
-- `MaxConsecutiveToolCalls`: Prevent infinite loops
-- `MaxToolCallsPerName`: Prevent tool abuse
-- `MaxTurns`: Prevent runaway conversations
-- `TaskTracking`: Remind agent of current task
-- `ContextManagement`: Remind agent to compact
-- `LLMTimeout`: Timeout LLM calls
-- `LLMRetries`: Retry on rate limits
-
-### Context Management (`pkg/context/`)
-
-**Purpose:** Maintain healthy conversation context.
-
-**Strategies:**
-- Priority-based compaction (compact oldest first)
-- Mini-compact for quick summaries
-- Dynamic cheatsheet for code-heavy conversations
-- ToolOutput truncation for large outputs
-
-**Key Files:**
-- `compactor.go`: Compaction logic
-- `checkpoint.go`: Checkpoint management
-- `reconstruction.go`: Context reconstruction
-
-### Tool Executor (`pkg/tools/`)
-
-**Purpose:** Execute tools with concurrency control.
-
-**Features:**
-- `MaxConcurrentTools`: Limit parallel tool execution
-- `QueueTimeout`: Timeout queued tools
-- Tool-specific timeouts
-- Output size limits
-
-**Key Tools:**
-- `bash`: Execute shell commands
-- `read`: Read file contents
-- `write`: Write files
-- `edit`: Edit files (fuzzy matching)
-- `grep`: Search file contents
-- `llm_context_recall`: Search external memory
-- And more...
-
-### Workflow System (`skills/workflow/`)
-
-**Purpose:** Multi-phase development workflows.
-
-**Templates:**
-- `feature`: Feature development with approval checkpoints
-- `bugfix`: Bug fix with verification
-- `refactor`: Code refactoring
-- `spike`: Exploratory research
-- `hotfix`: Urgent bug fix
-- `security`: Security issue handling
-
-**Workflow Phases:**
-- `explore`: Explore codebase
-- `plan`: Create implementation plan
-- `implement`: Implement changes
-- `test`: Test implementation
-- `review`: Review and approve
-- `ship`: Deploy
-
-### Orchestrate Runtime (`skills/workflow/orchestrate/`)
-
-**Purpose:** Code-driven task scheduling runtime.
-
-**Key Components:**
-- `runtime.go`: Task scheduling and state management
-- `api.go`: API for workers to interact with tasks
-- `storage.go`: File-based task state persistence
-- `types.go`: Task and state types
-
-**Task States:**
-- `pending`: Created, waiting to be claimed
-- `claimed`: Claimed by a worker
-- `in_progress`: Worker started execution
-- `completed`: Task completed successfully
-- `failed`: Task failed with error
-- `blocked`: Dependencies not met
-
-### Skills (`skills/`)
-
-**Purpose:** Specialized workflows and expert prompts.
-
-**Key Skills:**
-- `workflow`: Multi-phase development workflows
-- `orchestrate`: Multi-agent coordination runtime
-- `subagent`: Isolated expert execution
-- `systematic-debugging`: Four-phase bug fixing
-- `review`: Code review with codex-rs methodology
-- `tmux`: Tmux session management
-- `using-git-worktrees`: Git worktree management
-- `explore`: Codebase exploration
-- And more...
 
 ## Data Flow
 
-### Request Flow
+### Typical Turn (RPC mode)
 
 ```
-User Request
-  → RPC Handler
-  → Agent.Start (spawn goroutine)
-  → Loop.Run
-  → Prompt Builder (build system prompt)
-  → LLM API call (streaming)
-  → Tool Execution (if tool calls)
-  → Context Update
-  → Auto-Compact (if threshold)
-  → Emit Events
-  → RPC Response
+1. Client sends: {"type":"prompt","message":"fix the bug"}
+2. RPC Server receives → Agent.Prompt()
+3. Agent acquires lock → Appends user message to context
+4. Agent.RunLoop():
+   a. Build system prompt (Builder: tools + skills + project context + telemetry)
+   b. Convert context to LLM messages (with visibility filtering)
+   c. Call LLM API (streaming, with retry on rate limit)
+   d. Stream response: emit text_delta / toolcall_delta events
+   e. If tool calls: execute via ExecutorPool → append results → repeat from (a)
+   f. Emit turn_end event
+5. Auto-compact check: if token threshold exceeded, trigger compaction
+6. Session persistence: append entries to messages.jsonl
+7. Checkpoint: periodic snapshot for fast recovery
 ```
 
-### Event Flow
+### Context Management Flow
 
 ```
-Agent Loop
-  → emitEvent(EventMessageStart)
-  → emitEvent(EventToolCall)
-  → emitEvent(EventToolResult)
-  → emitEvent(EventTextDelta)
-  → ...
-  → Trace Event Store (~/.ai/traces/)
+1. Turn completes → check token usage
+2. If threshold exceeded:
+   a. ContextManager (lightweight): separate LLM call with mgmt tools
+      - truncate_messages: remove stale tool outputs
+      - update_llm_context: update task state summary
+      - compact: trigger full summarization
+      - no_action: skip (context is fine)
+   b. sessionCompactor (heavyweight): full LLM summarization
+      - Generates new summary from conversation
+      - Replaces old messages with summary
+      - Persists via checkpoint + journal
+3. LLMContext (task state) injected into future requests for continuity
 ```
 
 ### Session Persistence
 
 ```
-Messages (AgentMessage[])
-  → Save to messages.jsonl
-  → Load on restart
-  → Compact (periodically)
+Session Directory (~/.ai/sessions/--<git-root>--/)
+├── messages.jsonl          # Append-only entries
+│   ├── {"type":"session","id":"...","cwd":"..."}   # Header
+│   ├── {"type":"message","id":"abc1","parentId":null,...}
+│   ├── {"type":"message","id":"abc2","parentId":"abc1",...}
+│   ├── {"type":"truncate","id":"abc3",...}
+│   └── {"type":"compact","id":"abc4",...}
+├── checkpoint.jsonl        # Periodic snapshot (full state)
+└── checkpoint-index.json   # Checkpoint lookup index
 ```
 
-### Workflow Execution
-
-```
-User: /workflow start feature "User auth"
-  → Workflow skill parses command
-  → Orchestrate runtime loads feature.yaml
-  → Create tasks from phases (explore, plan, implement, test, review)
-  → Workers claim and execute tasks
-  → Output to .ai/team/outbox/
-  → Human approves at checkpoints
-  → Next task (if dependencies satisfied)
-  → All complete → Cleanup
-```
+Recovery: load latest checkpoint → replay journal entries after checkpoint → rebuild in-memory state.
 
 ## Key Design Decisions
 
-### Decision 1: RPC-First Design
+### Decision 1: RPC-First Architecture
 
-**Context:** Initial design considered CLI vs RPC vs HTTP.
+**Context:** How to integrate with editors and external tools.
 
-**Decision:** RPC over stdin/stdout.
-
-**Rationale:**
-- Standard interface for editor integration
-- Language-agnostic
-- Easier to test (mock RPC, no subprocess)
-- Cleaner separation of concerns
-
-**Trade-offs:**
-- + Clean protocol (JSON-RPC)
-- + Easy to add new RPC commands
-- + Better testability
-- - Requires external client
-- - Mixed stderr/stdout with RPC output
-
-### Decision 2: Stateful Agent with Sessions
-
-**Context:** Stateless vs stateful agent.
-
-**Decision:** Stateful with persistent sessions.
+**Decision:** JSON-RPC over stdin/stdout as the primary interface.
 
 **Rationale:**
-- Enable context preservation across restarts
-- Support long-running workflows
-- Resume interrupted work
+- Universal integration (any language, any editor)
+- Clean process boundary (crash isolation)
+- Streaming support via event protocol
+- Subcommands (run/serve) build on top of rpc
 
-**Trade-offs:**
-- + Better user experience
-- + Context preservation
-- - More complex state management
-- - Disk I/O overhead
+### Decision 2: Subcommand-Based CLI
 
-### Decision 3: Code-Driven State Machine for Orchestrate
+**Context:** How to expose different operational modes.
 
-**Context:** Prompt-driven vs code-driven workflow engine.
-
-**Decision:** Code-driven (Go state machine).
+**Decision:** Subcommands (`ai rpc`, `ai run`, `ai serve`, `ai ls`, `ai watch`, `ai send`, `ai kill`) instead of `--mode` flags.
 
 **Rationale:**
-- More reliable (no LLM hallucinations in control flow)
-- Better performance (no extra LLM calls)
-- Easier to debug (deterministic)
-- Testable without LLM
+- Clearer semantics (each command does one thing)
+- Independent flag sets per subcommand
+- Backward compatibility via deprecated `--mode` dispatch
+- `ai run` = subprocess rpc + TUI in one process
+- `ai serve` = daemon mode with socket control
 
-**Trade-offs:**
-- + Reliable control flow
-- + Better performance
-- + Easier debugging
-- - Less flexible (can't self-modify at runtime)
-- - Requires code changes to modify workflow
+### Decision 3: LLM-Driven Context Management
 
-### Decision 4: Tmux for Subagent Isolation
+**Context:** How to manage context within LLM window limits.
 
-**Context:** Process isolation strategy for subagents.
-
-**Options:** Goroutines (in-process), Docker containers, Tmux sessions, Separate processes (no terminal).
-
-**Decision:** Tmux sessions.
+**Decision:** Delegate context management decisions to a separate LLM call with dedicated tools.
 
 **Rationale:**
-- Easy to inspect/debug (tmux attach)
-- Captures full output (including colors)
-- Works on Linux/macOS
-- Can kill entire session tree
+- LLM can distinguish relevant vs stale content (rules cannot)
+- Flexible strategy (truncate, summarize, or skip)
+- System controls timing; LLM controls strategy
+- See [context-management.md](context-management.md) for full details
 
-**Trade-offs:**
-- + Great debugging experience
-- + Full output capture
-- + Automatic cleanup on completion
-- - Requires tmux installation
-- - Slight startup overhead (2-3s)
-- - Windows support limited
+### Decision 4: Bridge-Per-Agent Architecture
+
+**Context:** Process isolation for agent orchestration.
+
+**Decision:** Each agent gets its own bridge process (not tmux, not in-process).
+
+**Rationale:**
+- No central daemon (one crash doesn't take down others)
+- No tmux dependency
+- Direct process control via Unix socket
+- Backend-agnostic (any CLI-based agent)
+
+### Decision 5: Append-Only Session Storage
+
+**Context:** How to persist conversation state.
+
+**Decision:** Append-only JSONL with periodic checkpoints.
+
+**Rationale:**
+- Crash-safe (partial writes don't corrupt)
+- Efficient (no rewriting)
+- Fork support (tree structure via parent IDs)
+- Fast recovery (checkpoint + journal replay)
 
 ## Performance Characteristics
 
@@ -355,122 +256,64 @@ User: /workflow start feature "User auth"
 |-----------|---------|-------|
 | Agent turn (no tools) | 1-3s | LLM streaming |
 | Agent turn (with tools) | 3-30s | Depends on tool speed |
-| Subagent startup | 2-3s | Tmux session creation |
 | Auto-compact | 2-5s | LLM summarization |
-| Context restoration | 1-2s | Load from disk |
-| Task claim | <1s | File I/O |
-| Task completion | <1s | File I/O |
+| Context restoration | <1s | Checkpoint + journal replay |
+| Agent spawn (ag) | 2-3s | Bridge + subprocess startup |
+| Session load (lazy) | <100ms | Lazy loading from JSONL |
 
 ## Security Considerations
 
-- **Tool output sanitization**: Prevent prompt injection from malicious tool outputs
-- **Path traversal protection**: In file tools (read/write/edit)
-- **Execution timeout**: Prevent infinite loops in tools
-- **Resource limits**: Max tokens, max turns, tool call limits
-- **RPC isolation**: Client runs in separate process
-- **Session isolation**: Sessions isolated by working directory
-- **Subagent isolation**: Tmux provides process-level isolation
+- **Tool output truncation**: Prevents context overflow from large tool outputs
+- **Execution timeout**: Configurable per-tool and per-turn timeouts
+- **Resource limits**: Max consecutive tool calls, max turns, token limits
+- **Session isolation**: Sessions scoped by git repository root
+- **Agent isolation**: Each ag agent is an independent process
+- **Path protection**: Tools validate file paths within workspace
+- **API key storage**: Support for both env vars and file-based credentials
 
 ## Testing Strategy
 
-### Test Pyramid
+See [test-strategy.md](test-strategy.md) for detailed testing approach.
+
+## Package Structure
 
 ```
-        E2E Tests (74 benchmark tasks)
-              ↓
-      Integration Tests
-              ↓
-        Unit Tests
+ai/
+├── cmd/ai/           # CLI entry points
+│   ├── main.go       # Subcommand dispatch
+│   ├── rpc_handlers.go
+│   ├── run.go        # run + serve subcommands
+│   ├── watch.go      # TUI event renderer
+│   ├── send.go       # Send to running agent
+│   ├── ls.go         # List runs
+│   └── kill.go       # Terminate agent
+├── pkg/
+│   ├── agent/        # Core agent loop, execution, metrics
+│   ├── compact/      # Compaction strategies
+│   ├── command/      # Slash command registry
+│   ├── config/       # Configuration, auth, model specs
+│   ├── context/      # Agent context, messages, checkpoints
+│   ├── llm/          # LLM client (OpenAI-compatible)
+│   ├── logger/       # Structured logging
+│   ├── modelselect/  # Model selection logic
+│   ├── prompt/       # System prompt builder
+│   ├── rpc/          # RPC server, types
+│   ├── run/          # Run metadata, socket server
+│   ├── session/      # Session persistence (JSONL)
+│   ├── skill/        # Skill loading and formatting
+│   ├── tools/        # Tool implementations
+│   │   └── context_mgmt/  # Context management tools
+│   ├── traceevent/   # Perfetto-compatible tracing
+│   ├── truncate/     # Output truncation
+│   └── version/      # Version info
+├── skills/           # Skill definitions
+│   ├── ag/           # Agent orchestration CLI (separate Go module)
+│   ├── brainstorm/   # Intent exploration
+│   ├── plan/         # Task planning
+│   ├── implement/    # Task execution
+│   ├── review/       # Code review
+│   └── ...           # Other skills
+├── docs/             # Documentation
+├── benchmark/        # E2E benchmark tasks
+└── tests/            # Integration test scripts
 ```
-
-### Layer 1: Unit Tests (Fast, Focused)
-
-**Target:** 80% coverage of business logic.
-
-**Examples:**
-- `pkg/context/compactor_test.go`: Test compaction logic
-- `pkg/agent/loop_test.go`: Test loop behavior
-- `pkg/tools/bash_test.go`: Test bash tool timeout
-
-### Layer 2: Integration Tests (Medium, Realistic)
-
-**Target:** Cover all major integration points.
-
-**Examples:**
-- `pkg/agent/agent_integration_test.go`: Agent + tools
-- `pkg/rpc/`: RPC handlers + agent
-- Workflow execution end-to-end
-
-### Layer 3: E2E Tests (Slow, Realistic)
-
-**Target:** 74 benchmark tasks covering:
-- Bug fixing (agent_001-010)
-- Code generation (001-013)
-- Context management (004, 010, 011)
-- Tool usage (006)
-- Budget management (008)
-
-## Multi-Agent Patterns (Supported)
-
-### Pattern 1: Worker Uses Subagent
-
-```bash
-# Inside a worker task
-SESSION=$(start_subagent @reviewer.md "Review these changes")
-result=$(tmux_wait.sh $SESSION /tmp/output.txt)
-```
-
-**Use Case:** Need expert agent for focused task.
-
-**Rules:**
-- ✅ Use focused system prompts
-- ✅ Clear success criteria
-- ❌ Don't use generic prompts
-- ❌ Don't reuse subagent across tasks
-
-### Pattern 2: Parallel Tasks
-
-```yaml
-phases:
-  - id: task1
-    subject: "Task 1"
-  - id: task2
-    subject: "Task 2"
-  # task1 and task2 can run in parallel (no dependencies)
-```
-
-**Use Case:** Independent tasks that can run concurrently.
-
-**Rules:**
-- ✅ Parallelize independent tasks
-- ✅ Use multiple workers
-- ❌ Don't share state between tasks
-
-## Anti-Patterns (Avoided)
-
-❌ **Orchestrator Agent** - LLM doesn't control workflow (code-driven instead)
-
-❌ **Worker Orchestrating** - Workers don't spawn workers (runtime does)
-
-❌ **Nested Subagents** - Subagent spawning subagent (not supported)
-
-❌ **State Sharing** - Workers sharing global state (should be isolated)
-
-❌ **Agent as Hammer** - Using subagent for everything (use for focused tasks only)
-
-## Future Directions
-
-### Potential Improvements
-
-1. **Workflow Optimization**: Use session-analyzer offline to improve templates
-2. **Test Coverage**: Increase coverage for pkg/tools and pkg/rpc
-3. **Performance Metrics**: Add detailed performance tracking
-4. **Documentation**: More detailed usage examples
-5. **Error Recovery**: Better error recovery and retry logic
-
-### Out of Scope
-
-- Multi-agent orchestration (LLM-driven)
-- Automatic system prompt optimization (manual instead)
-- Real-time workflow self-modification (offline optimization instead)
-- Distributed execution (single-machine focus)

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -59,299 +59,195 @@ This means:
 │  │  RecentMessages: []AgentMessage                          │ │
 │  │  AgentState: *AgentState     — system metadata           │ │
 │  └─────────────────────────────────────────────────────────┘ │
-│                           │                                   │
-│                           ▼                                   │
-│  ┌─────────────────────────────────────────────────────────┐ │
-│  │          Persistence Layer                                │ │
-│  │                                                          │ │
-│  │  Journal (messages.jsonl) — append-only event log         │ │
-│  │  Checkpoints — periodic snapshots (checkpoint + symlink)  │ │
-│  └─────────────────────────────────────────────────────────┘ │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-## 3. The ContextManager: LLM as Decision-Maker
+## 3. Compaction Triggers
 
-`pkg/compact/context_management.go`
+### 3.1 Pre-LLM Threshold Check
 
-### 3.1 Trigger Logic (System Decides *When*)
+Before every LLM call, the agent loop checks:
 
-The system uses token percentage + tool-call interval to decide when to run a context management cycle:
-
-| Token Usage  | Check Interval (tool calls) |
-|--------------|-----------------------------|
-| < 20%        | No checks                   |
-| 20%–33%      | Every 15 tool calls         |
-| 33%–50%      | Every 10 tool calls         |
-| 50%+         | Every 7 tool calls          |
-
-### 3.2 Decision Cycle (LLM Decides *What*)
-
-When triggered, `ContextManager.CompactWithCtx()`:
-
-1. **Builds an annotated conversation** — the full `RecentMessages` with truncation status, tool output previews, and the current LLM Context.
-2. **Creates context management tools** — the LLM can choose from:
-   - `truncate_messages` — replace specific old tool outputs with head/tail summary
-   - `update_llm_context` — update the structured task state string
-   - `compact` — full compaction via the heavyweight Compactor (summarize + trim messages)
-   - `no_action` — context is healthy, do nothing
-3. **Makes an independent LLM call** — with a dedicated system prompt (`pkg/prompt/context_management.md`), the conversation context, and the management tools.
-4. **Executes the LLM's tool calls** — applies truncate/update/compact operations to `AgentContext`.
-
-The main agent LLM is **never** involved in context management decisions. This separation ensures the management LLM focuses solely on context quality.
-
-### 3.3 Why Tool-Based, Not Rule-Based
-
-| Scenario | Rule-Based | LLM-Driven (our approach) |
-|----------|-----------|--------------------------|
-| Old grep output from a resolved bug | Truncate by age → might lose it | LLM reads it → "resolved, safe to truncate" |
-| Critical error from 10 turns ago | Truncate by size → might remove it | LLM reads it → "still relevant, keep it" |
-| Task phase completed | Cannot detect | LLM detects phase shift → compact |
-| Context is healthy | Still runs checks | LLM returns `no_action` |
-
-## 4. Core Data Structures
-
-### 4.1 AgentContext (`pkg/context/context.go`)
-
-The central in-memory state:
-
-```go
-type AgentContext struct {
-    SystemPrompt   string
-    Tools          []Tool
-    Skills         []skill.Skill
-
-    LLMContext     string         // Structured task state maintained by LLM
-    RecentMessages []AgentMessage // Conversation history
-    AgentState     *AgentState    // System-maintained metadata
-
-    LastCompactionSummary string
-    LLMContext       string      // Structured context content (injected when non-empty)
-
-    OnCompactEvent func(*CompactEventDetail) error
-}
+```
+estimatedTokens > dynamicThreshold
 ```
 
-Note: `AgentContext` contains the same fields as `ContextSnapshot` but does **not** embed it. They serve different purposes:
-- `AgentContext` is the mutable, live state with callbacks and tool management
-- `ContextSnapshot` is an immutable, serializable point-in-time capture for checkpoint persistence
-
-### 4.2 AgentState (`pkg/context/agent_state.go`)
-
-System-maintained tracking metadata (LLM never writes this directly):
-
-```go
-type AgentState struct {
-    WorkspaceRoot     string
-    CurrentWorkingDir string
-    TotalTurns        int
-    TokensUsed        int
-    TokensLimit       int
-
-    // Context management tracking
-    LastLLMContextUpdate      int  // Turn when LLMContext was last updated
-    LastTriggerTurn           int  // Turn when context management last ran
-    TurnsSinceLastTrigger     int  // Turns since last trigger
-    ToolCallsSinceLastTrigger int  // Tool calls since last trigger
-    TotalTruncations          int
-    TotalCompactions           int
-    LastCompactTurn            int
-
-    // Runtime telemetry cache
-    RuntimeMetaSnapshot string
-    RuntimeMetaBand     string
-    RuntimeMetaTurns    int
-}
-```
-
-### 4.3 AgentMessage (`pkg/context/message.go`)
-
-```go
-type AgentMessage struct {
-    Role       string         // "user", "assistant", "toolResult"
-    Content    []ContentBlock // TextContent, ImageContent, ToolCallContent, ThinkingContent
-    Metadata   *MessageMetadata
-    Truncated  bool           // Set by truncate_messages tool
-    ToolCallID string         // For toolResult ↔ toolCall pairing
-    // ...
-}
-```
-
-Message visibility is controlled by `MessageMetadata`:
-
-| Flag | Default | Effect |
-|------|---------|--------|
-| `AgentVisible` | true (nil = true) | If false, excluded from `ConvertMessagesToLLM` and token estimation |
-| `UserVisible` | true (nil = true) | If false, excluded from UI display |
-| `Kind` | "" | Semantic type: "tool_result", "tool_result_archived", etc. |
-
-## 5. Compaction Triggers
-
-### 5.1 Pre-LLM Threshold Compaction
-
-Before each LLM call, the loop iterates through the Compactor chain:
-
-```go
-for _, c := range config.Compactors {
-    if c.ShouldCompact(ctx, agentCtx) {
-        compacted, compactErr = c.Compact(agentCtx)
-        if compactErr == nil {
-            break // First successful compaction wins
-        }
-    }
-}
-```
-
-The chain has two entries (in `cmd/ai/rpc_handlers.go`):
-
-1. **ContextManager** — lightweight LLM-driven (see §3)
-2. **sessionCompactor** — heavyweight; wraps `compact.Compactor` for full summarization and persists via `Session.Compact()`
-
-### 5.2 Context-Limit Recovery
-
-After an `IsContextLengthExceeded` API error, the loop attempts compaction once (`maxCompactionRecoveries = 1`), then retries the LLM call.
-
-### 5.3 The Compactor Interface
-
-```go
-type Compactor interface {
-    ShouldCompact(ctx context.Context, agentCtx *AgentContext) bool
-    Compact(ctx *AgentContext) (*CompactionResult, error)
-    CalculateDynamicThreshold() int
-}
-```
-
-## 6. Compaction Strategies in Detail
-
-### 6.1 truncate_messages (`pkg/tools/context_mgmt/truncate_messages.go`)
-
-The lightest action. The LLM selects specific tool result messages by ID, and the tool:
-
-1. Validates IDs exist and are not in the protected zone (last `RecentMessagesKeep=5` messages)
-2. Marks each message `Truncated=true`
-3. Replaces content with `TruncateWithHeadTail()` output: first 1000 chars + last 1000 chars with a truncation marker
-
-This is the primary tool for reclaiming tokens — most tool outputs are large and become irrelevant after a few turns.
-
-### 6.2 update_llm_context (`pkg/tools/context_mgmt/update_llm_context.go`)
-
-Updates the in-memory `AgentContext.LLMContext` string. This is the LLM's mechanism for maintaining a structured summary of:
-
-- Current task and progress
-- Key files and code elements
-- Errors encountered
-- Decisions made
-- Next steps
-
-After compaction, `LLMContext` is the **only** source of task continuity — the old messages are gone. This makes updating LLM Context before or during compaction critical.
-
-### 6.3 compact (`pkg/compact/compact_tool.go`)
-
-The heavy action. Delegates to the full `compact.Compactor` which:
-
-1. Finds the cut point using `KeepRecentTokens` (default 20,000) from the tail
-2. Summarizes removed messages via a separate LLM call (prompts: `compact_system.md`, `compact_summarize.md`)
-3. Replaces `RecentMessages` with: summary message + kept recent messages
-4. Preserves `LLMContext` — never overwritten (it is managed by the LLM via `update_llm_context`)
-
-After compact, `LLMContext` is injected into the next LLM call so the agent recovers task continuity.
-
-### 6.4 no_action (`pkg/tools/context_mgmt/no_action.go`)
-
-The LLM explicitly declines action. This is a valid outcome — the LLM judges the context is healthy and no management is needed.
-
-## 7. Persistence and Recovery
-
-### 7.1 Journal (`messages.jsonl`)
-
-Append-only event log. Entry types:
-
-| Type | Purpose |
-|------|---------|
-| `message` | Normal conversation message |
-| `truncate` | Records which tool output was truncated (ID + turn) |
-| `compact`  | Records summary + how many messages were kept |
-
-Truncate and compact entries enable **reconstruction**: when replaying journal entries, truncate events are re-applied to messages and compact events reset the message list.
-
-### 7.2 Checkpoints
-
-Periodic snapshots stored under `sessionDir/checkpoints/` with a `current` symlink to the latest. Managed by `AgentContextCheckpointManager` (`pkg/agent/checkpoint_manager.go`).
-
-**When created**: After compaction when `LLMContextUpdated == true` (meaningful state change). Skipped when only truncation occurred (resume can replay from last checkpoint).
-
-**What's stored**: Full `ContextSnapshot` — `LLMContext`, `RecentMessages`, `AgentState`.
-
-### 7.3 Reconstruction (`pkg/context/reconstruction.go`)
-
-On resume, `ReconstructSnapshotWithCheckpoint`:
-
-1. Load latest checkpoint
-2. Replay journal entries after checkpoint's `MessageIndex`
-3. Apply truncate events to replayed messages
-4. Apply compact events (reset messages, set summary as LLMContext)
-5. Recalculate runtime counters from replayed messages
-
-## 8. Runtime Telemetry
-
-### 8.1 runtime_state Snapshot
-
-Injected as a user message in every LLM call (from turn 1). Contains:
-
-- Token usage band and percentage
-- Message count bucket
-- LLM context size bucket
-- Workspace paths
-- Stale/large tool output counts
-- Compaction decision signals
-
-**Known issue with injection position**: Currently inserted before the last user message via `insertBeforeLastUserMessage`. In single-turn long-task scenarios, this position shifts on every turn, breaking the LLM provider's KV cache mechanism. In multi-turn conversations the position is fine — the earlier messages stay stable.
-
-### 8.2 Telemetry Refresh Policy
-
-`RuntimeMetaSnapshot` is cached and refreshed when:
-
-- First time (empty cache)
-- Token usage band changes
-- Every `defaultRuntimeMetaHeartbeatTurns = 6` turns
-
-Values are bucketized for privacy and to reduce cache invalidation:
-- `tokens_band`: 0-20, 20-40, 40-60, 60-80, 80-100
-- `messages_in_history_bucket`: 0-20, 20-50, 50-100, 100+
-- `llm_context_size_bucket`: 0-1KB, 1-4KB, 4-16KB, 16KB+
-
-## 9. Tool Output Processing
-
-### 9.1 Normalization (`pkg/agent/tool_output.go`)
-
-Every tool output is normalized before being added to `RecentMessages`:
-
-- **Text output**: Truncated to 10,000 chars (head+tail preservation) if it exceeds the limit
-- **Error patterns**: Detected and preserved with higher priority
-- **Images**: Preserved completely
-
-### 9.2 Stale Output Detection
-
-For runtime telemetry (not for automatic action), stale tool outputs are counted:
-- Tool results within the last 10 messages are "fresh"
-- Beyond that: "stale" and reported as truncation candidates to the context management LLM
-
-## 10. Token Estimation
-
-`AgentContext.EstimateTokens()` uses:
-
-1. Last assistant usage totals (from API response) if available
-2. Plus heuristic estimation for trailing messages since last usage report
-
-Per-message heuristic: `ceil(len(text) / 4)`, images ~1200 tokens each.
-
-The `Compactor.CalculateDynamicThreshold()` computes:
+Where `dynamicThreshold` is calculated by `Compactor.CalculateDynamicThreshold()`:
 
 ```
 threshold = contextWindow - systemPromptTokens - 3000(tool defs) - ReserveTokens(16384)
 ```
 
-## 11. Key File Index
+If exceeded, compactors are tried in priority order (array order in `LoopConfig.Compactors`). The first compactor whose `ShouldCompact()` returns true is used.
+
+### 3.2 Context-Limit Recovery
+
+If the LLM API returns a context-length-exceeded error:
+
+1. Compact the context using the heavyweight compactor
+2. Retry the LLM call
+3. Maximum one recovery attempt per session to prevent infinite loops
+
+This is the safety net for cases where the threshold check underestimated token usage.
+
+## 4. Compactor Implementations
+
+### 4.1 ContextManager (Lightweight, LLM-Driven)
+
+**File:** `pkg/compact/context_management.go`
+
+This is the primary compaction strategy. It makes a **separate LLM call** with:
+- The current conversation as context (with stale annotations)
+- Context management tools: `truncate_messages`, `update_llm_context`, `compact`, `no_action`
+- A specialized system prompt (`pkg/prompt/context_management.md`)
+
+The LLM decides what action to take. Common outcomes:
+- **Truncate**: Remove stale tool outputs from early in the conversation
+- **Update LLM Context**: Update the task state summary for continuity
+- **Compact**: Trigger full summarization (falls through to heavyweight compactor)
+- **No Action**: Context is healthy, do nothing
+
+### 4.2 Compact (Heavyweight Summarization)
+
+**File:** `pkg/compact/compact.go`
+
+Full conversation summarization via LLM:
+1. Sends the entire conversation to a summarization LLM
+2. Generates a summary of the conversation so far
+3. Replaces old messages with the summary
+4. Preserves recent messages (configurable `keepRecent`)
+
+### 4.3 Session Compaction Bridge
+
+**File:** `cmd/ai/session_writer.go`
+
+Wraps the heavyweight compactor with session-aware persistence:
+- Records compaction as a journal entry
+- Manages the compaction cut-point in the session file
+- Ensures session file consistency after compaction
+
+## 5. Context Management Tools
+
+These tools are provided to the context management LLM:
+
+### 5.1 `truncate_messages`
+
+**File:** `pkg/tools/context_mgmt/truncate_messages.go`
+
+Removes specific messages from the conversation. The LLM specifies which message IDs to truncate based on its analysis of staleness.
+
+### 5.2 `update_llm_context`
+
+**File:** `pkg/tools/context_mgmt/update_llm_context.go`
+
+Updates the `LLMContext` string — the structured task state that persists across compactions. This is the primary mechanism for task continuity.
+
+### 5.3 `no_action`
+
+**File:** `pkg/tools/context_mgmt/no_action.go`
+
+Signals that no context management is needed. The LLM uses this when the context is healthy.
+
+### 5.4 `compact`
+
+**File:** `pkg/compact/compact_tool.go`
+
+Triggers full heavyweight compaction. Used when the LLM determines that truncation alone is insufficient.
+
+## 6. LLM Context (Task State)
+
+`AgentContext.LLMContext` is a string maintained by the context management LLM. It serves as the **source of truth for task continuity** after compaction.
+
+### 6.1 How It Works
+
+1. Before compaction, the context management LLM reads the full conversation
+2. It uses `update_llm_context` to write a structured summary of current task state
+3. After compaction, `LLMContext` is injected into every future LLM request
+4. The agent continues with full awareness of what happened before compaction
+
+### 6.2 Injection Point
+
+`LLMContext` content is injected into the system prompt via `insertBeforeLastUserMessage`. This ensures:
+- The LLM always sees current task state
+- KV cache efficiency for earlier messages is preserved in multi-turn conversations
+
+### 6.3 Runtime Telemetry
+
+The agent loop injects runtime state as informational telemetry into the system prompt:
+
+```yaml
+context_meta:
+  tokens_band: 20-40
+  action_hint: light_compression
+  tokens_used_approx: 40000
+  tokens_max: 200000
+```
+
+This keeps the agent informed about context pressure without compelling it to act directly (the context management LLM handles that).
+
+## 7. Session Persistence & Recovery
+
+### 7.1 Journal Format
+
+Session entries in `messages.jsonl`:
+
+| Type | Description |
+|------|-------------|
+| `session` | Header with session ID and metadata |
+| `message` | User/assistant/tool message |
+| `truncate` | Record of truncated messages |
+| `compact` | Compaction cut-point marker |
+
+### 7.2 Checkpoint System
+
+**File:** `pkg/context/checkpoint.go`
+
+Periodic snapshots for fast recovery:
+- Checkpoint: Full state serialized to `checkpoint.jsonl`
+- Checkpoint index: Maps entry IDs to checkpoint positions
+- Recovery: Load checkpoint → replay journal entries after checkpoint
+
+### 7.3 Reconstruction
+
+**File:** `pkg/context/reconstruction.go`
+
+Rebuilds in-memory state from checkpoint + journal:
+1. Load checkpoint file
+2. Find all journal entries after the checkpoint
+3. Replay entries to rebuild `AgentContext`
+4. Track reconstruction counters for diagnostics
+
+## 8. Tool Output Processing
+
+### 8.1 Normalization
+
+**File:** `pkg/agent/tool_output.go`
+
+Every tool output is normalized before being added to context:
+- **Text output**: Truncated to 10,000 chars (head+tail preservation) if it exceeds the limit
+- **Error patterns**: Detected and preserved with higher priority
+- **Images**: Preserved completely
+
+### 8.2 Stale Output Detection
+
+For runtime telemetry (not automatic action), stale tool outputs are counted:
+- Tool results within the last 10 messages are "fresh"
+- Beyond that: "stale" and reported as truncation candidates
+
+### 8.3 Tool Call Cutoff
+
+When the number of visible tool results exceeds `ToolCallCutoff` (default: 10), the oldest tool outputs are summarized. This prevents context bloat from accumulated tool results.
+
+## 9. Token Estimation
+
+**File:** `pkg/context/context.go`
+
+`AgentContext.EstimateTokens()` uses:
+1. Last assistant usage totals (from API response) if available
+2. Plus heuristic estimation for trailing messages since last usage report
+3. Per-message heuristic: `ceil(len(text) / 4)`, images ~1200 tokens each
+
+## 10. Key File Index
 
 | File | Responsibility |
 |------|---------------|
@@ -361,7 +257,10 @@ threshold = contextWindow - systemPromptTokens - 3000(tool defs) - ReserveTokens
 | `pkg/context/snapshot.go` | ContextSnapshot for checkpoint persistence |
 | `pkg/context/compactor.go` | Compactor interface, CompactionResult |
 | `pkg/context/journal.go` | JournalEntry types (message/truncate/compact) |
+| `pkg/context/journal_io.go` | Journal I/O operations |
 | `pkg/context/checkpoint.go` | Checkpoint save/load, symlink management |
+| `pkg/context/checkpoint_index.go` | Checkpoint index for fast lookup |
+| `pkg/context/checkpoint_io.go` | Checkpoint I/O operations |
 | `pkg/context/reconstruction.go` | Snapshot reconstruction from checkpoint + journal replay |
 | `pkg/compact/compact.go` | Heavyweight Compactor (LLM summarization) |
 | `pkg/compact/compact_tool.go` | Compact tool (exposed to context management LLM) |
@@ -369,21 +268,28 @@ threshold = contextWindow - systemPromptTokens - 3000(tool defs) - ReserveTokens
 | `pkg/tools/context_mgmt/truncate_messages.go` | Truncate tool implementation |
 | `pkg/tools/context_mgmt/update_llm_context.go` | LLM Context update tool |
 | `pkg/tools/context_mgmt/no_action.go` | No-action tool |
-| `pkg/tools/context_mgmt/registry.go` | Tool registry |
+| `pkg/tools/context_mgmt/registry.go` | Context management tool registry |
 | `pkg/agent/loop.go` | Agent loop, compaction triggers, telemetry injection |
+| `pkg/agent/agent.go` | Agent lifecycle, auto-compact, config management |
 | `pkg/agent/conversion.go` | Message visibility filtering, LLM message conversion |
 | `pkg/agent/tool_output.go` | Tool output normalization |
+| `pkg/agent/tool_call_normalize.go` | Tool call normalization |
 | `pkg/agent/checkpoint_manager.go` | Checkpoint lifecycle management |
+| `pkg/agent/metrics.go` | Metrics collection (token rates, turn tracking) |
+| `pkg/agent/executor.go` | Tool execution with concurrency control |
 | `pkg/session/compaction.go` | Session-level compaction cut-point logic |
+| `pkg/session/session.go` | Session persistence (JSONL, fork support) |
+| `pkg/session/lazy.go` | Lazy session loading |
 | `cmd/ai/session_writer.go` | sessionCompactor: session-aware compaction wrapper |
+| `pkg/prompt/builder.go` | System prompt construction |
 | `pkg/prompt/context_management.md` | System prompt for context management LLM |
 | `pkg/prompt/compact_system.md` | Summarization assistant system prompt |
 | `pkg/prompt/compact_summarize.md` | Summarization template |
 | `pkg/prompt/compact_update.md` | Incremental summary update template |
 
-## 12. Design Principles
+## 11. Design Principles
 
-1. **LLM decides strategy, system decides timing** — The system controls *when* to trigger context management (token thresholds, intervals). The LLM controls *what* to do (truncate, update context, compact, or skip).
+1. **LLM decides strategy, system decides timing** — The system controls *when* to trigger context management (token thresholds, intervals). The LLM controls *what to do* (truncate, update context, compact, or skip).
 
 2. **LLM Context is the task state source of truth** — After compaction, `LLMContext` (maintained by the LLM via `update_llm_context`) is the only source of task continuity. Old messages are gone.
 
@@ -393,6 +299,6 @@ threshold = contextWindow - systemPromptTokens - 3000(tool defs) - ReserveTokens
 
 5. **LLM Context injection** — `LLMContext` content is always injected into LLM requests when non-empty, so the agent maintains task continuity after compaction or context updates.
 
-6. **Protected recent messages** — The last 5 messages are never truncated, ensuring the agent always has its most recent context.
+6. **Protected recent messages** — The last few messages are never truncated, ensuring the agent always has its most recent context.
 
 7. **Telemetry, not directives** — Runtime state is injected as informational telemetry (not commands), keeping the main agent informed about context pressure without compelling it to act directly.

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -59,6 +59,14 @@ This means:
 │  │  RecentMessages: []AgentMessage                          │ │
 │  │  AgentState: *AgentState     — system metadata           │ │
 │  └─────────────────────────────────────────────────────────┘ │
+│                           │                                   │
+│                           ▼                                   │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │          Persistence Layer                                │ │
+│  │                                                          │ │
+│  │  Journal (messages.jsonl) — append-only event log         │ │
+│  │  Checkpoints — periodic snapshots (checkpoint + symlink)  │ │
+│  └─────────────────────────────────────────────────────────┘ │
 └─────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -2,16 +2,18 @@
 
 ## Overview
 
-This document outlines the testing strategy for the `ai` project, covering unit tests, integration tests, regression tests, and E2E (end-to-end) tests.
+This document outlines the testing strategy for the `ai` project, covering unit tests, integration tests, regression tests, and E2E benchmark tests.
 
 ## Test Pyramid
 
 ```
-        E2E Tests (74 benchmark tasks)
+        E2E Benchmark Tests (benchmark/)
               ↓
       Integration Tests
               ↓
         Unit Tests
+              ↓
+    Regression Tests (guardrails)
 ```
 
 ## Layer 1: Unit Tests (Fast, Focused)
@@ -20,35 +22,49 @@ This document outlines the testing strategy for the `ai` project, covering unit 
 
 Test individual functions and methods in isolation.
 
-### Target Coverage
+### Key Test Files
 
-- **pkg/agent**: 71.2% → 80%
-- **pkg/prompt**: 77.5% → 80%
-- **pkg/skill**: 74.6% → 80%
-- **pkg/tools**: 35.4% → 60%
-- **pkg/rpc**: 24.8% → 50%
-- **pkg/context**: 37.0% → 60%
-- **pkg/llm**: 38.1% → 60%
-
-### Examples
-
-- `pkg/agent/agent_test.go`: Agent lifecycle
-- `pkg/agent/loop_test.go`: Loop behavior
-- `pkg/context/compactor_test.go`: Compaction logic
-- `pkg/tools/bash_test.go`: Bash tool timeout
-- `pkg/tools/executor_test.go`: Tool execution
-
-### When to Write
-
-- Implementing new business logic
-- Fixing bugs (test first)
-- Refactoring code
-- Adding new guardrails
+| Package | Test File | Focus |
+|---------|-----------|-------|
+| `pkg/agent` | `agent_test.go` | Agent lifecycle, config |
+| `pkg/agent` | `loop_test.go` | Loop behavior, telemetry |
+| `pkg/agent` | `executor_test.go` | Tool execution pool |
+| `pkg/agent` | `tool_output_test.go` | Output normalization |
+| `pkg/agent` | `tool_guard_test.go` | Guard rail enforcement |
+| `pkg/agent` | `tool_call_normalize_test.go` | Tool call parsing |
+| `pkg/agent` | `result_test.go` | Result processing |
+| `pkg/agent` | `error_stack_test.go` | Error chain tracking |
+| `pkg/agent` | `checkpoint_manager_test.go` | Checkpoint management |
+| `pkg/compact` | `compact_test.go` | Compaction logic |
+| `pkg/compact` | `context_management_test.go` | LLM-driven context management |
+| `pkg/compact` | `compact_tool_pairing_test.go` | Compact tool integration |
+| `pkg/config` | `config_test.go` | Configuration loading |
+| `pkg/config` | `auth_test.go` | API key resolution |
+| `pkg/config` | `models_test.go` | Model spec handling |
+| `pkg/context` | `checkpoint_test.go` | Checkpoint save/load |
+| `pkg/llm` | `client_test.go` | LLM client |
+| `pkg/llm` | `errors_test.go` | Error classification |
+| `pkg/prompt` | `builder_test.go` | Prompt construction |
+| `pkg/rpc` | `server_test.go` | RPC server |
+| `pkg/session` | `session_test.go` | Session CRUD |
+| `pkg/session` | `lazy_test.go` | Lazy loading |
+| `pkg/session` | `compaction_test.go` | Session compaction |
+| `pkg/skill` | `skill_test.go` | Skill loading |
+| `pkg/skill` | `integration_test.go` | Skill discovery |
+| `pkg/tools` | `bash_timeout_test.go` | Bash timeout handling |
+| `pkg/tools` | `bash_sleep_test.go` | Sleep detection |
+| `pkg/tools` | `grep_test.go` | Grep tool |
+| `pkg/tools` | `read_test.go` | Read tool |
+| `pkg/tools` | `hashline_test.go` | Hashline mode |
+| `pkg/traceevent` | `trace_test.go` | Trace recording |
+| `pkg/traceevent` | `slog_bridge_test.go` | Log bridge |
+| `pkg/traceevent` | `config_selectors_test.go` | Event configuration |
+| `pkg/truncate` | `truncate_test.go` | Output truncation |
 
 ### Running Unit Tests
 
 ```bash
-# Run all unit tests
+# Run all tests
 go test ./...
 
 # Run specific package
@@ -56,41 +72,45 @@ go test ./pkg/agent -v
 
 # Run with coverage
 go test -coverprofile=coverage.out ./...
-
-# Generate HTML coverage report
 go tool cover -html=coverage.out -o coverage.html
 
-# Check coverage for specific package
-go test -cover ./pkg/agent
+# Run a single test
+go test -run TestRegression001 ./pkg/agent -v
 ```
 
-## Layer 2: Integration Tests (Medium, Realistic)
+## Layer 2: Integration Tests
 
 ### Purpose
 
-Test component interactions.
+Test component interactions within the agent system.
 
-### Target Coverage
+### Key Test Files
 
-- Agent + Tools integration
-- RPC handlers + Agent
-- Workflow + Orchestrate
-- Task scheduling and dependencies
-- Human-in-the-loop checkpoints
-
-### Examples
-
-- `pkg/agent/agent_integration_test.go`: Agent with tools
-- `skills/workflow/orchestrate/integration_test.go`: Workflow execution
-- RPC handler integration tests
-- Session persistence tests
-
-### When to Write
-
-- Adding new integration points
-- Changing component interfaces
-- Testing error paths
-- Validating cross-component behavior
+| Test File | Focus |
+|-----------|-------|
+| `pkg/agent/agent_integration_test.go` | Agent + tools + session |
+| `pkg/agent/agent_stress_test.go` | Concurrent agent operations |
+| `pkg/agent/loop_stream_integration_test.go` | Streaming + loop interaction |
+| `pkg/agent/loop_recovery_test.go` | Error recovery flows |
+| `pkg/agent/loop_empty_response_test.go` | Empty response handling |
+| `pkg/agent/loop_tool_parallel_test.go` | Parallel tool execution |
+| `pkg/agent/conversion_visibility_test.go` | Message visibility filtering |
+| `pkg/agent/llm_context_test.go` | LLM context lifecycle |
+| `pkg/agent/runtime_meta_test.go` | Runtime telemetry |
+| `pkg/agent/metrics_trace_test.go` | Metrics via trace events |
+| `pkg/session/compact_event_test.go` | Session compaction events |
+| `pkg/skill/integration_test.go` | Skill loading integration |
+| `cmd/ai/integration_test.go` | Full CLI integration |
+| `cmd/ai/session_writer_test.go` | Session writer compaction |
+| `cmd/ai/traceevent_handler_test.go` | Trace event handling |
+| `cmd/ai/kill_test.go` | Agent lifecycle (kill) |
+| `cmd/ai/ls_test.go` | Run listing |
+| `cmd/ai/watch_test.go` | Watch TUI |
+| `pkg/run/conv_test.go` | Run metadata conversion |
+| `pkg/run/socket_test.go` | Socket server |
+| `pkg/run/meta_test.go` | Run metadata |
+| `skills/ag/cmd/backend_integration_test.go` | ag backend integration |
+| `skills/ag/internal/*/...` | ag internal package tests |
 
 ### Running Integration Tests
 
@@ -98,54 +118,39 @@ Test component interactions.
 # Run integration tests
 go test -v ./pkg/agent -run Integration
 
-# Run workflow integration tests
-go test -v ./skills/workflow/orchestrate
+# Run stress tests
+go test -v ./pkg/agent -run Stress
+
+# Run full agent tests (includes LLM calls, may be slow)
+go test -v ./pkg/agent -run Agent
 ```
 
-## Layer 3: Regression Tests (Critical, Must Pass)
+## Layer 3: Regression Tests (Guardrails)
 
 ### Purpose
 
-Prevent regression of historical bugs.
+Prevent regression of critical safety and behavior properties.
 
-### Target
+### Test File
 
-**100% pass rate** - All regression tests must pass.
+`pkg/agent/regression_test.go`
 
-### Test Categories
+### Regression Test Suite
 
-#### 1. Guardrail Configuration Tests (`pkg/agent/regression_test.go`)
-
-Ensure all guardrails are properly configured and enforced:
-
-- `TestRegression001_MaxConsecutiveToolCalls`: Prevent infinite tool call loops
-- `TestRegression002_AutoCompactConfiguration`: Context overflow recovery
-- `TestRegression003_ToolCallCutoffConfiguration`: Stale tool output truncation
-- `TestRegression004_MaxToolCallsPerName`: Prevent tool abuse
-- `TestRegression005_MaxTurnsConfiguration`: Prevent runaway conversations
-- `TestRegression006_ContextWindowConfiguration`: Enforce context limits
-- `TestRegression007_LLMRetryConfiguration`: Retry on rate limit errors
-- `TestRegression008_ToolOutputLimits`: Large output truncation
-- `TestRegression009_ExecutorPoolConfiguration`: Tool execution limits
-- `TestRegression010_EnableCheckpointConfiguration`: Checkpoint control
-- `TestRegression011_LLMTimeoutConfiguration`: LLM call timeouts
-- `TestRegression012_RuntimeMetaConfiguration`: Runtime meta updates
-
-#### 2. Behavior Regression Tests
-
-Test that specific behaviors don't regress:
-
-- Tool execution with timeout
-- Context compaction triggers
-- State persistence
-- Error recovery
-- Graceful degradation
-
-### When to Write
-
-- **Immediately after fixing a bug**: Add test to prevent regression
-- Before refactoring guardrails
-- When adding new safety features
+| Test | What It Guards |
+|------|---------------|
+| `TestRegression001_MaxConsecutiveToolCalls` | Prevent infinite tool call loops |
+| `TestRegression002_AutoCompactConfiguration` | Context overflow recovery |
+| `TestRegression003_ToolCallCutoffConfiguration` | Stale tool output truncation |
+| `TestRegression004_MaxToolCallsPerName` | Prevent tool abuse |
+| `TestRegression005_MaxTurnsConfiguration` | Prevent runaway conversations |
+| `TestRegression006_ContextWindowConfiguration` | Enforce context limits |
+| `TestRegression007_LLMRetryConfiguration` | Retry on rate limit errors |
+| `TestRegression008_ToolOutputLimits` | Large output truncation |
+| `TestRegression009_ExecutorPoolConfiguration` | Tool execution concurrency |
+| `TestRegression010_EnableCheckpointConfiguration` | Checkpoint control |
+| `TestRegression011_LLMTimeoutConfiguration` | LLM call timeouts |
+| `TestRegression012_RuntimeMetaConfiguration` | Runtime meta updates |
 
 ### Running Regression Tests
 
@@ -155,323 +160,85 @@ go test -v -run TestRegression ./...
 
 # Run specific regression test
 go test -v -run TestRegression001 ./pkg/agent
-
-# In CI: All regression tests must pass
 ```
 
-## Layer 4: E2E Tests (Slow, Realistic)
+**Rule:** All regression tests must pass before merging. 100% pass rate required.
+
+## Layer 4: E2E Benchmark Tests
 
 ### Purpose
 
-Test complete workflows and agent behaviors.
+Test complete agent behaviors with real LLM interactions.
 
 ### Test Suite
 
-74 benchmark tasks under `benchmark/tasks/`:
+Located under `benchmark/`:
 
-| Category | Tasks | Focus |
-|----------|-------|-------|
-| Agent Behavior | agent_001-010 | Exploration, debugging, memory |
-| Context Management | agent_004, 010, 011 | Overflow, compaction |
-| Tool Usage | agent_006 | Tool traps, misuse |
-| Performance | agent_008 | Budget management |
-| Code Generation | 001-013 | Various scenarios |
+| Category | Focus |
+|----------|-------|
+| Agent Behavior | Exploration, debugging, memory |
+| Context Management | Overflow, compaction |
+| Tool Usage | Tool traps, misuse |
+| Performance | Budget management |
+| Code Generation | Various scenarios |
 
-### Test Organization
-
-#### Agent Behavior Tests (agent_001-010)
-
-- `agent_001_forced_exploration`: Force agent to use grep efficiently
-- `agent_002_debugging_session`: Debug complex issues
-- `agent_003_...`: (various behavior tests)
-- `agent_010_compact_tool_call_mismatch`: Context compaction edge cases
-
-#### Context Management Tests
-
-- `agent_004_*`: Context overflow handling
-- `agent_010_*`: Compaction strategies
-- `agent_011_*`: Context window enforcement
-
-#### Tool Usage Tests
-
-- `agent_006_*`: Tool traps and misuse patterns
-- Tool execution with edge cases
-
-#### Performance Tests
-
-- `agent_008_*`: Budget and resource management
-- Token estimation accuracy
-- Cost enforcement
-
-### Running E2E Tests
+### Running Benchmark Tests
 
 ```bash
-# Run all E2E tests
-go test ./benchmark/...
-
-# Run fast subset (< 10 min)
-go test -fast ./benchmark/...
-
-# Run specific test
-go test -v ./benchmark/tasks/agent_001_forced_exploration
-
-# Run with manifest (subset of tasks)
-go test -manifest=fast-manifest.json ./benchmark/...
-```
-
-## Test Metrics
-
-### Coverage Targets
-
-| Package | Current | Target | Priority |
-|---------|---------|--------|----------|
-| pkg/agent | 71.2% | 80% | High |
-| pkg/prompt | 77.5% | 80% | Medium |
-| pkg/skill | 74.6% | 80% | Medium |
-| pkg/tools | 35.4% | 60% | High |
-| pkg/rpc | 24.8% | 50% | High |
-| pkg/context | 37.0% | 60% | High |
-| pkg/llm | 38.1% | 60% | Medium |
-
-### Pass Rate Targets
-
-- **Regression tests**: 100% (must pass)
-- **Unit tests**: >95%
-- **Integration tests**: >90%
-- **E2E tests (fast subset)**: >90%
-
-## Continuous Integration
-
-### Test Pipeline
-
-```yaml
-# CI Pipeline (example)
-
-stages:
-  - unit_tests:
-      - go test -cover ./...
-      - go tool cover -func=coverage.out
-      - Verify coverage >= targets
-
-  - regression_tests:
-      - go test -run TestRegression ./...
-      - Verify 100% pass rate
-
-  - integration_tests:
-      - go test ./pkg/agent -run Integration
-      - go test ./skills/workflow/orchestrate
-
-  - e2e_tests:
-      - go test -fast ./benchmark/...
-      - go test -manifest=fast-manifest.json ./benchmark/...
-```
-
-### Pre-Commit Checks
-
-```bash
-#!/bin/bash
-# scripts/pre-commit.sh
-
-# Run unit tests for changed packages
-go test ./$(changed_packages) -cover
-
-# Run regression tests (must pass)
-go test -run TestRegression ./...
-
-# Quick smoke test
-go test -run TestSmoke ./...
-```
-
-## Test Tools
-
-### Go Test Flags
-
-```bash
--v              # Verbose output
--cover          # Enable coverage
--coverprofile=  # Write coverage profile
--race           # Race detection
--parallel=      # Parallel execution
--count=1        # Run tests once (disable caching)
--timeout=       # Test timeout
--short          # Skip long tests
-```
-
-### Coverage Tools
-
-```bash
-# Generate coverage
-go test -coverprofile=coverage.out ./...
-
-# View coverage
-go tool cover -html=coverage.out -o coverage.html
-open coverage.html
-
-# Check coverage percentage
-go tool cover -func=coverage.out | grep total
-
-# Check specific package
-go tool cover -func=coverage.out | grep pkg/agent
-```
-
-### Benchmark Tests
-
-```bash
-# Run benchmarks
-go test -bench=. -benchmem ./...
-
-# Compare benchmarks
-go test -bench=. -benchmem ./... > old.txt
-# Make changes
-go test -bench=. -benchmem ./... > new.txt
-benchcmp old.txt new.txt
+# Run benchmark suite (requires API key, slow)
+cd benchmark && ./run.sh
 ```
 
 ## Test Best Practices
 
-### Unit Tests
+### When to Write Tests
 
-✅ **Do:**
-- Test single behavior per test
-- Use descriptive test names
-- Test happy paths and error paths
-- Use table-driven tests for multiple cases
-- Mock external dependencies
-- Test edge cases
+- **Unit test**: New business logic, bug fixes (test first), refactoring
+- **Integration test**: New integration points, interface changes, error paths
+- **Regression test**: Immediately after fixing a bug — prevent recurrence
+- **E2E test**: Complete workflow validation
 
-❌ **Don't:**
-- Test multiple behaviors in one test
-- Depend on external services
-- Test implementation details (test behavior instead)
-- Skip error cases
-- Use timeouts as primary test mechanism
+### Naming Conventions
 
-### Integration Tests
+- Unit tests: `Test<Component>_<Behavior>` (e.g., `TestAgent_Prompt`)
+- Regression tests: `TestRegression<NNN>_<Description>`
+- Integration tests: `Test<Feature>Integration` or file suffix `_integration_test.go`
 
-✅ **Do:**
-- Test component interactions
-- Use realistic data
-- Test error paths
-- Clean up after tests
-- Use test fixtures
-
-❌ **Don't:**
-- Test implementation details of internal components
-- Depend on external LLM (use mocks)
-- Skip cleanup
-- Test too many components at once
-
-### Regression Tests
-
-✅ **Do:**
-- Add test immediately after fixing bug
-- Test the specific bug scenario
-- Make test deterministic
-- Add comments explaining the bug
-- Run before merging any PR
-
-❌ **Don't:**
-- Skip regression tests
-- Remove tests when refactoring (update instead)
-- Make tests flaky (avoid timeouts, race conditions)
-
-### E2E Tests
-
-✅ **Do:**
-- Test complete workflows
-- Use representative scenarios
-- Document test purpose
-- Organize by category
-- Use timeouts appropriately
-
-❌ **Don't:**
-- Run too many tests in CI (use manifests)
-- Make tests too slow (target <10min for fast subset)
-- Skip tests silently
-
-## Test Maintenance
-
-### Adding Tests
-
-1. Write test first (TDD)
-2. Watch it fail
-3. Implement minimal code to pass
-4. Refactor
-5. Run full test suite
-
-### Updating Tests
-
-1. When behavior changes intentionally:
-   - Update test to match new behavior
-   - Document why behavior changed
-
-2. When fixing bugs:
-   - Add regression test
-   - Fix code to pass test
-   - Run full test suite
-
-### Removing Tests
-
-- Only remove tests when:
-  - Feature is being removed
-  - Test is redundant (document reason)
-  - Test is incorrect (replace with correct test)
-
-## Test Documentation
-
-### Test Comments
+### Test Patterns
 
 ```go
-// TestRegression001_MaxConsecutiveToolCalls tests that MaxConsecutiveToolCalls prevents infinite loops
-//
-// Bug: Agent gets stuck in tool call loop without progress
-// Fix: Added MaxConsecutiveToolCalls limit in LoopConfig
-func TestRegression001_MaxConsecutiveToolCalls(t *testing.T) {
-    // ...
+// Table-driven tests
+func TestToolNormalization(t *testing.T) {
+    tests := []struct{
+        name string
+        input string
+        want string
+    }{
+        {"basic", "hello", "hello"},
+        {"truncated", longString, truncatedResult},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got := normalize(tt.input)
+            assert.Equal(t, tt.want, got)
+        })
+    }
 }
 ```
 
-### Test Files
+## CI Pipeline
 
-- Organize tests alongside code (e.g., `agent_test.go`)
-- Use `*_test.go` suffix
-- Keep tests readable and maintainable
+### Stages
 
-## Troubleshooting
+1. **Unit tests**: `go test -cover ./...`
+2. **Regression tests**: `go test -run TestRegression ./...`
+3. **Integration tests**: `go test -v ./pkg/agent -run Integration`
+4. **E2E tests**: `cd benchmark && ./run.sh` (scheduled, not per-PR)
 
-### Flaky Tests
+### Pre-Commit
 
-Symptoms: Test passes sometimes, fails others.
-
-Solutions:
-- Remove randomness or use seeded random
-- Remove dependencies on timing
-- Use synchronization primitives
-- Add proper cleanup
-
-### Slow Tests
-
-Symptoms: Tests take too long to run.
-
-Solutions:
-- Use mocks instead of real LLM
-- Reduce test data size
-- Parallelize independent tests
-- Run only affected tests in CI
-
-### Coverage Not Improving
-
-Symptoms: Adding tests doesn't increase coverage.
-
-Solutions:
-- Check if tests are actually running
-- Verify tests are testing new code paths
-- Use `-coverprofile` to see what's not covered
-- Focus on untested critical paths
-
-## References
-
-- Go testing: https://golang.org/pkg/testing/
-- Table-driven tests: https://dave.cheney.net/2019/05/07/prefer-table-driven-tests
-- Test coverage: https://blog.golang.org/cover
-- Regression testing: https://en.wikipedia.org/wiki/Regression_testing
+```bash
+# Quick validation
+go test ./pkg/agent -run TestRegression -count=1
+go test ./... -short -count=1
+```


### PR DESCRIPTION
## Summary

Documentation overhaul to align with the current codebase.

### Changes

- **README.md**: Complete rewrite reflecting subcommand-based CLI (`ai run`, `ai serve`, `ai rpc`, `ai ls`, `ai watch`, `ai send`, `ai kill`), removed outdated win mode references, added ag CLI section, updated feature list, skills table, file locations, and tracing info. All in English.

- **docs/architecture.md**: Updated component diagram to match actual package structure (`pkg/agent`, `pkg/context`, `pkg/compact`, `pkg/traceevent`, etc.), added ag orchestration architecture (bridge-per-agent), removed stale workflow/orchestrate references, updated data flow descriptions and package structure listing.

- **docs/context-management.md**: Verified and aligned with current implementation. Updated key file index to reflect actual files (`checkpoint_index.go`, `journal_io.go`, `tool_call_normalize.go`, `metrics.go`, `executor.go`). Removed references to files that don't exist.

- **docs/test-strategy.md**: Replaced generic test file references with actual test files from the codebase. Updated regression test list (12 tests). Added comprehensive test file tables. Removed outdated workflow test references.

### What was NOT changed
- `docs/adr/` — kept as-is (architecture decision records)
- No code changes — documentation only

### Verification
- `go build ./...` passes (no code changes)
- All documentation references verified against actual source files