### PR TITLE
feat: implement --system @file parsing in agent spawn

### DIFF
--- a/skills/ag/cmd/root.go
+++ b/skills/ag/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -119,12 +120,22 @@ var agentSpawnCmd = &cobra.Command{
 	Use:   "spawn <id>",
 	Short: "Spawn a new agent",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, args []string) {
 		id := args[0]
 		system, _ := cmd.Flags().GetString("system")
 		input, _ := cmd.Flags().GetString("input")
 		cwd, _ := cmd.Flags().GetString("cwd")
 		backend, _ := cmd.Flags().GetString("backend")
+
+		// Resolve @file prefix for --system flag.
+		if strings.HasPrefix(system, "@") {
+			data, err := os.ReadFile(system[1:])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to read system prompt file: %v\n", err)
+				os.Exit(1)
+			}
+			system = string(data)
+		}
 
 		if err := agent.ValidateID(id); err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/skills/ag/patterns/pair.sh
+++ b/skills/ag/patterns/pair.sh
@@ -18,9 +18,8 @@ JUDGE_PROMPT_FILE="$2"
 INPUT_FILE="$3"
 MAX_ROUNDS="${4:-3}"
 
-# Read prompt file contents up front
-WORKER_PROMPT=$(cat "$WORKER_PROMPT_FILE")
-JUDGE_PROMPT=$(cat "$JUDGE_PROMPT_FILE")
+# --system @file reads the file content directly.
+# Prompt file args are paths prefixed with @.
 
 echo "[pair] Starting worker-judge loop (max $MAX_ROUNDS rounds)"
 echo "[pair] Worker prompt: $WORKER_PROMPT_FILE ($(wc -l < "$WORKER_PROMPT_FILE" | tr -d ' ') lines)"
@@ -42,8 +41,8 @@ for round in $(seq 1 "$MAX_ROUNDS"); do
     CURRENT_INPUT=$(cat "$INPUT_FILE")
   fi
 
-  $AG_BINARY agent spawn "$WORKER_ID" \
-    --system "$WORKER_PROMPT" \
+    $AG_BINARY agent spawn "$WORKER_ID" \
+    --system "@$WORKER_PROMPT_FILE" \
     --input "$CURRENT_INPUT"
 
   # --- Wait for worker ---
@@ -64,8 +63,8 @@ for round in $(seq 1 "$MAX_ROUNDS"); do
 
   # --- Spawn judge ---
   JUDGE_INPUT=$(cat "$WORKER_OUTPUT")
-  $AG_BINARY agent spawn "$JUDGE_ID" \
-    --system "$JUDGE_PROMPT" \
+    $AG_BINARY agent spawn "$JUDGE_ID" \
+    --system "@$JUDGE_PROMPT_FILE" \
     --input "$JUDGE_INPUT"
 
   # --- Wait for judge ---


### PR DESCRIPTION
## 问题

`ag agent spawn --system` 的帮助文本写着 `(inline or @file)`，但代码中根本没有 `@` 前缀的解析逻辑。这是一个文档与实现不一致的 bug。

## 修复

1. **`cmd/root.go`** — 在 `agentSpawnCmd` 的 Run 函数中加了 `@file` 解析：检测到 `@` 前缀后用 `os.ReadFile` 读取文件内容
2. **`patterns/pair.sh`** — 从 `cat` + 变量传递改为直接用 `@`，更简洁且避免 shell 特殊字符问题

## 验证

- 编译通过，全部测试通过
- 手动验证 `--system @/tmp/test-system-prompt.txt` 能正确读取文件内容并 spawn agent