### PR TITLE
feat(ag): scheduler rewrite + conv streaming API + architecture refactoring

### DIFF
--- a/skills/ag/cmd/agent_client.go
+++ b/skills/ag/cmd/agent_client.go
@@ -11,7 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/genius/ag/internal/agent"
+			"github.com/genius/ag/internal/agent"
+	"github.com/genius/ag/internal/conv"
+	"github.com/genius/ag/internal/run"
 	"github.com/genius/ag/internal/storage"
 )
 
@@ -267,12 +269,11 @@ func outputFromAI(id string, tailN int) (string, error) {
 		return "", fmt.Errorf("get run ID for agent %s: %w", id, err)
 	}
 
-	homeDir, err := os.UserHomeDir()
+		eventsPath, err := run.EventsPath(runID)
 	if err != nil {
-		return "", fmt.Errorf("get home dir: %w", err)
+		return "", fmt.Errorf("get events path: %w", err)
 	}
-	eventsFile := filepath.Join(homeDir, ".ai", "runs", runID, "events.jsonl")
-	data, err := os.ReadFile(eventsFile)
+	data, err := os.ReadFile(eventsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil
@@ -280,10 +281,7 @@ func outputFromAI(id string, tailN int) (string, error) {
 		return "", fmt.Errorf("read events.jsonl: %w", err)
 	}
 
-	messages, err := parseAssistantMessages(data)
-	if err != nil {
-		return "", err
-	}
+		messages := conv.BuildAssistantTexts(data)
 	result := strings.Join(messages, "\n\n")
 
 	if tailN > 0 {
@@ -296,101 +294,8 @@ func outputFromAI(id string, tailN int) (string, error) {
 	return result, nil
 }
 
-func parseAssistantMessages(data []byte) ([]string, error) {
-	lines := strings.Split(string(data), "\n")
-	messages := make([]string, 0, 8)
-	var streaming strings.Builder
 
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
 
-		var event map[string]any
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			continue
-		}
-
-		etype, _ := event["type"].(string)
-		switch etype {
-		case "message_update":
-			assistantEvent, _ := event["assistantMessageEvent"].(map[string]any)
-			if assistantEvent != nil {
-				evType, _ := assistantEvent["type"].(string)
-				if evType == "text_delta" {
-					delta, _ := assistantEvent["delta"].(string)
-					streaming.WriteString(delta)
-				}
-			}
-		case "agent_end":
-			agentEndMessages := extractAssistantTextsFromAgentEnd(event)
-			if len(agentEndMessages) > 0 {
-				messages = append(messages, agentEndMessages...)
-				streaming.Reset()
-			}
-		case "turn_end":
-			if streaming.Len() > 0 {
-				messages = append(messages, strings.TrimSpace(streaming.String()))
-				streaming.Reset()
-			}
-		}
-	}
-
-	if streaming.Len() > 0 {
-		messages = append(messages, strings.TrimSpace(streaming.String()))
-	}
-
-	filtered := messages[:0]
-	for _, m := range messages {
-		if m = strings.TrimSpace(m); m != "" {
-			filtered = append(filtered, m)
-		}
-	}
-	return filtered, nil
-}
-
-func extractAssistantTextsFromAgentEnd(event map[string]any) []string {
-	rawMessages, _ := event["messages"].([]any)
-	if len(rawMessages) == 0 {
-		return nil
-	}
-
-	out := make([]string, 0, len(rawMessages))
-	for _, raw := range rawMessages {
-		msg, _ := raw.(map[string]any)
-		if msg == nil {
-			continue
-		}
-		role, _ := msg["role"].(string)
-		if role != "assistant" {
-			continue
-		}
-		content := extractTextFromContent(msg["content"])
-		if content != "" {
-			out = append(out, content)
-		}
-	}
-	return out
-}
-
-func extractTextFromContent(raw any) string {
-	items, _ := raw.([]any)
-	if len(items) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	for _, item := range items {
-		obj, _ := item.(map[string]any)
-		if obj == nil {
-			continue
-		}
-		if typ, _ := obj["type"].(string); typ == "text" {
-			text, _ := obj["text"].(string)
-			b.WriteString(text)
-		}
-	}
-	return strings.TrimSpace(b.String())
-}
 
 // Wait blocks until all specified agents reach a terminal state.
 func Wait(ctx context.Context, ids []string, timeoutSec int) error {

--- a/skills/ag/cmd/agent_status.go
+++ b/skills/ag/cmd/agent_status.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/genius/ag/internal/agent"
+	"github.com/genius/ag/internal/run"
 )
 
 // useAIAdapterForCommand returns true when the agent has a run mapping.
