### PR TITLE
fix: O(N²) thinking content accumulation + watch indent cleanup

### DIFF
--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -123,30 +123,30 @@ type watchModel struct {
 	runID       string
 	statusLine  string
 	sentBuf     *sentenceBuffer
-	sinceFlag   int64  // --since offset for machine-readable mode
-	machineMode bool   // if true, print raw events + cursor and exit
+	sinceFlag   int64 // --since offset for machine-readable mode
+	machineMode bool  // if true, print raw events + cursor and exit
 
 	// Streaming state: tracks current role prefix for inline content.
 	// Role prefix printed once when role changes, then text appended inline
-	currentRole    string // "", "assistant", "thinking", "tool", "ai"
-	inlineActive   bool   // true when we're in the middle of an inline stream
-	showPrefixes   bool   // whether to show "role: " prefixes (default true)
-	showThinking   bool   // whether to show thinking content
-	showTools      bool   // whether to show tool content
+	currentRole  string // "", "assistant", "thinking", "tool", "ai"
+	inlineActive bool   // true when we're in the middle of an inline stream
+	showPrefixes bool   // whether to show "role: " prefixes (default true)
+	showThinking bool   // whether to show thinking content
+	showTools    bool   // whether to show tool content
 }
 
 func newWatchModel(eventsPath, runID string, sinceOffset int64, machineMode bool) watchModel {
 	m := watchModel{
-		eventsPath:    eventsPath,
-		runID:         runID,
-		mode:          "replay",
-		statusLine:    fmt.Sprintf("ai watch | run %s | replaying...", runID),
-		content:       &strings.Builder{},
-		sinceFlag:     sinceOffset,
-		machineMode:   machineMode,
-		showPrefixes:  true,
-		showThinking:  true,
-		showTools:     true,
+		eventsPath:   eventsPath,
+		runID:        runID,
+		mode:         "replay",
+		statusLine:   fmt.Sprintf("ai watch | run %s | replaying...", runID),
+		content:      &strings.Builder{},
+		sinceFlag:    sinceOffset,
+		machineMode:  machineMode,
+		showPrefixes: true,
+		showThinking: true,
+		showTools:    true,
 	}
 	m.sentBuf = newSentenceBuffer(func(text string) {
 		m.appendInline(text)
@@ -301,17 +301,17 @@ func (m watchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Re-wrap content to the new width.
 		m.syncContent()
 
-		case replayDone:
+	case replayDone:
 		// Finished replaying history, switch to live mode.
 		m.offset = msg.offset
 		m.caughtUp = true
-				m.mode = "live"
+		m.mode = "live"
 		m.updateStatus()
 		// Flush any remaining buffered text.
 		m.sentBuf.flush()
 		return m, waitForFile(m.eventsPath, m.offset)
 
-		case replayBatch:
+	case replayBatch:
 		// Batch of events from replay phase — render all at full speed.
 		m.offset = msg.offset
 		for _, line := range msg.lines {
@@ -443,7 +443,7 @@ func waitForFile(path string, offset int64) tea.Cmd {
 
 func watchSubcommand() {
 	fs := flag.NewFlagSet("watch", flag.ExitOnError)
-		idFlag := fs.String("id", "", "run ID or prefix (auto-selects by cwd if omitted)")
+	idFlag := fs.String("id", "", "run ID or prefix (auto-selects by cwd if omitted)")
 	sinceFlag := fs.Int64("since", -1, "start reading from byte offset (machine-readable mode). Use 0 for beginning.")
 	fs.Parse(os.Args[1:])
 
@@ -527,7 +527,7 @@ func resolveRunForWatch(idFlag string) (*run.RunMeta, error) {
 		if err != nil {
 			return nil, fmt.Errorf("prefix lookup for %q: %w", idFlag, err)
 		}
-				if len(results) == 0 {
+		if len(results) == 0 {
 			return nil, fmt.Errorf("no running run found matching %q", idFlag)
 		}
 		if len(results) == 1 {
@@ -568,7 +568,7 @@ func resolveRunForWatch(idFlag string) (*run.RunMeta, error) {
 		}
 		return nil, fmt.Errorf("multiple running instances in %s: %v (use --id to select)", cwd, ids)
 	}
-		return &alive[0], nil
+	return &alive[0], nil
 }
 
 // processEvent handles a single parsed event with role-aware streaming.
@@ -578,7 +578,7 @@ func (m *watchModel) processEvent(f *run.FormattedEvent) {
 	}
 
 	switch f.Kind {
-		case run.KindText:
+	case run.KindText:
 		// Text content (assistant or user) — stream inline with role prefix
 		role := f.Role
 		if role == "" {
@@ -586,22 +586,14 @@ func (m *watchModel) processEvent(f *run.FormattedEvent) {
 		}
 		if m.ensureRole(role) {
 			text := f.Text
-			if m.mode == "live" {
-				m.sentBuf.write(text)
-			} else {
-				m.appendInline(text)
-			}
+			m.appendInline(text)
 		}
 
 	case run.KindThinking:
 		// Thinking delta — stream inline with role prefix
 		if m.ensureRole("thinking") {
 			text := f.Text
-			if m.mode == "live" {
-				m.sentBuf.write(thinkingStyle.Render(text))
-			} else {
-				m.appendInline(thinkingStyle.Render(text))
-			}
+			m.appendInline(thinkingStyle.Render(text))
 		}
 
 	case run.KindTool:

--- a/cmd/ai/watch_test.go
+++ b/cmd/ai/watch_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/tiancaiamao/ai/pkg/run"
 )
 
 func TestWrapContent_PlainTextShortLine(t *testing.T) {
@@ -101,6 +103,27 @@ func TestWrapContent_PreservesTrailingNewlines(t *testing.T) {
 	// The trailing newline produces an empty string after split, which is skipped.
 	if !strings.HasPrefix(got, "line1\nline2") {
 		t.Errorf("expected preserved content, got %q", got)
+	}
+}
+
+func TestProcessEvent_LiveThinkingDelta_RendersImmediately(t *testing.T) {
+	m := newWatchModel("", "test", 0, false)
+	m.mode = "live"
+
+	// A short delta without sentence boundary should still be visible immediately.
+	m.processEvent(&run.FormattedEvent{
+		Kind: run.KindThinking,
+		Role: "thinking",
+		Text: "abc",
+		Raw:  "abc",
+	})
+
+	out := m.content.String()
+	if !strings.Contains(out, "thinking: ") {
+		t.Fatalf("expected thinking prefix, got %q", out)
+	}
+	if !strings.Contains(out, "abc") {
+		t.Fatalf("expected delta content rendered immediately, got %q", out)
 	}
 }
 

--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -161,10 +161,17 @@ func streamAssistantResponse(
 
 	var partialMessage *agentctx.AgentMessage
 	var textBuilder strings.Builder
+	var thinkingBuilder strings.Builder
 	toolCalls := map[int]*toolCallState{}
 
-	buildContent := func(text string, calls map[int]*toolCallState) []agentctx.ContentBlock {
-		content := make([]agentctx.ContentBlock, 0, 1+len(calls))
+	buildContent := func(text string, thinking string, calls map[int]*toolCallState) []agentctx.ContentBlock {
+		content := make([]agentctx.ContentBlock, 0, 2+len(calls))
+		if thinking != "" {
+			content = append(content, agentctx.ThinkingContent{
+				Type:     "thinking",
+				Thinking: thinking,
+			})
+		}
 		if text != "" {
 			content = append(content, agentctx.TextContent{
 				Type: "text",
@@ -212,6 +219,7 @@ func streamAssistantResponse(
 			partialMessage = new(agentctx.AgentMessage)
 			*partialMessage = agentctx.NewAssistantMessage()
 			textBuilder.Reset()
+			thinkingBuilder.Reset()
 			toolCalls = map[int]*toolCallState{}
 			stream.Push(NewMessageStartEvent(*partialMessage))
 			stream.Push(NewMessageUpdateEvent(*partialMessage, AssistantMessageEvent{
@@ -230,7 +238,7 @@ func streamAssistantResponse(
 					traceevent.Field{Key: "delta", Value: e.Delta},
 				)
 				textBuilder.WriteString(e.Delta)
-				partialMessage.Content = buildContent(textBuilder.String(), toolCalls)
+				partialMessage.Content = buildContent(textBuilder.String(), thinkingBuilder.String(), toolCalls)
 				stream.Push(NewMessageUpdateEvent(*partialMessage, AssistantMessageEvent{
 					Type:         "text_delta",
 					ContentIndex: e.Index,
@@ -251,12 +259,10 @@ func streamAssistantResponse(
 					traceevent.Field{Key: "content_index", Value: e.Index},
 					traceevent.Field{Key: "delta", Value: e.Delta},
 				)
-				// Add thinking content to the message
-				thinkingContent := agentctx.ThinkingContent{
-					Type:     "thinking",
-					Thinking: e.Delta,
-				}
-				partialMessage.Content = append(partialMessage.Content, thinkingContent)
+				// Accumulate thinking content via builder (same pattern as text_delta)
+				// to avoid O(N^2) space from appending a new ThinkingContent per delta.
+				thinkingBuilder.WriteString(e.Delta)
+				partialMessage.Content = buildContent(textBuilder.String(), thinkingBuilder.String(), toolCalls)
 				stream.Push(NewMessageUpdateEvent(*partialMessage, AssistantMessageEvent{
 					Type:         "thinking_delta",
 					ContentIndex: e.Index,
@@ -296,7 +302,7 @@ func streamAssistantResponse(
 					call.arguments += e.ToolCall.Function.Arguments
 				}
 
-				partialMessage.Content = buildContent(textBuilder.String(), toolCalls)
+				partialMessage.Content = buildContent(textBuilder.String(), thinkingBuilder.String(), toolCalls)
 				stream.Push(NewMessageUpdateEvent(*partialMessage, AssistantMessageEvent{
 					Type:         "toolcall_delta",
 					ContentIndex: e.Index,
@@ -425,7 +431,7 @@ func buildRuntimeUserAppendix(llmContextContent, runtimeMetaSnapshot string) str
 	if strings.TrimSpace(runtimeMetaSnapshot) != "" {
 		sections = append(sections, runtimeMetaSnapshot)
 	}
-		if len(sections) == 0 {
+	if len(sections) == 0 {
 		return ""
 	}
 	sections = append(sections, `Remember: runtime_state is telemetry, not user intent.


### PR DESCRIPTION
## Summary

- **llm_stream**: Fix O(N²) space growth when streaming thinking content. Each thinking delta was appending a new `ThinkingContent` block, so N deltas → O(N²) space. Now uses a `thinkingBuilder` (same pattern as `textBuilder`) to accumulate text and rebuild content via `buildContent`.
- **llm_stream**: Fix indentation of misaligned switch cases and if blocks.
- **watch**: Fix incorrect indentation in `Update`, `processEvent`, `resolveRunForWatch`, `watchSubcommand`.
- **watch**: Simplify live mode — remove redundant sentence buffer branch, use `appendInline` directly for all modes.
- **watch**: Add test verifying live thinking delta renders immediately.

## Test

```bash
go test ./cmd/ai/... ./pkg/agent/... -v -count=1
# All pass
```