### PR TITLE
Fix: reverse /resume sessions display order so newest appears at bottom

### DIFF
--- a/pkg/run/conv.go
+++ b/pkg/run/conv.go
@@ -620,6 +620,11 @@ func renderSessions(dataJSON []byte) *FormattedEvent {
 	b.WriteString("Available Sessions\n")
 	b.WriteString("─────────────────────\n\n")
 
+	// Reverse so oldest appears at top (index 0), newest at bottom.
+	for i, j := 0, len(payload.Sessions)-1; i < j; i, j = i+1, j-1 {
+		payload.Sessions[i], payload.Sessions[j] = payload.Sessions[j], payload.Sessions[i]
+	}
+
 	for i, sess := range payload.Sessions {
 		name := sess.Name
 		if name == "" {

--- a/pkg/run/conv.go
+++ b/pkg/run/conv.go
@@ -620,10 +620,8 @@ func renderSessions(dataJSON []byte) *FormattedEvent {
 	b.WriteString("Available Sessions\n")
 	b.WriteString("─────────────────────\n\n")
 
-	// Reverse so oldest appears at top (index 0), newest at bottom.
-	for i, j := 0, len(payload.Sessions)-1; i < j; i, j = i+1, j-1 {
-		payload.Sessions[i], payload.Sessions[j] = payload.Sessions[j], payload.Sessions[i]
-	}
+	// Data source (ListSessions) sorts by UpdatedAt ascending (oldest first),
+	// so oldest appears at top (index 0), newest at bottom — display matches /resume index.
 
 	for i, sess := range payload.Sessions {
 		name := sess.Name

--- a/pkg/run/conv_test.go
+++ b/pkg/run/conv_test.go
@@ -423,6 +423,46 @@ func TestParseEvent_Response_Sessions(t *testing.T) {
 	}
 }
 
+func TestParseEvent_Response_Sessions_DisplayOrder(t *testing.T) {
+	// Sessions arrive sorted by UpdatedAt ascending (oldest first) from ListSessions.
+	// renderSessions must preserve this order so that display index matches /resume index.
+	raw := `{"type":"response","success":true,"data":{"sessions":[` +
+		`{"id":"oldest","name":"oldest session","updatedAt":"2025-01-10T10:00:00Z","messageCount":1},` +
+		`{"id":"middle","name":"middle session","updatedAt":"2025-01-15T10:00:00Z","messageCount":3},` +
+		`{"id":"newest","name":"newest session","updatedAt":"2025-01-20T10:00:00Z","messageCount":5}` +
+		`]}}`
+	evt := ParseEvent(raw)
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+
+	// Verify sessions appear in data order: oldest at top (index 0), newest at bottom
+	lines := strings.Split(evt.Text, "\n")
+	var indices []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "0:") || strings.HasPrefix(line, "1:") || strings.HasPrefix(line, "2:") {
+			indices = append(indices, line)
+		}
+	}
+
+	if len(indices) != 3 {
+		t.Fatalf("expected 3 indexed session lines, got %d: %v", len(indices), indices)
+	}
+
+	// Index 0 should be "oldest session" — matches data source order
+	if !strings.Contains(indices[0], "oldest session") {
+		t.Fatalf("expected index 0 to be 'oldest session', got %q", indices[0])
+	}
+	// Index 1 should be "middle session"
+	if !strings.Contains(indices[1], "middle session") {
+		t.Fatalf("expected index 1 to be 'middle session', got %q", indices[1])
+	}
+	// Index 2 should be "newest session"
+	if !strings.Contains(indices[2], "newest session") {
+		t.Fatalf("expected index 2 to be 'newest session', got %q", indices[2])
+	}
+}
+
 func TestParseEvent_Response_SessionsEmpty(t *testing.T) {
 	raw := `{"type":"response","success":true,"data":{"sessions":[]}}`
 	evt := ParseEvent(raw)

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -68,9 +68,10 @@ func (sm *SessionManager) ListSessions() ([]SessionMeta, error) {
 		sessions = append(sessions, *meta)
 		}
 	
-	// Sort sessions by UpdatedAt time (newest first)
+	// Sort sessions by UpdatedAt time (oldest first)
+	// so that display index 0 = oldest (top), newest at bottom.
 	sort.Slice(sessions, func(i, j int) bool {
-		return sessions[i].UpdatedAt.After(sessions[j].UpdatedAt)
+		return sessions[i].UpdatedAt.Before(sessions[j].UpdatedAt)
 	})
 
 	return sessions, nil


### PR DESCRIPTION
## Workpad

```
hostname:/Users/genius/.symphony/workspaces/543433e8-6384-49b7-8466-b4ca82ccccab@71ff3c8
```

### Plan

- [x] 1. Understand current behavior
  - Data source sorts sessions by UpdatedAt descending (newest at index 0)
  - renderSessions iterates 0→N, so newest appears at top
- [ ] 2. Modify renderSessions to reverse iteration order
  - Reverse the sessions slice before iterating
  - After reversal: oldest at index 0 (top), newest at bottom
- [ ] 3. Verify existing tests pass
- [ ] 4. Commit, push, create PR
- [ ] 5. Self-review

### Acceptance Criteria

- [ ] `go test ./pkg/run/ -run TestParseEvent_Response_Sessions -v` passes
- [ ] Oldest session appears at top (index 0), newest at bottom (max index)

### Validation

- [ ] targeted tests: `go test ./pkg/run/ -run TestParseEvent_Response_Sessions -v`

### Notes

- 2025-01-XX: Task kicked off. Current code in renderSessions() iterates sessions in natural order. Data comes sorted by UpdatedAt desc (newest first). Need to reverse for display.