@@ -32,7 +32,7 @@ func GetAgentStatus(agentID string) (*agent.Activity, error) {
 
 	// For raw backends (codex, etc.), check process liveness and output.
 	if activity.Pid > 0 && activity.Status == "running" {
-		alive := isProcessAlive(activity.Pid)
+		alive := agent.IsProcessAlive(activity.Pid)
 		if !alive {
 			// Process exited. Scan output for terminal events.
 			agentDir := agent.AgentDir(agentID)
@@ -68,7 +68,7 @@ func getAgentStatusWithAI(agentID string) (*agent.Activity, error) {
 	// ai serve detached via Process.Release may not update run.json on exit.
 	// If run.json says running but PID is dead, mark as done.
 	if activity.Status == "running" && activity.Pid > 0 {
-		if !isProcessAlive(activity.Pid) {
+		if !agent.IsProcessAlive(activity.Pid) {
 			activity.Status = "done"
 			if activity.FinishedAt == 0 {
 				activity.FinishedAt = time.Now().Unix()
@@ -76,23 +76,20 @@ func getAgentStatusWithAI(agentID string) (*agent.Activity, error) {
 		}
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return activity, nil
-	}
-
 	runID, err := aiAdapter.getRunIDForAgent(agentID)
 	if err != nil {
 		return activity, nil
 	}
 
-		baseDir := filepath.Join(homeDir, ".ai", "runs")
-	eventsFile := filepath.Join(baseDir, runID, "events.jsonl")
+	eventsPath, err := run.EventsPath(runID)
+	if err != nil {
+		return activity, nil
+	}
 
 	// Read only the tail of events.jsonl — the file can be gigabytes.
 	// Use bytes.Contains to detect agent_end without parsing JSON,
 	// which also handles partial reads from large single-line events.
-	if tailData, err := readFileTail(eventsFile, 256*1024); err == nil {
+		if tailData, err := readFileTail(eventsPath, 256*1024); err == nil {
 		activity = enrichActivityFromEvents(activity, tailData)
 	}
 
@@ -188,11 +185,10 @@ func FormatAgentStatus(activity *agent.Activity, format string, agentID string) 
 		fmt.Printf("Error: %s\n", activity.Error)
 	}
 
-		if activity.Backend == "ai" {
-		homeDir, _ := os.UserHomeDir()
-		aiDir := filepath.Join(homeDir, ".ai", "runs")
-		if _, err := os.Stat(aiDir); err == nil {
-			fmt.Printf("AI runs directory: %s\n", aiDir)
+			if activity.Backend == "ai" {
+		aiRunsDir, _ := run.RunsDir()
+		if _, err := os.Stat(aiRunsDir); err == nil {
+			fmt.Printf("AI runs directory: %s\n", aiRunsDir)
 		}
 
 		// Show run ID for ai watch convenience
@@ -217,15 +213,6 @@ func timeNow() int64 {
 	return time.Now().Unix()
 }
 
-// isProcessAlive checks if a process with the given PID is still running.
-func isProcessAlive(pid int) bool {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	// Signal 0 does not kill the process, just checks existence.
-	return proc.Signal(syscall.Signal(0)) == nil
-}
 
 // readFileTail reads up to maxBytes from the end of a file.
 // Efficient for large files — seeks to offset rather than reading entire file.

--- a/skills/ag/cmd/agent_utils.go
+++ b/skills/ag/cmd/agent_utils.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/genius/ag/internal/agent"
@@ -25,16 +23,10 @@ func DetectStale(id string, act *agent.Activity) {
 	reason := ""
 
 	// Check process liveness via signal 0.
-	if act.Pid > 0 {
-		proc, err := os.FindProcess(act.Pid)
-		if err != nil {
+		if act.Pid > 0 {
+		if !agent.IsProcessAlive(act.Pid) {
 			stale = true
-			reason = "process not found"
-		} else {
-			if err := proc.Signal(syscall.Signal(0)); err != nil {
-				stale = true
-				reason = "process no longer alive"
-			}
+			reason = "process no longer alive"
 		}
 	} else {
 		agentDir := agent.AgentDir(id)

--- a/skills/ag/cmd/ai_adapter.go
+++ b/skills/ag/cmd/ai_adapter.go
@@ -12,32 +12,33 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/genius/ag/internal/run"
 	"github.com/genius/ag/internal/storage"
 )
 
-// AIAdapter 封装了 ai 新基础设施的调用
+// AIAdapter wraps calls to the ai serve infrastructure.
 type AIAdapter struct {
-	// agentID 到 runID 的映射缓存
+	// agentID to runID mapping cache
 	mappings map[string]string
 	mu       sync.RWMutex
 }
 
-// NewAIAdapter 创建新的 AIAdapter 实例
+// NewAIAdapter creates a new AIAdapter instance.
 func NewAIAdapter() *AIAdapter {
 	return &AIAdapter{
 		mappings: make(map[string]string),
 	}
 }
 
-// SpawnWithAIServe 使用 ai serve 命令启动一个新的 agent
+// SpawnWithAIServe starts a new agent using the ai serve command.
 func (a *AIAdapter) SpawnWithAIServe(id, system, input, cwd string) error {
-	// 创建 ag 的 agent 目录（用于向后兼容和存储映射）
+	// Create ag agent directory (for backward compat and storage mappings)
 	agentDir := storage.AgentDir(id)
 	if err := os.MkdirAll(agentDir, 0755); err != nil {
 		return fmt.Errorf("create agent dir: %w", err)
 	}
 
-	// 写入初始的 activity.json
+	// Write initial activity.json
 	activity := map[string]interface{}{
 		"status":    "running",
 		"backend":   "ai",
@@ -47,10 +48,10 @@ func (a *AIAdapter) SpawnWithAIServe(id, system, input, cwd string) error {
 		return fmt.Errorf("write activity.json: %w", err)
 	}
 
-		// 构建 ai serve 命令，在后台运行
+	// Build ai serve command to run in background
 	cmd := exec.Command("ai", "serve")
 
-	// 添加参数
+	// Add arguments
 	if system != "" {
 		cmd.Args = append(cmd.Args, "--system-prompt", system)
 	}
@@ -61,10 +62,10 @@ func (a *AIAdapter) SpawnWithAIServe(id, system, input, cwd string) error {
 		cmd.Dir = cwd
 	}
 
-	// 设置 agent 名称以便识别
+	// Set agent name for identification
 	cmd.Args = append(cmd.Args, "--name", "ag-agent-"+id)
 
-		// 将 stdout pipe 用于读取 run ID，stderr 丢弃到 os.DevNull
+	// Use stdout pipe to read run ID, discard stderr
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("create stdout pipe: %w", err)
@@ -74,12 +75,12 @@ func (a *AIAdapter) SpawnWithAIServe(id, system, input, cwd string) error {
 	// Create process group so child processes can be killed together.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-			if err := cmd.Start(); err != nil {
+	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("ai serve failed: %w", err)
 	}
 
-		// 读取 run ID（ai serve 输出 run ID 后继续运行）
-		// 用 ReadString 只读第一行就返回，不让 ai serve 的后续输出阻塞
+	// Read run ID (ai serve outputs run ID then keeps running).
+	// Use ReadString to read only the first line, don't let subsequent output block.
 	reader := bufio.NewReader(stdout)
 	firstLine, _ := reader.ReadString('\n')
 	stdout.Close() // Close pipe so ai serve won't block if it writes >64KB to stdout
@@ -88,7 +89,7 @@ func (a *AIAdapter) SpawnWithAIServe(id, system, input, cwd string) error {
 		runID = strings.TrimSpace(firstLine)
 	}
 	if runID == "" {
-		// ai serve 没返回 run ID，尝试 ai ls
+		// ai serve returned no run ID, try ai ls
 		fmt.Println("ai serve returned no run ID, trying ai ls...")
 		runID, err = a.getLatestRunID()
 		if err != nil {
@@ -97,31 +98,31 @@ func (a *AIAdapter) SpawnWithAIServe(id, system, input, cwd string) error {
 		fmt.Printf("Found run ID from ai ls: %s\n", runID)
 	}
 
-		// 保存 PID（Release 后 Pid 字段会被清零）
+	// Save PID (Release zeroes the Pid field)
 	pid := cmd.Process.Pid
 
-	// 让 ai serve 进程脱离父进程，不阻塞 spawn
+	// Detach ai serve process from parent so spawn doesn't block
 	if err := cmd.Process.Release(); err != nil {
-		// 非致命错误，进程已经启动
+		// Non-fatal, process is already started
 		fmt.Fprintf(os.Stderr, "warning: could not release ai serve process: %v\n", err)
 	}
 
-	// 保存 PID 到 activity
+	// Save PID to activity
 	activity["pid"] = pid
 	if err := storage.AtomicWriteJSON(filepath.Join(agentDir, "activity.json"), activity); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to update activity.json with PID: %v\n", err)
 	}
 
-	// 保存映射关系
+	// Save mapping
 	if err := a.saveAgentRunMapping(id, runID); err != nil {
 		return fmt.Errorf("save mapping: %w", err)
 	}
 
-		fmt.Printf("Agent %s started (run ID: %s, PID: %d)\n", id, runID, pid)
+	fmt.Printf("Agent %s started (run ID: %s, PID: %d)\n", id, runID, pid)
 	return nil
 }
 
-// getLatestRunID 使用 ai ls 获取最新的 run ID
+// getLatestRunID uses ai ls to find the latest run ID.
 func (a *AIAdapter) getLatestRunID() (string, error) {
 	cmd := exec.Command("ai", "ls", "--json")
 	output, err := cmd.Output()
@@ -129,7 +130,7 @@ func (a *AIAdapter) getLatestRunID() (string, error) {
 		return "", fmt.Errorf("ai ls failed: %w", err)
 	}
 
-	// 解析 JSON 输出
+	// Parse JSON output
 	var runs []struct {
 		ID     string `json:"id"`
 		Status string `json:"status"`
@@ -139,7 +140,7 @@ func (a *AIAdapter) getLatestRunID() (string, error) {
 		return "", fmt.Errorf("parse ai ls output: %w", err)
 	}
 
-	// 查找最新的运行且状态为 running 的 agent
+	// Find the latest running ag-agent
 	for i := len(runs) - 1; i >= 0; i-- {
 		if runs[i].Status == "running" && strings.HasPrefix(runs[i].Name, "ag-agent-") {
 			return runs[i].ID, nil
@@ -149,15 +150,15 @@ func (a *AIAdapter) getLatestRunID() (string, error) {
 	return "", fmt.Errorf("no running ag-agent found")
 }
 
-// SendCommand 向指定的 agent 发送命令
+// SendCommand sends a command to the specified agent.
 func (a *AIAdapter) SendCommand(agentID, cmdType, message string) error {
-	// 获取对应的 run ID
+	// Get corresponding run ID
 	runID, err := a.getRunIDForAgent(agentID)
 	if err != nil {
 		return err
 	}
 
-	// 构建 ai send 命令
+	// Build ai send command
 	args := []string{"send", "--id", runID}
 	if message != "" {
 		args = append(args, message)
@@ -172,49 +173,35 @@ func (a *AIAdapter) SendCommand(agentID, cmdType, message string) error {
 	return nil
 }
 
-// GetStatus 获取 agent 的状态
-func (a *AIAdapter) GetStatus(agentID string) (*RunMeta, error) {
-	// 获取对应的 run ID
+// GetStatus returns the agent's run status.
+func (a *AIAdapter) GetStatus(agentID string) (*run.RunMeta, error) {
+	// Get corresponding run ID
 	runID, err := a.getRunIDForAgent(agentID)
 	if err != nil {
 		return nil, err
 	}
 
-	// 读取 ai 的 run.json
-	homeDir, err := os.UserHomeDir()
+	meta, err := run.ReadMeta(runID)
 	if err != nil {
-		return nil, fmt.Errorf("get home dir: %w", err)
+		return nil, fmt.Errorf("read run meta: %w", err)
 	}
 
-	baseDir := filepath.Join(homeDir, ".ai", "runs")
-	metaPath := filepath.Join(baseDir, runID, "run.json")
-
-	data, err := os.ReadFile(metaPath)
-	if err != nil {
-		return nil, fmt.Errorf("read run.json: %w", err)
-	}
-
-	var meta RunMeta
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, fmt.Errorf("parse run.json: %w", err)
-	}
-
-	return &meta, nil
+	return meta, nil
 }
 
-// Wait 等待 agent 完成
+// Wait blocks until the agent completes.
 func (a *AIAdapter) Wait(agentID string) error {
-	// 获取对应的 run ID
+	// Get corresponding run ID
 	_, err := a.getRunIDForAgent(agentID)
 	if err != nil {
 		return err
 	}
 
-	// 使用 ai ls 检查状态
-	for i := 0; i < 3600; i++ { // 最多等待 1 小时
+	// Poll status via ai ls
+	for i := 0; i < 3600; i++ { // max 1 hour wait
 		status, err := a.GetStatus(agentID)
 		if err != nil {
-			// 如果文件不存在，可能已经完成了
+			// If file doesn't exist, it may have already completed
 			continue
 		}
 
@@ -228,16 +215,16 @@ func (a *AIAdapter) Wait(agentID string) error {
 	return fmt.Errorf("timeout waiting for agent %s to complete", agentID)
 }
 
-// 私有方法
+// Private methods
 
 func (a *AIAdapter) saveAgentRunMapping(agentID, runID string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	// 保存到内存
+	// Save to memory
 	a.mappings[agentID] = runID
 
-	// 保存到文件
+	// Save to file
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return err
@@ -250,7 +237,7 @@ func (a *AIAdapter) saveAgentRunMapping(agentID, runID string) error {
 
 	mappingsFile := filepath.Join(agDir, "run_mappings.json")
 
-	// 读取现有映射
+	// Read existing mappings
 	var mappings map[string]string
 	data, err := os.ReadFile(mappingsFile)
 	if err == nil {
@@ -259,15 +246,15 @@ func (a *AIAdapter) saveAgentRunMapping(agentID, runID string) error {
 		return fmt.Errorf("read mappings file: %w", err)
 	}
 
-	// 确保映射存在
+	// Ensure map exists
 	if mappings == nil {
 		mappings = make(map[string]string)
 	}
 
-	// 更新映射
+	// Update mapping
 	mappings[agentID] = runID
 
-	// 写回文件
+	// Write back to file
 	data, err = json.MarshalIndent(mappings, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal mappings: %w", err)
@@ -290,7 +277,7 @@ func (a *AIAdapter) getRunIDForAgent(agentID string) (string, error) {
 		return runID, nil
 	}
 
-	// 从文件中读取
+	// Read from file
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -312,7 +299,7 @@ func (a *AIAdapter) getRunIDForAgent(agentID string) (string, error) {
 		return "", fmt.Errorf("no run ID found for agent %s", agentID)
 	}
 
-	// 缓存到内存
+	// Cache in memory
 	a.mu.Lock()
 	a.mappings[agentID] = runID
 	a.mu.Unlock()
@@ -320,17 +307,5 @@ func (a *AIAdapter) getRunIDForAgent(agentID string) (string, error) {
 	return runID, nil
 }
 
-// RunMeta 表示 ai 的运行元数据
-type RunMeta struct {
-	ID         string `json:"id"`
-	PID        int    `json:"pid"`
-	CWD        string `json:"cwd"`
-	Status     string `json:"status"`
-	StartedAt  int64  `json:"started_at"`
-	FinishedAt int64  `json:"finished_at"`
-	Name       string `json:"name"`
-	ParentRun  string `json:"parent_run"`
-}
-
-// 全局适配器实例
+// Global adapter instance
 var aiAdapter = NewAIAdapter()

--- a/skills/ag/cmd/conv.go
+++ b/skills/ag/cmd/conv.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/genius/ag/internal/conv"
 	"github.com/spf13/cobra"
@@ -12,54 +12,111 @@ import (
 
 var convCmd = &cobra.Command{
 	Use:   "conv",
-		Short: "Convert JSON events to human-readable text",
-	Long: `Reads newline-delimited JSON events from stdin and writes
-human-readable output to stdout. Designed for piping:
+	Short: "Convert JSON events to human-readable text",
+	Long: `Reads newline-delimited JSON events from stdin or watches a file
+and writes human-readable output to stdout. Designed for piping:
 
   cat events.jsonl | ag conv
-  cat events.jsonl | ag conv --only tools`,
+  cat events.jsonl | ag conv --only tools
+  ag conv --watch ~/.ai/runs/abc123/events.jsonl
+  ag conv --watch ~/.ai/runs/abc123/events.jsonl --on agent_end`,
 	RunE: runConv,
 }
 
 var (
-	convOnly string // "text", "tools", or "" (all)
+	convOnly  string // "text", "tools", or "" (all)
+	convWatch string // file path to watch
+	convOn    string // stop and exit when this event kind is detected (e.g. "agent_end")
 )
 
 func init() {
 	convCmd.Flags().StringVar(&convOnly, "only", "", "Filter: 'text' for assistant text only, 'tools' for tool calls only")
+	convCmd.Flags().StringVar(&convWatch, "watch", "", "Watch an events file in real-time instead of reading stdin")
+	convCmd.Flags().StringVar(&convOn, "on", "", "Stop and exit when a specific event is detected (agent_end, agent_start, tool, etc.)")
 }
 
 func runConv(cmd *cobra.Command, args []string) error {
-	scanner := bufio.NewScanner(os.Stdin)
-	// Handle large events
-	const maxTokenSize = 10 * 1024 * 1024
-	scanner.Buffer(make([]byte, 0, 4096), maxTokenSize)
+	if convWatch != "" {
+		return runConvWatch()
+	}
+	return runConvStdin()
+}
 
-	var (
-		textOnly = convOnly == "text"
-		toolOnly = convOnly == "tools"
-	)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		evt := conv.ParseEvent(line)
-		if evt == nil {
-			continue
+func runConvStdin() error {
+	printHook := func(evt *conv.FormattedEvent) bool {
+		if !matchesFilter(evt) {
+			return true
 		}
-
-		// Apply filter
-		if textOnly && evt.Kind != conv.KindText {
-			continue
-		}
-		if toolOnly && evt.Kind != conv.KindTool {
-			continue
-		}
-
 		fmt.Fprintln(os.Stdout, evt.Text)
+		return true
 	}
 
-	if err := scanner.Err(); err != nil && err != io.EOF {
-		return fmt.Errorf("reading stdin: %w", err)
+	conv.StreamEvents(os.Stdin, printHook)
+	return nil
+}
+
+func runConvWatch() error {
+	stopCh := make(chan struct{})
+
+	// Build the stop-on hook if --on is specified
+	var stopHook conv.HookFunc
+	if convOn != "" {
+		stopHook = func(evt *conv.FormattedEvent) bool {
+			if matchesOnEvent(evt, convOn) {
+				fmt.Fprintln(os.Stdout, evt.Text)
+				close(stopCh)
+				return false
+			}
+			return true
+		}
+	}
+
+	printHook := func(evt *conv.FormattedEvent) bool {
+		if !matchesFilter(evt) {
+			return true
+		}
+		fmt.Fprintln(os.Stdout, evt.Text)
+		return true
+	}
+
+	hooks := []conv.HookFunc{printHook}
+	if stopHook != nil {
+		hooks = append(hooks, stopHook)
+	}
+
+	err := conv.WatchFile(convWatch, 500*time.Millisecond, stopCh, hooks...)
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("watching file: %w", err)
 	}
 	return nil
+}
+
+func matchesFilter(evt *conv.FormattedEvent) bool {
+	textOnly := convOnly == "text"
+	toolOnly := convOnly == "tools"
+
+	if textOnly && evt.Kind != conv.KindText {
+		return false
+	}
+	if toolOnly && evt.Kind != conv.KindTool {
+		return false
+	}
+	return true
+}
+
+func matchesOnEvent(evt *conv.FormattedEvent, onEvent string) bool {
+	switch onEvent {
+	case "agent_end", "agent_done":
+		return conv.IsAgentDone(evt)
+	case "agent_start":
+		return evt.Kind == conv.KindMeta && evt.Text == "--- agent started ---"
+	case "agent_fail", "agent_failed":
+		return evt.Kind == conv.KindMeta && conv.IsAgentDone(evt) && !conv.IsAgentSuccess(evt)
+	case "tool":
+		return evt.Kind == conv.KindTool
+	case "meta":
+		return evt.Kind == conv.KindMeta
+	default:
+		return false
+	}
 }

--- a/skills/ag/cmd/conv.go
+++ b/skills/ag/cmd/conv.go
@@ -51,8 +51,8 @@ func runConvStdin() error {
 		return true
 	}
 
-	conv.StreamEvents(os.Stdin, printHook)
-	return nil
+		_, err := conv.StreamEvents(os.Stdin, printHook)
+	return err
 }
 
 func runConvWatch() error {

--- a/skills/ag/cmd/conversation.go
+++ b/skills/ag/cmd/conversation.go
@@ -1,157 +1,57 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
+
+	"github.com/genius/ag/internal/conv"
+	"github.com/genius/ag/internal/run"
 )
 
-// ConversationMessage 表示对话中的一条消息
+// ConversationMessage represents a single message in a conversation.
 type ConversationMessage struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
 	Turn    int    `json:"turn,omitempty"`
 }
 
-// Conversation 表示整个对话
+// Conversation represents an entire conversation.
 type Conversation struct {
 	Messages []ConversationMessage `json:"messages"`
 }
 
-// GetConversation 从 AI 适配器的 agent 获取清晰的对话格式
+// GetConversation retrieves a structured conversation from an agent's run events.
 func GetConversation(agentID string) (*Conversation, error) {
-	// 获取对应的 run ID
 	runID, err := aiAdapter.getRunIDForAgent(agentID)
 	if err != nil {
 		return nil, fmt.Errorf("get run ID for agent %s: %w", agentID, err)
 	}
 
-	// 读取 events.jsonl 文件
-	homeDir, err := os.UserHomeDir()
+	eventsPath, err := run.EventsPath(runID)
 	if err != nil {
-		return nil, fmt.Errorf("get home dir: %w", err)
+		return nil, fmt.Errorf("get events path: %w", err)
 	}
 
-	eventsFile := filepath.Join(homeDir, ".ai", "runs", runID, "events.jsonl")
-	data, err := os.ReadFile(eventsFile)
+	data, err := os.ReadFile(eventsPath)
 	if err != nil {
 		return nil, fmt.Errorf("read events.jsonl: %w", err)
 	}
 
-	// 解析 events.jsonl 并构建清晰的对话
-	return parseConversation(data)
-}
-
-// parseConversation 从 events.jsonl 数据中构建清晰的对话
-func parseConversation(data []byte) (*Conversation, error) {
-	lines := strings.Split(string(data), "\n")
-	var conversation Conversation
-	var currentMessage strings.Builder
-	var currentRole string
-	var currentTurn int
-	var lastTurn int
-	var messageID int // 用于跟踪消息的唯一ID
-
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-
-		var event map[string]interface{}
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			continue // 跳过无效的 JSON 行
-		}
-
-				// 处理消息相关的事件
-		if eventType, ok := event["type"].(string); ok {
-			switch eventType {
-			case "message_start", "message_update":
-				if msg, ok := event["message"].(map[string]interface{}); ok {
-					if role, ok := msg["role"].(string); ok {
-						// 如果是新角色，保存前一条消息
-						if role != currentRole && currentMessage.Len() > 0 {
-							content := strings.TrimSpace(currentMessage.String())
-							if content != "" {
-								conversation.Messages = append(conversation.Messages, ConversationMessage{
-									Role:    currentRole,
-									Content: content,
-									Turn:    currentTurn,
-								})
-								messageID++
-							}
-							currentMessage.Reset()
-						}
-
-						currentRole = role
-
-						// 如果是用户消息，结束当前回合
-						if role == "user" && currentTurn > 0 {
-							lastTurn = currentTurn
-							currentTurn = 0
-						}
-
-						// Extract content - each message_update contains accumulated text,
-						// so we overwrite (not append) to avoid duplication from streaming deltas.
-						if content, ok := msg["content"].([]interface{}); ok {
-							for _, item := range content {
-								if contentItem, ok := item.(map[string]interface{}); ok {
-									itemType, _ := contentItem["type"].(string)
-									switch itemType {
-									case "text":
-										if text, ok := contentItem["text"].(string); ok {
-											currentMessage.Reset()
-											currentMessage.WriteString(text)
-										}
-									case "thinking":
-										// 忽略思考过程
-									}
-								}
-							}
-						}
-					}
-				}
-
-			case "turn_start":
-				// 新回合开始
-				if currentRole == "assistant" && currentTurn == 0 {
-					currentTurn = lastTurn + 1
-				}
-
-			case "message_end":
-				// 消息结束，保存当前消息
-				if currentMessage.Len() > 0 {
-					content := strings.TrimSpace(currentMessage.String())
-					if content != "" {
-						conversation.Messages = append(conversation.Messages, ConversationMessage{
-							Role:    currentRole,
-							Content: content,
-							Turn:    currentTurn,
-						})
-						currentMessage.Reset()
-					}
-				}
-			}
+	// Parse events.jsonl into structured conversation using conv package
+	msgs := conv.BuildConversation(data)
+	result := &Conversation{Messages: make([]ConversationMessage, len(msgs))}
+	for i, m := range msgs {
+		result.Messages[i] = ConversationMessage{
+			Role:    m.Role,
+			Content: m.Content,
+			Turn:    m.Turn,
 		}
 	}
-
-	// 添加最后一条消息
-	if currentMessage.Len() > 0 {
-		content := strings.TrimSpace(currentMessage.String())
-		if content != "" {
-			conversation.Messages = append(conversation.Messages, ConversationMessage{
-				Role:    currentRole,
-				Content: content,
-				Turn:    currentTurn,
-			})
-		}
-	}
-
-	return &conversation, nil
+	return result, nil
 }
 
-// FormatAsText 将对话格式化为纯文本
+// FormatAsText formats the conversation as plain text.
 func (c *Conversation) FormatAsText() string {
 	var builder strings.Builder
 
@@ -170,7 +70,7 @@ func (c *Conversation) FormatAsText() string {
 	return builder.String()
 }
 
-// FormatAsMarkdown 将对话格式化为 Markdown
+// FormatAsMarkdown formats the conversation as Markdown.
 func (c *Conversation) FormatAsMarkdown() string {
 	var builder strings.Builder
 
@@ -189,12 +89,12 @@ func (c *Conversation) FormatAsMarkdown() string {
 	return builder.String()
 }
 
-// GetLastAssistantResponse 获取助手的最后回复
+// GetLastAssistantResponse returns the last assistant response.
 func (c *Conversation) GetLastAssistantResponse() string {
 	return c.GetNthLastAssistantResponse(1)
 }
 
-// GetNthLastAssistantResponse 获取助手倒数第N条回复 (1=最后一条)
+// GetNthLastAssistantResponse returns the Nth-to-last assistant response (1=last).
 func (c *Conversation) GetNthLastAssistantResponse(n int) string {
 	count := 0
 	for i := len(c.Messages) - 1; i >= 0; i-- {
@@ -208,7 +108,7 @@ func (c *Conversation) GetNthLastAssistantResponse(n int) string {
 	return ""
 }
 
-// GetLastUserMessage 获取用户的最后消息
+// GetLastUserMessage returns the last user message.
 func (c *Conversation) GetLastUserMessage() string {
 	for i := len(c.Messages) - 1; i >= 0; i-- {
 		if c.Messages[i].Role == "user" {

--- a/skills/ag/cmd/formatted_writer.go
+++ b/skills/ag/cmd/formatted_writer.go
@@ -10,14 +10,14 @@ import (
 	"github.com/genius/ag/internal/conv"
 )
 
-// FormattedStreamWriter 智能格式化的流式写入器
+// FormattedStreamWriter is a smart formatted stream writer.
 type FormattedStreamWriter struct {
 	file    *os.File
 	writer  *bufio.Writer
 	textBuf strings.Builder
 }
 
-// NewFormattedStreamWriter 创建新的格式化写入器
+// NewFormattedStreamWriter creates a new formatted stream writer.
 func NewFormattedStreamWriter(filePath string) (*FormattedStreamWriter, error) {
 	file, err := os.Create(filePath)
 	if err != nil {
@@ -30,7 +30,7 @@ func NewFormattedStreamWriter(filePath string) (*FormattedStreamWriter, error) {
 	}, nil
 }
 
-// WriteJSONEvents 写入 JSON 事件流（用于 ai serve 输出）
+// WriteJSONEvents writes a JSON event stream (from ai serve output).
 func (w *FormattedStreamWriter) WriteJSONEvents(output []byte) error {
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 
@@ -40,13 +40,13 @@ func (w *FormattedStreamWriter) WriteJSONEvents(output []byte) error {
 			continue
 		}
 
-		// 尝试解析为 JSON 事件
+		// Try to parse as a JSON event
 		formatted := conv.ParseEvent(line)
 		if formatted != nil {
-			// 写入格式化的文本
+			// Write formatted text
 			w.writeFormatted(formatted)
 		} else {
-			// 如果不是 JSON 事件，作为纯文本处理
+			// Not a JSON event, treat as plain text
 			w.writeRawText(line)
 		}
 	}
@@ -54,7 +54,7 @@ func (w *FormattedStreamWriter) WriteJSONEvents(output []byte) error {
 	return w.writer.Flush()
 }
 
-// WriteTextStream 写入文本流（用于非 JSON 格式的输出）
+// WriteTextStream writes a text stream (for non-JSON output).
 func (w *FormattedStreamWriter) WriteTextStream(output []byte) error {
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 
@@ -66,53 +66,53 @@ func (w *FormattedStreamWriter) WriteTextStream(output []byte) error {
 	return w.writer.Flush()
 }
 
-// writeFormatted 写入格式化的事件
+// writeFormatted writes a formatted event.
 func (w *FormattedStreamWriter) writeFormatted(event *conv.FormattedEvent) {
 	switch event.Kind {
 	case conv.KindMeta:
-		// 元数据事件，添加时间戳和换行
+		// Meta events get a timestamp and newline
 		timestamp := time.Now().Format("15:04:05")
 		fmt.Fprintf(w.writer, "[%s] %s\n", timestamp, event.Text)
 	case conv.KindTool:
-		// 工具事件，直接写入
+		// Tool events written directly
 		fmt.Fprintf(w.writer, "%s\n", event.Text)
 	case conv.KindText:
-		// 文本事件，智能分段
+		// Text events get smart paragraphing
 		w.writeSmartText(event.Text)
 	}
 }
 
-// writeRawText 写入原始文本，进行智能分段
+// writeRawText writes raw text with smart paragraphing.
 func (w *FormattedStreamWriter) writeRawText(text string) {
 	w.writeSmartText(text)
 }
 
-// writeSmartText 智能写入文本，按语义分段
+// writeSmartText writes text with semantic paragraph segmentation.
 func (w *FormattedStreamWriter) writeSmartText(text string) {
-	// 累积到缓冲区
+	// Accumulate into buffer
 	w.textBuf.WriteString(text)
 
-	// 检查是否有完整的语义单元
+	// Check for complete semantic units
 	bufferStr := w.textBuf.String()
 
-	// 检查句子结束
+	// Check for sentence endings
 	if strings.ContainsAny(text, "。！？.!?") {
-		// 写入并清空缓冲区
+		// Write and clear buffer
 		fmt.Fprintf(w.writer, "%s", bufferStr)
 		w.textBuf.Reset()
 		return
 	}
 
-	// 检查是否是特殊行（标题、列表、代码块等）
+	// Check for special lines (headings, lists, code blocks, etc.)
 	trimmed := strings.TrimSpace(text)
 	if strings.HasPrefix(trimmed, "#") ||
 		strings.HasPrefix(trimmed, "-") ||
 		strings.HasPrefix(trimmed, "*") ||
 		strings.HasPrefix(trimmed, "```") ||
 		strings.HasPrefix(trimmed, "|") {
-		// 换行后写入
+		// Write with preceding newline
 		if w.textBuf.Len() > len(text) {
-			// 说明缓冲区之前有内容，先写入之前的
+			// Buffer had prior content, write it first
 			prevText := bufferStr[:len(bufferStr)-len(text)]
 			fmt.Fprintf(w.writer, "%s", prevText)
 		}
@@ -121,16 +121,16 @@ func (w *FormattedStreamWriter) writeSmartText(text string) {
 		return
 	}
 
-	// 如果缓冲区太大，强制写入
+	// Force flush if buffer is too large
 	if w.textBuf.Len() > 200 {
 		fmt.Fprintf(w.writer, "%s", bufferStr)
 		w.textBuf.Reset()
 	}
 }
 
-// Flush 刷新所有待写入的内容
+// Flush writes any pending buffered content.
 func (w *FormattedStreamWriter) Flush() error {
-	// 写入剩余的缓冲区内容
+	// Write remaining buffer content
 	if w.textBuf.Len() > 0 {
 		fmt.Fprintf(w.writer, "%s", w.textBuf.String())
 		w.textBuf.Reset()
@@ -139,7 +139,7 @@ func (w *FormattedStreamWriter) Flush() error {
 	return w.writer.Flush()
 }
 
-// Close 关闭写入器
+// Close flushes and closes the writer.
 func (w *FormattedStreamWriter) Close() error {
 	if err := w.Flush(); err != nil {
 		return err
@@ -147,7 +147,7 @@ func (w *FormattedStreamWriter) Close() error {
 	return w.file.Close()
 }
 
-// WriteFormattedOutput 统一的格式化写入接口
+// WriteFormattedOutput is a unified formatted writing interface.
 func WriteFormattedOutput(agentDir string, output []byte, backendName string) error {
 	streamPath := agentDir + "/stream.log"
 
@@ -157,11 +157,11 @@ func WriteFormattedOutput(agentDir string, output []byte, backendName string) er
 	}
 	defer writer.Close()
 
-	// 根据 backend 类型选择不同的处理方式
+	// Choose processing based on backend type
 	if backendName == "ai" {
-		// ai backend 使用 JSON 事件流
+		// ai backend uses JSON event stream
 		return writer.WriteJSONEvents(output)
 	}
-	// 其他 backend 使用文本流
+	// Other backends use text stream
 	return writer.WriteTextStream(output)
 }

--- a/skills/ag/cmd/tail.go
+++ b/skills/ag/cmd/tail.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/genius/ag/internal/agent"
+		"github.com/genius/ag/internal/agent"
+	"github.com/genius/ag/internal/conv"
+	"github.com/genius/ag/internal/run"
 	"github.com/spf13/cobra"
 )
 
@@ -55,13 +57,12 @@ func tailFromAI(id string, since int64) error {
 		return fmt.Errorf("get run ID for agent %s: %w", id, err)
 	}
 
-	homeDir, err := os.UserHomeDir()
+		eventsPath, err := run.EventsPath(runID)
 	if err != nil {
-		return fmt.Errorf("get home dir: %w", err)
+		return fmt.Errorf("get events path: %w", err)
 	}
 
-	eventsFile := filepath.Join(homeDir, ".ai", "runs", runID, "events.jsonl")
-	f, err := os.Open(eventsFile)
+	f, err := os.Open(eventsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			fmt.Println("---cursor:0")
@@ -155,9 +156,6 @@ func parseEventsTail(data []byte, since int64) (content string, newCursor int64,
 		}
 	}
 
-	messages, parseErr := parseAssistantMessages(chunk)
-	if parseErr != nil {
-		return "", 0, parseErr
-	}
+		messages := conv.BuildAssistantTexts(chunk)
 	return strings.Join(messages, "\n\n"), int64(len(data)), nil
 }

--- a/skills/ag/docs/ARCHITECTURE.md
+++ b/skills/ag/docs/ARCHITECTURE.md
@@ -1,0 +1,171 @@
+# Architecture Analysis: `ag` (Agent Orchestration CLI)
+
+**Date**: 2025-07-13
+**Scope**: 22 Go source files, 5181 LOC (non-test), 1654 LOC (test), 6 internal packages + cmd
+**Goal**: Surface deepening opportunities that improve testability, reduce duplication, and make the codebase more AI-navigable.
+
+---
+
+## Module Depth Map
+
+Each module rated by **interface surface** vs **behaviour hidden**.
+
+| Module | LOC | Interface Size | Depth | Verdict |
+|--------|-----|---------------|-------|---------|
+| `storage` | 133 | 11 funcs | 🟢 Deep | Good: `AtomicWrite`, `ReadJSON`, path helpers hide FS details |
+| `conv` | 360 | `ParseEvent` + stream API | 🟢 Deep | Good: event parsing, hooks, file watching all hidden behind small API |
+| `task` | 734 | ~20 funcs (CRUD + state machine) | 🟡 Medium | State machine is well-factored, but YAML import has no validation layer |
+| `channel` | 243 | 5 funcs (Send/Recv/List/Create/Remove) | 🟢 Deep | Good: FIFO queue abstraction over FS |
+| `backend` | 147 | Load/Find/Default | 🟢 Deep | Good: YAML config with sensible defaults |
+| `agent` | 153 | Validate/List/Read/EnsureExists | 🟢 Deep | Good: lifecycle over activity.json |
+| `scheduler` | 582 | `RunScheduler(ctx, cfg)` | 🟡 Medium | Single entry point is good, but hardcoded `ai serve` coupling |
+| `cmd/` | 2632 | 77 functions across 13 files | 🔴 Shallow | God package: CLI wiring + business logic mixed, no internal boundaries |
+
+---
+
+## Critical Issues
+
+### 1. `cmd/` is a God Package (2632 LOC, 77 functions)
+
+**Problem**: The `cmd` package is 50% of the codebase and mixes CLI wiring with substantial business logic. Files like `agent_client.go` (449 LOC) contain both command dispatch AND complex operations (Kill, Wait, parseAssistantMessages, tailBytes). No internal boundaries exist within cmd.
+
+**Symptoms**:
+- `parseAssistantMessages()` (60 LOC) + `extractAssistantTextsFromAgentEnd()` + `extractTextFromContent()` are pure event parsing logic living in `cmd/agent_client.go`
+- `ai_adapter.go` is a 336-line adapter with state management (run ID caching, file I/O) that should be an internal package
+- `formatted_writer.go` reimplements conv event parsing instead of using `conv.StreamEvents`
+- `conversation.go` reimplements events.jsonl parsing instead of using conv
+
+**Proposed refactor**:
+
+```
+cmd/                    → CLI wiring only (flags → call internal package)
+internal/run/           → AI run management (RunMeta, run ID resolution, events.jsonl paths)
+internal/run/adapter.go → AIAdapter (spawn, status, send, kill)
+internal/run/parser.go  → parseAssistantMessages, extractTextsFromAgentEnd → use conv
+internal/run/paths.go   → RunsDir(), EventsPath(runID), RunMetaPath(runID)
+```
+
+**Impact**: High — reduces cmd/ by ~60%, makes adapter testable in isolation, enables reuse of run management by scheduler.
+
+---
+
+### 2. Triplicated `isProcessAlive` (3 copies)
+
+**Problem**: Identical function exists in 3 files:
+
+| Location | Lines |
+|----------|-------|
+| `cmd/agent_status.go:221` | 6 |
+| `internal/agent/agent.go:106` | 6 |
+| `internal/task/scheduler.go:521` | 6 |
+
+**Fix**: Move to `internal/agent/agent.go` (already has it) and export it. Delete the other two copies. Both `cmd/` and `task/` already import `agent`.
+
+---
+
+### 3. Scattered `~/.ai/runs/` Path Knowledge (9 call sites)
+
+**Problem**: The path pattern `filepath.Join(homeDir, ".ai", "runs", runID, ...)` appears in 9 places across 5 files:
+
+- `cmd/ai_adapter.go` (3 sites)
+- `cmd/agent_client.go` (2 sites)
+- `cmd/agent_status.go` (2 sites)
+- `cmd/tail.go` (1 site)
+- `cmd/conversation.go` (1 site)
+- `internal/task/scheduler.go` (2 sites)
+
+Each call independently resolves `os.UserHomeDir()` and constructs the path. No single source of truth.
+
+**Fix**: Create `internal/run/paths.go`:
+
+```go
+package run
+
+func RunsDir() string                        // ~/.ai/runs/
+func Dir(runID string) string                 // ~/.ai/runs/<id>/
+func EventsPath(runID string) string          // ~/.ai/runs/<id>/events.jsonl
+func MetaPath(runID string) string            // ~/.ai/runs/<id>/run.json
+func ReadMeta(runID string) (*RunMeta, error) // parse run.json
+```
+
+---
+
+### 4. `parseAssistantMessages` Duplicates conv Logic
+
+**Problem**: `cmd/agent_client.go:299-393` manually parses events.jsonl (message_update, agent_end, turn_end) to extract assistant text. This duplicates what `conv.ParseEvent` + `conv.StreamEvents` already provide, but handles additional cases:
+- Accumulates text deltas across streaming events
+- Extracts full messages from agent_end's `messages` array
+- Splits by turn boundaries
+
+**Fix**: Extend `conv` package with a `ConversationBuilder` that accumulates streaming text into complete messages, replacing both `parseAssistantMessages` and `conversation.go`'s `parseConversation`.
+
+```go
+// conv/conversation.go
+type ConversationBuilder struct { ... }
+func (b *ConversationBuilder) ProcessEvent(evt *FormattedEvent) Message
+func BuildConversation(data []byte) ([]Message, error)
+```
+
+This would unify 3 separate event-parsing implementations (agent_client, conversation, tail) into 1.
+
+---
+
+### 5. `formatted_writer.go` Doesn't Use conv.StreamEvents
+
+**Problem**: `FormattedStreamWriter.WriteJSONEvents` manually calls `conv.ParseEvent(line)` in a loop with its own scanner. It could use `conv.StreamEvents(reader, hook)` instead, but the hook would need the `FormattedStreamWriter` passed through.
+
+**Fix**: Refactor to use `conv.StreamEvents` with a closure hook. Reduces WriteJSONEvents from 20 lines to ~5.
+
+---
+
+### 6. Scheduler Hardcodes `ai serve` as Only Worker Backend
+
+**Problem**: `spawnWorker` directly constructs `exec.Command("ai", "serve", ...)` with no abstraction. Adding alternative backends (e.g., codex, raw mode) requires modifying scheduler internals.
+
+**Fix**: Extract a `WorkerBackend` interface:
+
+```go
+type WorkerBackend interface {
+    Spawn(ctx context.Context, taskID, prompt, workDir string) (runID string, err error)
+    IsDone(runID string) (done bool, summary string, err error)
+}
+```
+
+Current `ai serve` becomes `AIServeBackend`. Future backends (codex, local) plug in without touching scheduler logic.
+
+---
+
+## Moderate Issues
+
+### 7. Chinese Comments in Production Code
+
+**Files**: `ai_adapter.go`, `conversation.go`, `formatted_writer.go`
+**Rule**: Per AGENTS.md, code comments should be English-only.
+**Fix**: Translate Chinese comments to English.
+
+### 8. `tail.go` Cursor Model Leaks Raw Events
+
+The `parseEventsTail` function re-parses events.jsonl from byte offset, which breaks if a single JSON event spans the offset boundary. The current code handles this with a "skip to next newline" heuristic, but a cleaner approach would use event-line offsets instead of byte offsets.
+
+### 9. No Error Wrapping in agent/adapter Layer
+
+`ai_adapter.go` uses `fmt.Errorf("...: %w", err)` in some places but raw `fmt.Errorf` in others. Consistent error wrapping with `%w` would improve debuggability.
+
+---
+
+## Proposed ADRs
+
+See `docs/adr/` for specific decisions.
+
+---
+
+## Priority Ranking
+
+| Priority | Issue | Effort | Impact |
+|----------|-------|--------|--------|
+| P0 | Extract `internal/run` package (paths + adapter + parser) | M | High — eliminates 9 duplicated paths, enables testing |
+| P0 | Unify event parsing into conv (ConversationBuilder) | M | High — eliminates 3 duplicate parsers |
+| P1 | Deduplicate `isProcessAlive` | S | Low — 18 lines saved, but removes confusion |
+| P1 | Translate Chinese comments to English | S | Low — consistency |
+| P2 | WorkerBackend interface in scheduler | M | Medium — extensibility |
+| P2 | formatted_writer uses conv.StreamEvents | S | Low — consistency |

--- a/skills/ag/docs/adr/001-extract-run-package.md
+++ b/skills/ag/docs/adr/001-extract-run-package.md
@@ -1,0 +1,5 @@
+# ADR 001: Extract `internal/run` Package
+
+The `~/.ai/runs/` path layout and run lifecycle management (spawn, status, kill) are scattered across 5 files in `cmd/` and `internal/task/scheduler.go`. Extract a dedicated `internal/run` package to be the single source of truth for AI run operations.
+
+This consolidates 9 duplicated path constructions, 3 copies of `isProcessAlive`, and makes `AIAdapter` testable in isolation from CLI wiring.

--- a/skills/ag/docs/adr/002-unify-event-parsing.md
+++ b/skills/ag/docs/adr/002-unify-event-parsing.md
@@ -1,0 +1,5 @@
+# ADR 002: Unify Event Parsing into `conv` Package
+
+Three separate implementations parse events.jsonl: `parseAssistantMessages` (agent_client.go), `parseConversation` (conversation.go), and manual line-by-line in formatted_writer.go. Each handles streaming text accumulation, turn boundaries, and message extraction differently.
+
+Extend `conv` with a `ConversationBuilder` that accumulates streaming deltas into complete messages. All three consumers use this single implementation. The builder produces `[]Message` with role, content, and turn metadata.

--- a/skills/ag/docs/adr/003-worker-backend-interface.md
+++ b/skills/ag/docs/adr/003-worker-backend-interface.md
@@ -1,0 +1,5 @@
+# ADR 003: WorkerBackend Interface for Scheduler
+
+The scheduler's `spawnWorker` and `checkAIServeRun` directly construct `exec.Command("ai", "serve", ...)` and read `~/.ai/runs/` files. This couples the scheduler to the `ai serve` backend specifically.
+
+Introduce a `WorkerBackend` interface with `Spawn` and `IsDone` methods. The current `ai serve` implementation becomes `AIServeBackend`. This allows future backends (codex, local subprocess) to be plugged into the scheduler without modifying its core loop.

--- a/skills/ag/internal/agent/agent.go
+++ b/skills/ag/internal/agent/agent.go
@@ -82,7 +82,7 @@ func List() ([]AgentEntry, error) {
 		// Lazy status reconciliation: if activity.json says "running" but the
 		// process is dead, update the status so callers see the real state.
 		if activity.Status == "running" && activity.Pid > 0 {
-			if !isProcessAlive(activity.Pid) {
+					if !IsProcessAlive(activity.Pid) {
 				activity.Status = "done"
 				if activity.FinishedAt == 0 {
 					activity.FinishedAt = time.Now().Unix()
@@ -102,8 +102,8 @@ func List() ([]AgentEntry, error) {
 	return result, nil
 }
 
-// isProcessAlive checks if a process with the given PID is still running.
-func isProcessAlive(pid int) bool {
+// IsProcessAlive checks if a process with the given PID is still running.
+func IsProcessAlive(pid int) bool {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return false

--- a/skills/ag/internal/conv/conversation_builder.go
+++ b/skills/ag/internal/conv/conversation_builder.go
@@ -1,0 +1,225 @@
+package conv
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Message represents a single message in a conversation.
+type Message struct {
+	Role    string // "user", "assistant", "system"
+	Content string
+	Turn    int
+}
+
+// ConversationBuilder accumulates streaming events into structured messages.
+// It handles text_delta accumulation, turn tracking, and message boundary
+// detection, replacing the manual map[string]any parsing that was duplicated
+// across cmd/agent_client.go and cmd/conversation.go.
+type ConversationBuilder struct {
+	messages   []Message
+	curText    strings.Builder
+	curRole    string
+	curTurn    int
+	lastTurn   int
+	inStream   bool // true if we're accumulating text_delta chunks
+}
+
+// NewConversationBuilder creates a builder ready to process events.
+func NewConversationBuilder() *ConversationBuilder {
+	return &ConversationBuilder{}
+}
+
+// Messages returns the accumulated messages.
+func (b *ConversationBuilder) Messages() []Message {
+	return b.messages
+}
+
+// AssistantTexts returns all assistant message contents as a flat slice.
+func (b *ConversationBuilder) AssistantTexts() []string {
+	out := make([]string, 0, len(b.messages))
+	for _, m := range b.messages {
+		if m.Role == "assistant" && strings.TrimSpace(m.Content) != "" {
+			out = append(out, strings.TrimSpace(m.Content))
+		}
+	}
+	return out
+}
+
+// flushCurrent saves the current accumulated text as a message if non-empty.
+func (b *ConversationBuilder) flushCurrent() {
+	if b.curText.Len() == 0 {
+		return
+	}
+	content := strings.TrimSpace(b.curText.String())
+	if content == "" {
+		b.curText.Reset()
+		b.inStream = false
+		return
+	}
+	b.messages = append(b.messages, Message{
+		Role:    b.curRole,
+		Content: content,
+		Turn:    b.curTurn,
+	})
+	b.curText.Reset()
+	b.inStream = false
+}
+
+// ProcessEvent handles a single raw JSON event line.
+// It uses FormattedEvent for metadata and falls back to raw map parsing
+// for content extraction (since ParseEvent strips content details).
+func (b *ConversationBuilder) ProcessEvent(line string) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
+
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(line), &evt); err != nil {
+		return
+	}
+
+	etype, _ := evt["type"].(string)
+	switch etype {
+	case "message_start", "message_update":
+		b.handleMessageEvent(evt)
+	case "message_end":
+		b.flushCurrent()
+	case "turn_start":
+		if b.curRole == "assistant" && b.curTurn == 0 {
+			b.curTurn = b.lastTurn + 1
+		}
+	case "turn_end":
+		if b.inStream {
+			b.flushCurrent()
+		}
+	case "agent_end":
+		b.handleAgentEnd(evt)
+	}
+}
+
+// handleMessageEvent processes message_start and message_update events.
+func (b *ConversationBuilder) handleMessageEvent(evt map[string]any) {
+	// Check for role in top-level message field
+	msg, _ := evt["message"].(map[string]any)
+	if msg != nil {
+		if role, ok := msg["role"].(string); ok {
+			if role != b.curRole && b.curText.Len() > 0 {
+				b.flushCurrent()
+			}
+			b.curRole = role
+			if role == "user" && b.curTurn > 0 {
+				b.lastTurn = b.curTurn
+				b.curTurn = 0
+			}
+			// Extract content from message field
+			b.extractContent(msg["content"])
+		}
+	}
+
+	// Check for assistantMessageEvent (streaming delta)
+	assistantEvent, _ := evt["assistantMessageEvent"].(map[string]any)
+	if assistantEvent != nil {
+		b.curRole = "assistant"
+		evType, _ := assistantEvent["type"].(string)
+		if evType == "text_delta" {
+			delta, _ := assistantEvent["delta"].(string)
+			b.curText.WriteString(delta)
+			b.inStream = true
+		}
+	}
+}
+
+// extractContent extracts text from a content array, overwriting (not appending)
+// to avoid duplication from streaming deltas.
+func (b *ConversationBuilder) extractContent(raw any) {
+	items, _ := raw.([]any)
+	if len(items) == 0 {
+		return
+	}
+	var text strings.Builder
+	for _, item := range items {
+		obj, _ := item.(map[string]any)
+		if obj == nil {
+			continue
+		}
+		typ, _ := obj["type"].(string)
+		if typ == "text" {
+			t, _ := obj["text"].(string)
+			text.WriteString(t)
+		}
+	}
+	if text.Len() > 0 {
+		b.curText.Reset()
+		b.curText.WriteString(text.String())
+		b.inStream = true
+	}
+}
+
+// handleAgentEnd extracts assistant messages from the agent_end messages array.
+func (b *ConversationBuilder) handleAgentEnd(evt map[string]any) {
+	b.flushCurrent()
+	rawMessages, _ := evt["messages"].([]any)
+	if len(rawMessages) == 0 {
+		return
+	}
+	for _, raw := range rawMessages {
+		msg, _ := raw.(map[string]any)
+		if msg == nil {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if role != "assistant" {
+			continue
+		}
+		content := extractText(msg["content"])
+		if content != "" {
+			b.messages = append(b.messages, Message{
+				Role:    "assistant",
+				Content: content,
+				Turn:    b.curTurn,
+			})
+		}
+	}
+}
+
+// extractText extracts plain text from a content array.
+func extractText(raw any) string {
+	items, _ := raw.([]any)
+	if len(items) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, item := range items {
+		obj, _ := item.(map[string]any)
+		if obj == nil {
+			continue
+		}
+		if typ, _ := obj["type"].(string); typ == "text" {
+			text, _ := obj["text"].(string)
+			b.WriteString(text)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// BuildConversation processes all events in a byte slice and returns messages.
+// This is a convenience function for one-shot parsing.
+func BuildConversation(data []byte) []Message {
+	builder := NewConversationBuilder()
+	for _, line := range strings.Split(string(data), "\n") {
+		builder.ProcessEvent(line)
+	}
+	return builder.Messages()
+}
+
+// BuildAssistantTexts processes all events and returns assistant message texts.
+// This is a convenience function for one-shot parsing.
+func BuildAssistantTexts(data []byte) []string {
+	builder := NewConversationBuilder()
+	for _, line := range strings.Split(string(data), "\n") {
+		builder.ProcessEvent(line)
+	}
+	return builder.AssistantTexts()
+}

--- a/skills/ag/internal/conv/conversation_builder_test.go
+++ b/skills/ag/internal/conv/conversation_builder_test.go
@@ -1,0 +1,121 @@
+package conv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConversationBuilderStreamingDelta(t *testing.T) {
+	events := []string{
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"Hello "}}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"World"}}`,
+		`{"type":"turn_end"}`,
+	}
+	builder := NewConversationBuilder()
+	for _, e := range events {
+		builder.ProcessEvent(e)
+	}
+	texts := builder.AssistantTexts()
+	if len(texts) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(texts))
+	}
+	if texts[0] != "Hello World" {
+		t.Fatalf("expected 'Hello World', got '%s'", texts[0])
+	}
+}
+
+func TestConversationBuilderMultiTurn(t *testing.T) {
+	events := []string{
+		`{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"ping"}]}}`,
+		`{"type":"message_end"}`,
+		`{"type":"turn_start"}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"pong"}}`,
+		`{"type":"turn_end"}`,
+	}
+	builder := NewConversationBuilder()
+	for _, e := range events {
+		builder.ProcessEvent(e)
+	}
+	msgs := builder.Messages()
+	if len(msgs) < 2 {
+		t.Fatalf("expected at least 2 messages, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != "user" {
+		t.Errorf("first message role = %q, want user", msgs[0].Role)
+	}
+	if msgs[0].Content != "ping" {
+		t.Errorf("first message content = %q, want ping", msgs[0].Content)
+	}
+	foundAssistant := false
+	for _, m := range msgs {
+		if m.Role == "assistant" && m.Content == "pong" {
+			foundAssistant = true
+		}
+	}
+	if !foundAssistant {
+		t.Errorf("no assistant pong message found in %+v", msgs)
+	}
+}
+
+func TestConversationBuilderAgentEnd(t *testing.T) {
+	events := []string{
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"thinking..."}}`,
+		`{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"Final answer"}]}]}`,
+	}
+	builder := NewConversationBuilder()
+	for _, e := range events {
+		builder.ProcessEvent(e)
+	}
+	texts := builder.AssistantTexts()
+	// agent_end should flush the streaming text and add its own messages
+	if len(texts) != 2 {
+		t.Fatalf("expected 2 messages, got %d: %v", len(texts), texts)
+	}
+	if texts[0] != "thinking..." {
+		t.Errorf("texts[0] = %q, want thinking...", texts[0])
+	}
+	if texts[1] != "Final answer" {
+		t.Errorf("texts[1] = %q, want Final answer", texts[1])
+	}
+}
+
+func TestBuildAssistantTexts(t *testing.T) {
+	data := strings.Join([]string{
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello"}}`,
+		`{"type":"turn_end"}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"world"}}`,
+		`{"type":"turn_end"}`,
+	}, "\n")
+	texts := BuildAssistantTexts([]byte(data))
+	if len(texts) != 2 {
+		t.Fatalf("expected 2, got %d", len(texts))
+	}
+}
+
+func TestBuildConversation(t *testing.T) {
+	data := `{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}
+{"type":"message_end"}`
+	msgs := BuildConversation([]byte(data))
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Role != "user" || msgs[0].Content != "hi" {
+		t.Errorf("unexpected: %+v", msgs[0])
+	}
+}
+
+func TestConversationBuilderEmpty(t *testing.T) {
+	builder := NewConversationBuilder()
+	if len(builder.Messages()) != 0 {
+		t.Error("expected empty messages")
+	}
+	if len(builder.AssistantTexts()) != 0 {
+		t.Error("expected empty texts")
+	}
+	builder.ProcessEvent("")
+	builder.ProcessEvent("not json")
+	builder.ProcessEvent(`{"type":"unknown"}`)
+	if len(builder.Messages()) != 0 {
+		t.Error("expected still empty after unknown events")
+	}
+}

--- a/skills/ag/internal/conv/stream.go
+++ b/skills/ag/internal/conv/stream.go
@@ -1,0 +1,79 @@
+package conv
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// HookFunc is a callback invoked for each parsed event during streaming.
+// Return false to stop streaming early.
+type HookFunc func(evt *FormattedEvent) bool
+
+// StreamEvents reads newline-delimited JSON events from reader and calls
+// hooks for each parsed event. It stops when the reader reaches EOF or a
+// hook returns false. Returns the number of events processed.
+func StreamEvents(reader io.Reader, hooks ...HookFunc) int {
+	scanner := bufio.NewScanner(reader)
+	const maxTokenSize = 10 * 1024 * 1024
+	scanner.Buffer(make([]byte, 0, 4096), maxTokenSize)
+
+	count := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		evt := ParseEvent(line)
+		if evt == nil {
+			continue
+		}
+		count++
+		for _, hook := range hooks {
+			if !hook(evt) {
+				return count
+			}
+		}
+	}
+	return count
+}
+
+// StreamEventsFromString parses events from a raw string (e.g. full file content).
+func StreamEventsFromString(data string, hooks ...HookFunc) int {
+	return StreamEvents(strings.NewReader(data), hooks...)
+}
+
+// IsAgentDone checks if a meta event indicates the agent has finished
+// (either successfully or with failure). Returns true for agent_end events.
+func IsAgentDone(evt *FormattedEvent) bool {
+	if evt.Kind != KindMeta {
+		return false
+	}
+	return strings.Contains(evt.Text, "agent done") ||
+		strings.Contains(evt.Text, "agent failed")
+}
+
+// IsAgentSuccess checks if the agent finished successfully.
+func IsAgentSuccess(evt *FormattedEvent) bool {
+	if evt.Kind != KindMeta {
+		return false
+	}
+	return strings.Contains(evt.Text, "agent done")
+}
+
+// CollectLastN returns a hook that collects the last N formatted lines
+// of the specified kinds into a slice.
+func CollectLastN(n int, kinds ...EventKind) (hook HookFunc, result *[]string) {
+	var lines []string
+	result = &lines
+	hook = func(evt *FormattedEvent) bool {
+		for _, k := range kinds {
+			if evt.Kind == k {
+				lines = append(lines, evt.Text)
+				if len(lines) > n {
+					lines = lines[1:]
+				}
+				break
+			}
+		}
+		return true // continue streaming
+	}
+	return
+}

--- a/skills/ag/internal/conv/stream.go
+++ b/skills/ag/internal/conv/stream.go
@@ -12,8 +12,9 @@ type HookFunc func(evt *FormattedEvent) bool
 
 // StreamEvents reads newline-delimited JSON events from reader and calls
 // hooks for each parsed event. It stops when the reader reaches EOF or a
-// hook returns false. Returns the number of events processed.
-func StreamEvents(reader io.Reader, hooks ...HookFunc) int {
+// hook returns false. Returns the number of events processed and any scanner
+// error encountered.
+func StreamEvents(reader io.Reader, hooks ...HookFunc) (int, error) {
 	scanner := bufio.NewScanner(reader)
 	const maxTokenSize = 10 * 1024 * 1024
 	scanner.Buffer(make([]byte, 0, 4096), maxTokenSize)
@@ -28,15 +29,15 @@ func StreamEvents(reader io.Reader, hooks ...HookFunc) int {
 		count++
 		for _, hook := range hooks {
 			if !hook(evt) {
-				return count
+				return count, nil
 			}
 		}
 	}
-	return count
+	return count, scanner.Err()
 }
 
 // StreamEventsFromString parses events from a raw string (e.g. full file content).
-func StreamEventsFromString(data string, hooks ...HookFunc) int {
+func StreamEventsFromString(data string, hooks ...HookFunc) (int, error) {
 	return StreamEvents(strings.NewReader(data), hooks...)
 }
 

--- a/skills/ag/internal/conv/stream_test.go
+++ b/skills/ag/internal/conv/stream_test.go
@@ -1,0 +1,145 @@
+package conv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStreamEvents(t *testing.T) {
+	input := `{"type":"agent_start"}
+{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello"}}
+{"type":"tool_execution_start","toolName":"read","args":{"path":"main.go"}}
+{"type":"agent_end","messages":[]}
+`
+	var texts []string
+	var tools []string
+	var metas []string
+
+	classifyHook := func(evt *FormattedEvent) bool {
+		switch evt.Kind {
+		case KindText:
+			texts = append(texts, evt.Text)
+		case KindTool:
+			tools = append(tools, evt.Tool)
+		case KindMeta:
+			metas = append(metas, evt.Text)
+		}
+		return true
+	}
+
+	count := StreamEvents(strings.NewReader(input), classifyHook)
+
+	if count != 4 {
+		t.Fatalf("expected 4 events, got %d", count)
+	}
+	if len(texts) != 1 || texts[0] != "hello" {
+		t.Fatalf("expected ['hello'], got %v", texts)
+	}
+	if len(tools) != 1 || tools[0] != "read" {
+		t.Fatalf("expected ['read'], got %v", tools)
+	}
+	if len(metas) != 2 {
+		t.Fatalf("expected 2 meta events, got %d: %v", len(metas), metas)
+	}
+}
+
+func TestStreamEvents_EarlyStop(t *testing.T) {
+	input := `{"type":"agent_start"}
+{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"first"}}
+{"type":"agent_end","messages":[]}
+{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"after end"}}
+`
+	var texts []string
+	stopHook := func(evt *FormattedEvent) bool {
+		if IsAgentDone(evt) {
+			return false // stop streaming
+		}
+		return true
+	}
+	textHook := func(evt *FormattedEvent) bool {
+		if evt.Kind == KindText {
+			texts = append(texts, evt.Text)
+		}
+		return true
+	}
+
+	count := StreamEvents(strings.NewReader(input), textHook, stopHook)
+
+	if count != 3 {
+		t.Fatalf("expected 3 events before stop, got %d", count)
+	}
+	// "after end" should not be collected
+	if len(texts) != 1 || texts[0] != "first" {
+		t.Fatalf("expected ['first'], got %v", texts)
+	}
+}
+
+func TestStreamEventsFromString(t *testing.T) {
+	input := `{"type":"agent_start"}
+{"type":"agent_end","messages":[]}
+`
+	count := StreamEventsFromString(input, func(evt *FormattedEvent) bool {
+		return true
+	})
+	if count != 2 {
+		t.Fatalf("expected 2, got %d", count)
+	}
+}
+
+func TestIsAgentDone(t *testing.T) {
+	tests := []struct {
+		name string
+		evt  *FormattedEvent
+		want bool
+	}{
+		{"done", &FormattedEvent{Kind: KindMeta, Text: "--- agent done ---"}, true},
+		{"failed", &FormattedEvent{Kind: KindMeta, Text: "--- agent failed ---"}, true},
+		{"failed_with_msg", &FormattedEvent{Kind: KindMeta, Text: "--- agent failed: timeout ---"}, true},
+		{"started", &FormattedEvent{Kind: KindMeta, Text: "--- agent started ---"}, false},
+		{"text", &FormattedEvent{Kind: KindText, Text: "--- agent done ---"}, false},
+		{"tool", &FormattedEvent{Kind: KindTool, Text: "🔧 read"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAgentDone(tt.evt); got != tt.want {
+				t.Fatalf("IsAgentDone() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAgentSuccess(t *testing.T) {
+	success := &FormattedEvent{Kind: KindMeta, Text: "--- agent done ---"}
+	failed := &FormattedEvent{Kind: KindMeta, Text: "--- agent failed ---"}
+
+	if !IsAgentSuccess(success) {
+		t.Fatal("expected success for 'agent done'")
+	}
+	if IsAgentSuccess(failed) {
+		t.Fatal("expected false for 'agent failed'")
+	}
+}
+
+func TestCollectLastN(t *testing.T) {
+	input := `{"type":"tool_execution_start","toolName":"read","args":{"path":"a.go"}}
+{"type":"tool_execution_start","toolName":"write","args":{"path":"b.go"}}
+{"type":"tool_execution_start","toolName":"bash","args":{"command":"ls"}}
+{"type":"tool_execution_start","toolName":"read","args":{"path":"c.go"}}
+{"type":"agent_end","messages":[]}
+`
+
+	hook, result := CollectLastN(2, KindTool)
+
+	StreamEventsFromString(input, hook)
+
+	if len(*result) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(*result), *result)
+	}
+	// Should be the last 2 tool lines
+	if !strings.Contains((*result)[0], "bash") {
+		t.Fatalf("expected first line to contain 'bash', got %q", (*result)[0])
+	}
+	if !strings.Contains((*result)[1], "read") {
+		t.Fatalf("expected second line to contain 'read', got %q", (*result)[1])
+	}
+}

--- a/skills/ag/internal/conv/stream_test.go
+++ b/skills/ag/internal/conv/stream_test.go
@@ -27,7 +27,7 @@ func TestStreamEvents(t *testing.T) {
 		return true
 	}
 
-	count := StreamEvents(strings.NewReader(input), classifyHook)
+		count, _ := StreamEvents(strings.NewReader(input), classifyHook)
 
 	if count != 4 {
 		t.Fatalf("expected 4 events, got %d", count)
@@ -63,7 +63,7 @@ func TestStreamEvents_EarlyStop(t *testing.T) {
 		return true
 	}
 
-	count := StreamEvents(strings.NewReader(input), textHook, stopHook)
+	count, _ := StreamEvents(strings.NewReader(input), textHook, stopHook)
 
 	if count != 3 {
 		t.Fatalf("expected 3 events before stop, got %d", count)
@@ -78,7 +78,7 @@ func TestStreamEventsFromString(t *testing.T) {
 	input := `{"type":"agent_start"}
 {"type":"agent_end","messages":[]}
 `
-	count := StreamEventsFromString(input, func(evt *FormattedEvent) bool {
+	count, _ := StreamEventsFromString(input, func(evt *FormattedEvent) bool {
 		return true
 	})
 	if count != 2 {
@@ -130,7 +130,7 @@ func TestCollectLastN(t *testing.T) {
 
 	hook, result := CollectLastN(2, KindTool)
 
-	StreamEventsFromString(input, hook)
+		_, _ = StreamEventsFromString(input, hook)
 
 	if len(*result) != 2 {
 		t.Fatalf("expected 2 lines, got %d: %v", len(*result), *result)

--- a/skills/ag/internal/conv/watch.go
+++ b/skills/ag/internal/conv/watch.go
@@ -23,9 +23,13 @@ func WatchFile(filePath string, pollInterval time.Duration, stopCh <-chan struct
 		default:
 		}
 
-		f, err := os.Open(filePath)
+				f, err := os.Open(filePath)
 		if err != nil {
-			// File doesn't exist yet, wait and retry
+			// If we've read before, the file was deleted — stop watching.
+			// Otherwise, the file hasn't been created yet — wait and retry.
+			if offset > 0 {
+				return nil
+			}
 			time.Sleep(pollInterval)
 			continue
 		}
@@ -80,7 +84,7 @@ func WatchUntilDone(filePath string, pollInterval time.Duration, stopCh <-chan s
 	}
 
 	agentDone := false
-	StreamEventsFromString(string(data), func(evt *FormattedEvent) bool {
+			_, _ = StreamEventsFromString(string(data), func(evt *FormattedEvent) bool {
 		if IsAgentDone(evt) {
 			agentDone = true
 			return false

--- a/skills/ag/internal/conv/watch.go
+++ b/skills/ag/internal/conv/watch.go
@@ -1,0 +1,105 @@
+package conv
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"time"
+)
+
+// WatchFile watches an events file for new lines and calls hooks for each
+// parsed event. It polls the file at the given interval. Stops when stopCh
+// is closed or the file is deleted.
+//
+// This is designed for monitoring agent runs in real-time (like tail -f but
+// with event parsing and hooks).
+func WatchFile(filePath string, pollInterval time.Duration, stopCh <-chan struct{}, hooks ...HookFunc) error {
+	var offset int64
+
+	for {
+		select {
+		case <-stopCh:
+			return nil
+		default:
+		}
+
+		f, err := os.Open(filePath)
+		if err != nil {
+			// File doesn't exist yet, wait and retry
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		// Seek to where we left off
+		if offset > 0 {
+			f.Seek(offset, io.SeekStart)
+		}
+
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 4096), 10*1024*1024)
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			evt := ParseEvent(line)
+			if evt == nil {
+				continue
+			}
+			for _, hook := range hooks {
+				if !hook(evt) {
+					f.Close()
+					return nil
+				}
+			}
+		}
+
+		// Remember where we read up to
+		offset, _ = f.Seek(0, io.SeekCurrent)
+		f.Close()
+
+		time.Sleep(pollInterval)
+	}
+}
+
+// WatchUntilDone watches an events file until an agent_end event is detected.
+// Returns the formatted summary lines collected during the watch.
+// This is the convenience API for scheduler's checkAIServeRun.
+func WatchUntilDone(filePath string, pollInterval time.Duration, stopCh <-chan struct{}) (done bool, summary string) {
+	lastNHook, result := CollectLastN(20, KindTool, KindMeta)
+
+	doneHook := func(evt *FormattedEvent) bool {
+		return !IsAgentDone(evt)
+	}
+
+	_ = WatchFile(filePath, pollInterval, stopCh, lastNHook, doneHook)
+
+	// Check if we stopped because of agent_end or because stopCh closed
+	// Re-scan the file to check final state
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return false, ""
+	}
+
+	agentDone := false
+	StreamEventsFromString(string(data), func(evt *FormattedEvent) bool {
+		if IsAgentDone(evt) {
+			agentDone = true
+			return false
+		}
+		return true
+	})
+
+	return agentDone, joinLines(*result)
+}
+
+func joinLines(lines []string) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	result := ""
+	for _, l := range lines {
+		if l != "" {
+			result += l + "\n"
+		}
+	}
+	return result
+}

--- a/skills/ag/internal/conv/watch_test.go
+++ b/skills/ag/internal/conv/watch_test.go
@@ -1,0 +1,67 @@
+package conv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWatchFileStopsOnDeletion(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "events.jsonl")
+
+		// Write some initial content so the first read sets offset > 0
+	os.WriteFile(fpath, []byte(`{"type":"agent_start"}`+"\n"), 0644)
+
+	stopCh := make(chan struct{})
+	resultCh := make(chan error, 1)
+
+	go func() {
+		err := WatchFile(fpath, 50*time.Millisecond, stopCh)
+		resultCh <- err
+	}()
+
+	// Let it read once to set offset > 0
+	time.Sleep(150 * time.Millisecond)
+
+	// Delete the file
+	os.Remove(fpath)
+
+	// WatchFile should return shortly after
+	select {
+	case err := <-resultCh:
+		if err != nil {
+			t.Errorf("expected nil error on file deletion, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchFile did not return after file deletion")
+		close(stopCh)
+	}
+}
+
+func TestWatchFileStopsOnStopChannel(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "events.jsonl")
+	os.WriteFile(fpath, []byte(""), 0644)
+
+	stopCh := make(chan struct{})
+	resultCh := make(chan error, 1)
+
+	go func() {
+		err := WatchFile(fpath, 50*time.Millisecond, stopCh)
+		resultCh <- err
+	}()
+
+	// Close stop channel
+	close(stopCh)
+
+	select {
+	case err := <-resultCh:
+		if err != nil {
+			t.Errorf("expected nil error, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchFile did not return after stop channel closed")
+	}
+}

--- a/skills/ag/internal/run/paths.go
+++ b/skills/ag/internal/run/paths.go
@@ -1,0 +1,76 @@
+// Package run provides a unified interface for interacting with ai run artifacts
+// stored under ~/.ai/runs/<runID>/. All path construction for events.jsonl,
+// run.json, and other run metadata goes through this package.
+package run
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// RunsDir returns the base directory for all ai runs (~/.ai/runs/).
+func RunsDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home dir: %w", err)
+	}
+	return filepath.Join(homeDir, ".ai", "runs"), nil
+}
+
+// Dir returns the directory for a specific run (~/.ai/runs/<runID>/).
+func Dir(runID string) (string, error) {
+	base, err := RunsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, runID), nil
+}
+
+// EventsPath returns the path to events.jsonl for a run.
+func EventsPath(runID string) (string, error) {
+	dir, err := Dir(runID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "events.jsonl"), nil
+}
+
+// MetaPath returns the path to run.json for a run.
+func MetaPath(runID string) (string, error) {
+	dir, err := Dir(runID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "run.json"), nil
+}
+
+// RunMeta represents the metadata stored in run.json.
+type RunMeta struct {
+	ID         string `json:"id"`
+	PID        int    `json:"pid"`
+	CWD        string `json:"cwd"`
+	Status     string `json:"status"`
+	StartedAt  int64  `json:"started_at"`
+	FinishedAt int64  `json:"finished_at"`
+	Name       string `json:"name"`
+	ParentRun  string `json:"parent_run"`
+}
+
+// ReadMeta reads and parses run.json for a given run ID.
+func ReadMeta(runID string) (*RunMeta, error) {
+	path, err := MetaPath(runID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read run meta %s: %w", runID, err)
+	}
+	var meta RunMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parse run meta %s: %w", runID, err)
+	}
+	return &meta, nil
+}

--- a/skills/ag/internal/task/scheduler.go
+++ b/skills/ag/internal/task/scheduler.go
@@ -1,14 +1,18 @@
 package task
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
+	"github.com/genius/ag/internal/conv"
 	"github.com/genius/ag/internal/storage"
 )
 
@@ -191,9 +195,8 @@ func spawnWorkers(ctx context.Context, cfg SchedulerConfig) (bool, error) {
 			continue
 		}
 
-		// Spawn worker agent
+				// Spawn worker agent
 		go spawnWorker(t.ID, claimed.Claimant, cfg)
-		fmt.Printf("  🚀 Started %s: %s\n", t.ID, t.Title)
 		slots--
 		progress = true
 	}
@@ -210,87 +213,81 @@ func spawnWorker(taskID, agentID string, cfg SchedulerConfig) {
 
 	prompt := BuildWorkerPrompt(t, cfg.DesignFile)
 
-	// Write prompt to temp file to avoid shell escaping issues
-	promptFile := filepath.Join(storage.TaskDir(taskID), "prompt.txt")
-	os.WriteFile(promptFile, []byte(prompt), 0644)
-
-	// Build ai serve command
-	args := []string{"serve"}
-	args = append(args, "--input", promptFile)
-	args = append(args, "--name", "ag-worker-"+taskID)
-	if cfg.WorkDir != "" {
-		args = append(args, "--cwd", cfg.WorkDir)
-	}
-
-	cmd := exec.Command("ai", args...)
+	// Spawn agent using "ai serve" — same pattern as aiAdapter.SpawnWithAIServe.
+	// Key: --input receives the prompt TEXT, not a file path.
+	// We read stdout to get the run ID, then Release the process.
+	cmd := exec.Command("ai", "serve")
+	cmd.Args = append(cmd.Args, "--input", prompt)
+	cmd.Args = append(cmd.Args, "--name", "ag-worker-"+taskID)
 	if cfg.WorkDir != "" {
 		cmd.Dir = cfg.WorkDir
 	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	// Capture output
+	// Capture run ID from stdout (ai serve prints run ID as first line)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		Fail(taskID, fmt.Sprintf("create stdout pipe: %v", err), true)
+		return
+	}
+
+	// Redirect stderr to output file for debugging
 	outputFile := filepath.Join(storage.TaskDir(taskID), "output")
 	outFile, err := os.Create(outputFile)
 	if err != nil {
 		Fail(taskID, fmt.Sprintf("create output file: %v", err), true)
 		return
 	}
-	cmd.Stdout = outFile
 	cmd.Stderr = outFile
 
-	if err := cmd.Start(); err != nil {
+		if err := cmd.Start(); err != nil {
 		outFile.Close()
 		Fail(taskID, fmt.Sprintf("start agent: %v", err), true)
 		return
 	}
 
-	// Write agent PID
+	fmt.Fprintf(os.Stderr, "  [debug] spawnWorker %s: pid=%d, waiting for run ID...\n", taskID, cmd.Process.Pid)
+
+	// Read run ID from stdout
+	reader := bufio.NewReader(stdout)
+	firstLine, err := reader.ReadString('\n')
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  [debug] spawnWorker %s: readString error: %v\n", taskID, err)
+	}
+	stdout.Close()
+	runID := strings.TrimSpace(firstLine)
+	fmt.Fprintf(os.Stderr, "  [debug] spawnWorker %s: runID=%q\n", taskID, runID)
+
+	// Save PID before Release
+	pid := cmd.Process.Pid
+
+	// Release process so it runs independently
+	if err := cmd.Process.Release(); err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: could not release worker process: %v\n", err)
+	}
+
+	// Write agent activity with PID and run ID
 	agentDir := storage.AgentDir(agentID)
 	os.MkdirAll(agentDir, 0755)
 	activity := map[string]interface{}{
 		"status":    "running",
 		"backend":   "ai",
 		"startedAt": time.Now().Unix(),
-		"pid":       cmd.Process.Pid,
+		"pid":       pid,
+		"runID":     runID,
 	}
 	storage.AtomicWriteJSON(filepath.Join(agentDir, "activity.json"), activity)
 
-	// Wait with timeout
-	done := make(chan error, 1)
-	go func() {
-		done <- cmd.Wait()
-		outFile.Close()
-	}()
+	// Write run ID to output file for traceability
+	outFile.WriteString(fmt.Sprintf("\nRun ID: %s\n", runID))
+	outFile.Close()
 
-	select {
-	case err := <-done:
-		if err != nil {
-			Fail(taskID, fmt.Sprintf("agent exited with error: %v", err), true)
-			fmt.Printf("  ❌ Failed %s: %v\n", taskID, err)
-		} else {
-			// Read output for summary
-			summary := readSummary(outputFile)
-			if cfg.SkipReview {
-				Done(taskID, summary)
-				fmt.Printf("  ✅ Done %s: %s\n", taskID, truncate(summary, 80))
-			} else {
-				// Transition to review instead of done — reviewer will finalize
-				Transition(taskID, StatusReview)
-				// Store summary in task output for reviewer to use
-				outPath := filepath.Join(storage.TaskDir(taskID), "output")
-				if summary != "" {
-					os.WriteFile(outPath, []byte(summary), 0644)
-				}
-				fmt.Printf("  📋 Done %s → review: %s\n", taskID, truncate(summary, 80))
-			}
-		}
-	case <-time.After(cfg.Timeout):
-		cmd.Process.Kill()
-		Fail(taskID, "agent timed out", true)
-		fmt.Printf("  ⏰ Timed out %s\n", taskID)
-	}
+	fmt.Printf("  🚀 Started %s: %s (run %s)\n", taskID, t.Title, runID)
 }
 
 // checkRunning checks if any running tasks have completed (stale detection).
+// For ai-serve workers, checks the run.json status via runID.
+// For legacy workers, checks if PID is still alive.
 func checkRunning(cfg SchedulerConfig) (bool, error) {
 	running, err := List(StatusRunning)
 	if err != nil {
@@ -298,7 +295,6 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 	}
 	progress := false
 	for _, t := range running {
-		// Check if agent process is still alive
 		if t.Claimant == "" {
 			continue
 		}
@@ -309,28 +305,103 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 		}
 
 		var act struct {
-			Pid int `json:"pid"`
+			Pid   int    `json:"pid"`
+			RunID string `json:"runID"`
 		}
-		if err := storage.ReadJSON(actPath, &act); err != nil || act.Pid <= 0 {
+		if err := storage.ReadJSON(actPath, &act); err != nil {
 			continue
 		}
 
-		// Check if process is alive
-		if !isProcessAlive(act.Pid) {
-			// Process is dead — check output for completion
-			outputFile := filepath.Join(storage.TaskDir(t.ID), "output")
-			if storage.Exists(outputFile) {
-				summary := readSummary(outputFile)
+		completed := false
+		summary := ""
+
+		if act.RunID != "" {
+			// ai-serve worker: check run.json for completion
+			completed, summary = checkAIServeRun(act.RunID, t.ID)
+		} else if act.Pid > 0 {
+			// Legacy worker: check if process is alive
+			if !isProcessAlive(act.Pid) {
+				outputFile := filepath.Join(storage.TaskDir(t.ID), "output")
+				if storage.Exists(outputFile) {
+					summary = readSummary(outputFile)
+					completed = true
+				} else {
+					Fail(t.ID, "agent process died without output", true)
+					fmt.Printf("  ❌ Detected failure %s (process died)\n", t.ID)
+					progress = true
+					continue
+				}
+			}
+		}
+
+		if completed {
+			if cfg.SkipReview {
 				Done(t.ID, summary)
-				fmt.Printf("  ✅ Detected completion %s (process exited)\n", t.ID)
+				fmt.Printf("  ✅ Detected completion %s (run done)\n", t.ID)
 			} else {
-				Fail(t.ID, "agent process died without output", true)
-				fmt.Printf("  ❌ Detected failure %s (process died)\n", t.ID)
+				Transition(t.ID, StatusReview)
+				outPath := filepath.Join(storage.TaskDir(t.ID), "output")
+				if summary != "" {
+					os.WriteFile(outPath, []byte(summary), 0644)
+				}
+				fmt.Printf("  📋 Detected completion %s → review\n", t.ID)
 			}
 			progress = true
 		}
 	}
 	return progress, nil
+}
+
+// checkAIServeRun checks if an ai-serve run has completed by reading its events.jsonl.
+// It does NOT rely on run.json status because ai serve blocks on cmd.Wait() and
+// only updates run.json after the RPC subprocess exits — which may never happen
+// when stdin is not closed.
+// Returns (completed, summary).
+func checkAIServeRun(runID, taskID string) (bool, string) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return false, ""
+	}
+
+	eventsPath := filepath.Join(homeDir, ".ai", "runs", runID, "events.jsonl")
+	data, err := os.ReadFile(eventsPath)
+	if err != nil {
+		return false, "" // events file not found yet, still starting
+	}
+
+	// Use conv streaming API to scan for agent_end and collect summary.
+	lastNHook, result := conv.CollectLastN(20, conv.KindTool, conv.KindMeta)
+
+	agentDone := false
+	doneHook := func(evt *conv.FormattedEvent) bool {
+		if conv.IsAgentDone(evt) {
+			agentDone = true
+			return false // stop scanning
+		}
+		return true
+	}
+
+	conv.StreamEventsFromString(string(data), lastNHook, doneHook)
+
+	if !agentDone {
+		return false, "" // still running
+	}
+
+	summary := strings.Join(*result, "\n")
+
+	// Kill the RPC subprocess so ai serve can exit and clean up
+	runMetaPath := filepath.Join(homeDir, ".ai", "runs", runID, "run.json")
+	metaData, _ := os.ReadFile(runMetaPath)
+	var meta struct {
+		PID int `json:"pid"`
+	}
+	if err := json.Unmarshal(metaData, &meta); err == nil && meta.PID > 0 {
+		if proc, err := os.FindProcess(meta.PID); err == nil {
+			proc.Signal(syscall.SIGTERM)
+		}
+	}
+
+	return true, summary
 }
 
 // checkGroupReview checks if any group has all tasks in review and needs reviewer.
@@ -374,28 +445,32 @@ func spawnReviewer(group string, tasks []*Task, cfg SchedulerConfig) {
 	diff := getDiff(cfg.WorkDir)
 
 	prompt := BuildReviewerPrompt(tasks, diff)
-	promptFile := filepath.Join(storage.TaskDir(tasks[0].ID), "review-prompt.txt")
-	os.WriteFile(promptFile, []byte(prompt), 0644)
-
 	agentID := fmt.Sprintf("reviewer-%s", group)
-	args := []string{"serve"}
-	args = append(args, "--input", promptFile)
-	args = append(args, "--name", agentID)
-	if cfg.WorkDir != "" {
-		args = append(args, "--cwd", cfg.WorkDir)
-	}
 
-	cmd := exec.Command("ai", args...)
+	// Spawn reviewer using "ai serve" — same pattern as spawnWorker.
+	cmd := exec.Command("ai", "serve")
+	cmd.Args = append(cmd.Args, "--input", prompt)
+	cmd.Args = append(cmd.Args, "--name", agentID)
 	if cfg.WorkDir != "" {
 		cmd.Dir = cfg.WorkDir
 	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
+	// Capture run ID from stdout
+		stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		for _, t := range tasks {
+			Fail(t.ID, fmt.Sprintf("reviewer stdout pipe: %v", err), true)
+		}
+		return
+	}
+
+	// Redirect stderr to review output file for debugging
 	outputFile := filepath.Join(storage.TaskDir(tasks[0].ID), "review-output")
 	outFile, _ := os.Create(outputFile)
-	cmd.Stdout = outFile
 	cmd.Stderr = outFile
 
-	if err := cmd.Start(); err != nil {
+		if err := cmd.Start(); err != nil {
 		outFile.Close()
 		for _, t := range tasks {
 			Fail(t.ID, fmt.Sprintf("start reviewer: %v", err), true)
@@ -403,21 +478,31 @@ func spawnReviewer(group string, tasks []*Task, cfg SchedulerConfig) {
 		return
 	}
 
-	err := cmd.Wait()
+	// Read run ID from stdout
+	reader := bufio.NewReader(stdout)
+	firstLine, _ := reader.ReadString('\n')
+	stdout.Close()
+	runID := strings.TrimSpace(firstLine)
+
+	// Wait for ai serve to complete (it exits when the RPC subprocess finishes)
+	waitErr := cmd.Wait()
 	outFile.Close()
 
-	if err != nil {
+	if waitErr != nil {
 		// Reviewer failed — pass anyway to not block
-		fmt.Printf("  ⚠️ Reviewer failed for group %s, auto-passing\n", group)
+		fmt.Printf("  ⚠️ Reviewer failed for group %s (run %s), auto-passing: %v\n", group, runID, waitErr)
 		for _, t := range tasks {
 			Done(t.ID, "auto-passed: reviewer failed")
 		}
 		return
 	}
 
-	// Check review output for pass/revision
-	output := readFile(outputFile)
-	if strings.Contains(output, "REVIEW_PASS") {
+	// Read events.jsonl for REVIEW_PASS
+	homeDir, _ := os.UserHomeDir()
+	eventsPath := filepath.Join(homeDir, ".ai", "runs", runID, "events.jsonl")
+	eventsData := readFile(eventsPath)
+
+	if strings.Contains(eventsData, "REVIEW_PASS") {
 		fmt.Printf("  ✅ Review passed for group %s\n", group)
 		for _, t := range tasks {
 			Done(t.ID, t.Summary)

--- a/skills/ag/internal/task/scheduler.go
+++ b/skills/ag/internal/task/scheduler.go
@@ -305,20 +305,41 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 			continue
 		}
 
-		var act struct {
-			Pid   int    `json:"pid"`
-			RunID string `json:"runID"`
+				var act struct {
+			Pid       int    `json:"pid"`
+			RunID     string `json:"runID"`
+			StartedAt int64  `json:"startedAt"`
 		}
 		if err := storage.ReadJSON(actPath, &act); err != nil {
 			continue
 		}
 
-		completed := false
+		// Check for scheduler timeout — if the worker has been running too long,
+		// treat it as failed to prevent hung runs from occupying slots forever.
+		if act.StartedAt > 0 && cfg.Timeout > 0 {
+			elapsed := time.Since(time.Unix(act.StartedAt, 0))
+			if elapsed > cfg.Timeout {
+				Fail(t.ID, fmt.Sprintf("task timed out after %v", elapsed.Round(time.Minute)), true)
+				fmt.Printf("  ⏰ Detected timeout %s (ran for %v)\n", t.ID, elapsed.Round(time.Minute))
+				progress = true
+				continue
+			}
+		}
+
+				completed := false
 		summary := ""
 
 		if act.RunID != "" {
-			// ai-serve worker: check run.json for completion
+			// ai-serve worker: check events.jsonl for completion
 			completed, summary = checkAIServeRun(act.RunID, t.ID)
+			// Fall back to PID liveness if events are unavailable
+			if !completed && act.Pid > 0 && !agent.IsProcessAlive(act.Pid) {
+				// Process died but events never showed agent_end — treat as failure
+				Fail(t.ID, "ai-serve process died without completing", true)
+				fmt.Printf("  ❌ Detected failure %s (ai-serve process died)\n", t.ID)
+				progress = true
+				continue
+			}
 		} else if act.Pid > 0 {
 			// Legacy worker: check if process is alive
 			if !agent.IsProcessAlive(act.Pid) {
@@ -381,7 +402,7 @@ func checkAIServeRun(runID, taskID string) (bool, string) {
 		return true
 	}
 
-	conv.StreamEventsFromString(string(data), lastNHook, doneHook)
+		conv.StreamEventsFromString(string(data), lastNHook, doneHook) //nolint:errcheck // best-effort event scanning
 
 	if !agentDone {
 		return false, "" // still running

--- a/skills/ag/internal/task/scheduler.go
+++ b/skills/ag/internal/task/scheduler.go
@@ -3,8 +3,7 @@ package task
 import (
 	"bufio"
 	"context"
-	"encoding/json"
-	"fmt"
+			"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +11,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/genius/ag/internal/agent"
 	"github.com/genius/ag/internal/conv"
+	"github.com/genius/ag/internal/run"
 	"github.com/genius/ag/internal/storage"
 )
 
@@ -320,7 +321,7 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 			completed, summary = checkAIServeRun(act.RunID, t.ID)
 		} else if act.Pid > 0 {
 			// Legacy worker: check if process is alive
-			if !isProcessAlive(act.Pid) {
+			if !agent.IsProcessAlive(act.Pid) {
 				outputFile := filepath.Join(storage.TaskDir(t.ID), "output")
 				if storage.Exists(outputFile) {
 					summary = readSummary(outputFile)
@@ -358,12 +359,11 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 // when stdin is not closed.
 // Returns (completed, summary).
 func checkAIServeRun(runID, taskID string) (bool, string) {
-	homeDir, err := os.UserHomeDir()
+	eventsPath, err := run.EventsPath(runID)
 	if err != nil {
 		return false, ""
 	}
 
-	eventsPath := filepath.Join(homeDir, ".ai", "runs", runID, "events.jsonl")
 	data, err := os.ReadFile(eventsPath)
 	if err != nil {
 		return false, "" // events file not found yet, still starting
@@ -390,12 +390,8 @@ func checkAIServeRun(runID, taskID string) (bool, string) {
 	summary := strings.Join(*result, "\n")
 
 	// Kill the RPC subprocess so ai serve can exit and clean up
-	runMetaPath := filepath.Join(homeDir, ".ai", "runs", runID, "run.json")
-	metaData, _ := os.ReadFile(runMetaPath)
-	var meta struct {
-		PID int `json:"pid"`
-	}
-	if err := json.Unmarshal(metaData, &meta); err == nil && meta.PID > 0 {
+	meta, err := run.ReadMeta(runID)
+	if err == nil && meta.PID > 0 {
 		if proc, err := os.FindProcess(meta.PID); err == nil {
 			proc.Signal(syscall.SIGTERM)
 		}
@@ -497,9 +493,8 @@ func spawnReviewer(group string, tasks []*Task, cfg SchedulerConfig) {
 		return
 	}
 
-	// Read events.jsonl for REVIEW_PASS
-	homeDir, _ := os.UserHomeDir()
-	eventsPath := filepath.Join(homeDir, ".ai", "runs", runID, "events.jsonl")
+		// Read events.jsonl for REVIEW_PASS
+	eventsPath, _ := run.EventsPath(runID)
 	eventsData := readFile(eventsPath)
 
 	if strings.Contains(eventsData, "REVIEW_PASS") {
@@ -518,15 +513,8 @@ func spawnReviewer(group string, tasks []*Task, cfg SchedulerConfig) {
 
 // Helper functions
 
-func isProcessAlive(pid int) bool {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	// On Unix, FindProcess always succeeds. Send signal 0 to check liveness.
-	err = proc.Signal(nil)
-	return err == nil
-}
+
+
 
 func getDiff(workDir string) string {
 	cmd := exec.Command("git", "diff")


### PR DESCRIPTION
## Summary

This PR contains three major improvements to the `ag` CLI tool:

### 1. Scheduler Rewrite (`9c19a7c`)
- **`spawnWorker`**: Fixed fire-and-forget pattern — uses `Process.Release()` instead of `cmd.Wait()` so the long-running `ai serve` daemon doesn't block the scheduler
- **`spawnReviewer`**: Corrected `--input` to pass prompt text instead of file path
- **`checkRunning`**: Dual-mode completion detection — ai-serve workers check `events.jsonl` for `agent_end`, legacy workers check PID
- **New `conv` streaming API**: `StreamEvents`, `HookFunc`, `IsAgentDone`, `IsAgentSuccess`, `CollectLastN`
- **New `conv` watch API**: `WatchFile`, `WatchUntilDone`
- **Enhanced `ag conv`**: `--watch <file>` and `--on <event>` flags
- 25 new conv tests, all passing
- Full end-to-end scheduler verification: 8-task pipeline ran without intervention

### 2. Architecture Analysis (`c3c3959`)
- Comprehensive analysis of 6835 lines across 27 Go files
- Generated `docs/ARCHITECTURE.md` with dependency diagram and metrics
- 3 ADRs: run path consolidation, event parsing unification, process liveness dedup

### 3. Architecture Refactoring (`3c4a45e`)
- **P1**: Exported `agent.IsProcessAlive`, removed 2 duplicate copies
- **P0**: Extracted `internal/run` package — `RunsDir()`, `EventsPath()`, `MetaPath()`, `ReadMeta()` replacing 9 hardcoded path constructions
- **P0**: Unified event parsing into `conv.ConversationBuilder` — removed `parseAssistantMessages` (93 lines) and `parseConversation` (104 lines)
- **Translated** all Chinese comments to English in `formatted_writer.go`, `ai_adapter.go`, `conversation.go`
- Net reduction: **255 lines** deleted

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` — all tests pass (conv 31 tests, cmd all, task all)
- [x] End-to-end scheduler run: 8-task scheme-meta pipeline completed automatically