### PR TITLE
Fix: [BUG] aiclaw working directory set to process startup dir instead of ~/.aiclaw

### DIFF
--- a/claw/cmd/aiclaw/main.go
+++ b/claw/cmd/aiclaw/main.go
@@ -219,7 +219,7 @@ func main() {
 	// Load skills
 	skillLoader := skill.NewLoader(clawDir)
 	skillResult := skillLoader.Load(&skill.LoadOptions{
-		CWD:             "", // no workspace
+		CWD:             clawDir,
 		AgentDir:        clawDir,
 		SkillPaths:      nil,
 		IncludeDefaults: true,

--- a/claw/pkg/adapter/adapter.go
+++ b/claw/pkg/adapter/adapter.go
@@ -156,7 +156,7 @@ func NewAgentLoop(cfg *AppConfig, msgBus *bus.MessageBus) *AgentLoop {
 	}
 
 	// Create ConnManager — the core of the RPC architecture
-	connManager := NewConnManager(sessionsDir, cfg.SystemPrompt)
+	connManager := NewConnManager(sessionsDir, cfg.SystemPrompt, cfg.ClawDir)
 
 	// Create Feishu client (for voice file download)
 	var feishuClient *lark.Client

--- a/claw/pkg/adapter/integration_test.go
+++ b/claw/pkg/adapter/integration_test.go
@@ -29,7 +29,7 @@ func TestIntegrationConnManagerPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cm := NewConnManager(sessionsDir, "You are a helpful test assistant. Reply with exactly: PONG")
+	cm := NewConnManager(sessionsDir, "You are a helpful test assistant. Reply with exactly: PONG", "")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -73,7 +73,7 @@ func TestIntegrationConnManagerMultipleSessions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cm := NewConnManager(sessionsDir, "You are a helpful test assistant. Reply briefly.")
+	cm := NewConnManager(sessionsDir, "You are a helpful test assistant. Reply briefly.", "")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()

--- a/claw/pkg/adapter/rpc_client.go
+++ b/claw/pkg/adapter/rpc_client.go
@@ -54,7 +54,7 @@ type rpcResponseOrEvent struct {
 // The subprocess command is:
 //
 //	ai --mode rpc --session <sessionsDir>/<safeKey> --system-prompt @<systemPromptFile>
-func StartRPC(sessionKey, sessionsDir, systemPromptFile string) (*RPCConn, error) {
+func StartRPC(sessionKey, sessionsDir, systemPromptFile, workingDir string) (*RPCConn, error) {
 	sessionPath := sessionsDir + "/" + sessionKey
 	systemPromptArg := "@" + systemPromptFile
 
@@ -73,6 +73,12 @@ func StartRPC(sessionKey, sessionsDir, systemPromptFile string) (*RPCConn, error
 	}
 	// Route stderr to this process's stderr so subprocess logs are visible.
 	cmd.Stderr = os.Stderr
+
+	// Set working directory for the ai subprocess so it uses clawDir
+	// instead of inheriting aiclaw's process CWD.
+	if workingDir != "" {
+		cmd.Dir = workingDir
+	}
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("rpc_client: start subprocess: %w", err)
@@ -389,15 +395,17 @@ type ConnManager struct {
 	mu          sync.RWMutex
 	sessionsDir string
 	sysprompt   string // system prompt content (written to temp file per conn)
+	workingDir  string // working directory for ai subprocess (clawDir)
 }
 
 // NewConnManager creates a new connection manager.
-func NewConnManager(sessionsDir, sysprompt string) *ConnManager {
+func NewConnManager(sessionsDir, sysprompt, workingDir string) *ConnManager {
 	return &ConnManager{
 		conns:       make(map[string]*RPCConn),
 		sessionsDir: sessionsDir,
 		sysprompt:   sysprompt,
-			}
+		workingDir:  workingDir,
+	}
 }
 
 // safeSessionKey replaces characters that are unsafe for filesystem paths.
@@ -520,7 +528,7 @@ func (m *ConnManager) getOrCreateConn(sessionKey string) (*RPCConn, error) {
 	}
 
 	// Launch the subprocess.
-	conn, err = StartRPC(safeKey, m.sessionsDir, promptFile.Name())
+	conn, err = StartRPC(safeKey, m.sessionsDir, promptFile.Name(), m.workingDir)
 	if err != nil {
 		return nil, fmt.Errorf("conn_manager: start rpc for %q: %w", sessionKey, err)
 	}


### PR DESCRIPTION
## Workpad

```text
genius:/Users/genius/.symphony/workspaces/c144f1ff-3155-49ab-9faa-36735c1d39c3@e58febb
```

### Plan

- [ ] 1. Fix skill loader CWD in `main.go` (`CWD: ""` → `CWD: clawDir`)
- [ ] 2. Add `workingDir` to `ConnManager` and `StartRPC` in `rpc_client.go`
- [ ] 3. Pass `clawDir` to `NewConnManager` in `adapter.go`
- [ ] 4. Update integration test calls with empty workingDir
- [ ] 5. Build verification (`cd claw && go build ./...`)
- [ ] 6. Commit, push, create PR
- [ ] 7. Self-review

### Acceptance Criteria

- [ ] `cd claw && go build ./...` passes
- [ ] ai subprocess started by aiclaw has CWD set to ~/.aiclaw
- [ ] Skill paths resolve relative to ~/.aiclaw

### Validation

- [ ] targeted tests: `cd claw && go build ./...`

### Notes

- (none yet)

### Confusions

- (none)