### PR TITLE
Fix: [BUG] Fix /resume infinite recursion causing hang

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -1754,17 +1754,81 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	server.RegisterSlash("resume", "List sessions or resume a session by ID/name", func(args string) (any, error) {
 		arg := strings.TrimSpace(args)
 		if arg == "" {
-			h, ok := server.GetSlashHandler("list_sessions")
-			if !ok {
-				return nil, fmt.Errorf("unknown command: list_sessions")
+			// List all sessions directly (was previously delegating to list_sessions alias → infinite recursion)
+			sessions, err := sessionMgr.ListSessions()
+			if err != nil {
+				return nil, fmt.Errorf("failed to list sessions: %w", err)
 			}
-			return h("")
+			return map[string]any{"sessions": sessions}, nil
 		}
-		h, ok := server.GetSlashHandler("switch_session")
-		if !ok {
-			return nil, fmt.Errorf("unknown command: switch_session")
+
+		// Resolve session by index, ID, or name
+		var targetID string
+		sessions, err := sessionMgr.ListSessions()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list sessions: %w", err)
 		}
-		return h(arg)
+
+		// Try numeric index first
+		if idx, err := strconv.Atoi(arg); err == nil {
+			if idx < 0 || idx >= len(sessions) {
+				return nil, fmt.Errorf("session index %d out of range (0-%d)", idx, len(sessions)-1)
+			}
+			targetID = sessions[idx].ID
+		} else {
+			// Try exact ID match, then name match
+			for _, s := range sessions {
+				if s.ID == arg {
+					targetID = s.ID
+					break
+				}
+			}
+			if targetID == "" {
+				for _, s := range sessions {
+					if s.Name == arg {
+						targetID = s.ID
+						break
+					}
+				}
+			}
+			if targetID == "" {
+				return nil, fmt.Errorf("session not found: %s", arg)
+			}
+		}
+
+		// Load the target session
+		newSess, err := sessionMgr.GetSession(targetID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load session %s: %w", targetID, err)
+		}
+
+		// Update session manager's current ID
+		if err := sessionMgr.SetCurrent(targetID); err != nil {
+			return nil, err
+		}
+		if err := sessionMgr.SaveCurrent(); err != nil {
+			slog.Info("Failed to update session metadata:", "value", err)
+		}
+
+		// Switch to the new session
+		newSessionName := resolveSessionName(sessionMgr, targetID)
+		sess = newSess
+		sessionComp.Update(sess, compactor)
+		setAgentContext(createBaseContext())
+
+		// Update checkpoint manager for switched session
+		if err := updateCheckpointManager(); err != nil {
+			slog.Warn("Failed to update checkpoint manager for session switch", "error", err)
+		}
+
+		stateMu.Lock()
+		sessionID = targetID
+		sessionName = newSessionName
+		stateMu.Unlock()
+
+		slog.Info("Switched to session", "id", targetID, "name", newSessionName)
+		server.EmitEvent(map[string]any{"type": "session_switch", "session": targetID, "sessionName": newSessionName})
+		return map[string]any{"sessionId": targetID, "sessionName": newSessionName}, nil
 	})
 
 	// /context — composite: returns state + session stats + available models


### PR DESCRIPTION
## Workpad

```
hostname:worktree@9123754
```

### Plan

- [x] 1. Reproduce and understand the bug
  - [x] 1.1 Identify circular alias chain: `list_sessions` → `resume` → `list_sessions` (infinite recursion)
  - [x] 1.2 Identify circular alias chain: `switch_session` → `resume` → `switch_session` (infinite recursion)
- [ ] 2. Implement fix: inline session listing and switching logic in `/resume` handler
  - [ ] 2.1 No-args case: call `sessionMgr.ListSessions()` directly, return session list
  - [ ] 2.2 With-args case: resolve session by index/ID, load it, update state, emit event
- [ ] 3. Remove broken alias registrations for `list_sessions` and `switch_session`
- [ ] 4. Run tests to verify
- [ ] 5. Commit, push, create PR

### Acceptance Criteria

- [ ] `/resume` with no args returns session list without recursion
- [ ] `/resume` with args switches session without recursion
- [ ] Backward-compatible aliases `list_sessions` and `switch_session` still work (they now resolve to the fixed `/resume` handler)
- [ ] All tests pass

### Validation

- [ ] targeted tests: `go test ./cmd/ai/... ./pkg/session/... ./pkg/run/...`

### Notes

- Root cause confirmed: Lines 1670-1671 register aliases `list_sessions → resume` and `switch_session → resume`. Lines 1754-1770 in `/resume` handler try to call `GetSlashHandler("list_sessions")` and `GetSlashHandler("switch_session")`, creating circular dispatch.
- Fix approach: Inline the session listing and switching logic directly in the `/resume` handler, removing the delegation to non-existent handlers.
- The aliases on lines 1670-1671 should be KEPT because external clients may still send `list_sessions` or `switch_session` commands. They will now correctly route to the fixed `/resume` handler which no longer tries to call back.