### PR TITLE
Fix: /new slash command displays all-unknown SessionState output

### DIFF
--- a/pkg/run/conv.go
+++ b/pkg/run/conv.go
@@ -516,6 +516,14 @@ func parseResponseEvent(evt map[string]any) *FormattedEvent {
 		return renderContext(dataJSON)
 	}
 
+	// /new → {sessionId, cancelled} — skip; session_switch event already handles display
+	// Must check both fields to avoid suppressing /fork which also has {cancelled} but no {sessionId}.
+	if _, hasCancelled := dataRaw["cancelled"]; hasCancelled {
+		if _, hasSessionID := dataRaw["sessionId"]; hasSessionID {
+			return nil
+		}
+	}
+
 	// /session → SessionState (has sessionId + model + thinkingLevel)
 	if _, hasSessionID := dataRaw["sessionId"]; hasSessionID {
 		return renderSessionState(dataJSON)

--- a/pkg/run/conv_test.go
+++ b/pkg/run/conv_test.go
@@ -554,6 +554,36 @@ func TestParseEvent_ThinkingDelta_ValidContent(t *testing.T) {
 	}
 }
 
+func TestParseEvent_Response_NewSession_SkipsSessionState(t *testing.T) {
+	// /new returns {sessionId, cancelled} — should be skipped (session_switch event handles display)
+	input := `{"type":"response","command":"new","success":true,"data":{"sessionId":"abc-123","cancelled":false}}`
+	evt := ParseEvent(input)
+	if evt != nil {
+		t.Fatalf("expected nil for /new response (should be skipped), got %+v", evt)
+	}
+}
+
+func TestParseEvent_Response_NewSession_Cancelled(t *testing.T) {
+	// /new with cancelled=true should also be skipped
+	input := `{"type":"response","command":"new","success":true,"data":{"sessionId":"abc-123","cancelled":true}}`
+	evt := ParseEvent(input)
+	if evt != nil {
+		t.Fatalf("expected nil for cancelled /new response, got %+v", evt)
+	}
+}
+
+func TestParseEvent_Response_ForkNotSuppressed(t *testing.T) {
+	// /fork returns {cancelled, text} but no sessionId — must not be suppressed
+	input := `{"type":"response","command":"fork","success":true,"data":{"cancelled":false,"text":"forked content here"}}`
+	evt := ParseEvent(input)
+	if evt == nil {
+		t.Fatal("expected non-nil event for /fork response, should not be suppressed")
+	}
+	if !strings.Contains(evt.Text, "forked content here") {
+		t.Fatalf("expected fork text content, got: %s", evt.Text)
+	}
+}
+
 func TestParseEvent_MessageUpdate_ThinkingDelta(t *testing.T) {
 	// Test the thinking_delta in message_update format (assistantMessageEvent)
 	json := `{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"   "}}`


### PR DESCRIPTION
## Fix

The `/new` slash command showed a SessionState block full of unknown values (name, file, ai-pid, model, etc.).

### Root Cause

The `/new` handler returns `{"sessionId": "...", "cancelled": false}`. The `parseResponseEvent` function in `pkg/run/conv.go` sees `sessionId` in the response data and routes it to `renderSessionState()`, which expects a full SessionState struct. Since `/new` only returns `sessionId` + `cancelled`, all other fields render as "unknown".

### Fix

Added detection for the `cancelled` field (present in `/new` response, absent in `/session` response) before the `sessionId` branch in `parseResponseEvent()`. Returns `nil` to skip rendering, since the `session_switch` event already handles the display.

### Testing

- 2 new test cases covering the fix
- All 67 existing tests pass (`go test ./pkg/run/ -v`)
- `/session` still correctly displays full session state (unaffected by the change)

### Files

- `pkg/run/conv.go` — Added `cancelled` field detection in `parseResponseEvent()`
- `pkg/run/conv_test.go` — Added tests for the fix