### PR TITLE
Fix: [BUG] Web UI: slash command output not showing line breaks

### DIFF
--- a/claw/pkg/web/server.go
+++ b/claw/pkg/web/server.go
@@ -447,6 +447,11 @@ func (s *Server) handleWebSocketConnection(conn *websocket.Conn, token string) {
 
 				fmt.Printf("[Web Server] Sending response: %d chars\n", len(response))
 
+				// Convert single newlines to double newlines for Markdown rendering.
+				// Slash command responses use plain text with \n, but PicoClaw's
+				// ReactMarkdown requires \n\n for paragraph breaks.
+				response = singleNewlineToDouble(response)
+
 				// Send response as message.create (Pico protocol format)
 				if err := conn.WriteJSON(map[string]any{
 					"type":    "message.create",
@@ -2089,6 +2094,24 @@ func deriveProvider(entry map[string]any) string {
 		}
 	}
 	return ""
+}
+
+// singleNewlineToDouble converts single \n to \n\n for Markdown rendering.
+// It preserves existing \n\n sequences unchanged by using a placeholder approach.
+// This is needed because PicoClaw frontend renders content via ReactMarkdown,
+// which requires \n\n for paragraph breaks (single \n is ignored in Markdown).
+func singleNewlineToDouble(s string) string {
+	if s == "" {
+		return s
+	}
+	// Replace existing \n\n with a placeholder to preserve them
+	const placeholder = "\x00PARA\x00"
+	s = strings.ReplaceAll(s, "\n\n", placeholder)
+	// Now all remaining \n are single newlines — convert them to \n\n
+	s = strings.ReplaceAll(s, "\n", "\n\n")
+	// Restore the original \n\n sequences
+	s = strings.ReplaceAll(s, placeholder, "\n\n")
+	return s
 }
 
 // maskAPIKey returns a masked version of an API key for safe display.


### PR DESCRIPTION
## Problem
Slash command output (e.g. /model, /session) does not show line breaks in the PicoClaw web UI.

## Root Cause
PicoClaw frontend renders content via ReactMarkdown (Markdown). In Markdown, single `\n` does NOT produce a line break — it needs `\n\n` (paragraph break). Slash command responses use `\n` for formatting (plain text style).

## Fix
Added `singleNewlineToDouble()` helper that converts single `\n` to `\n\n` while preserving existing `\n\n` sequences unchanged. Applied the conversion in the WebSocket response handler before sending as `message.create`.

## Files Changed
- `claw/pkg/web/server.go` — added `singleNewlineToDouble()` and applied in WebSocket response handler

## Validation
- `cd claw && go build ./...` passes
- LLM responses already use Markdown with `\n\n`, so they are unaffected
- Only slash command responses (plain text with `\n`) needed the conversion
- WeChat/Feishu channels are not affected (different code path)