### PR TITLE
feat(aiclaw): make web server port and host configurable

### DIFF
--- a/claw/cmd/aiclaw/main.go
+++ b/claw/cmd/aiclaw/main.go
@@ -61,9 +61,12 @@ type VoiceConfig struct {
 
 // Config 是 aiclaw 的统一配置
 type Config struct {
-	Model    ModelConfig                   `json:"model"`
-	Voice    VoiceConfig                   `json:"voice,omitempty"`
-	Channels picoclawconfig.ChannelsConfig `json:"channels,omitempty"`
+	Model      ModelConfig                   `json:"model"`
+	Voice      VoiceConfig                   `json:"voice,omitempty"`
+	WebPort    int                           `json:"web_port,omitempty"`    // default: 18800
+	WebHost    string                        `json:"web_host,omitempty"`    // default: "127.0.0.1", use "0.0.0.0" for all interfaces
+	WebEnabled *bool                         `json:"web_enabled,omitempty"` // nil or true = enabled, explicit false = disabled
+	Channels   picoclawconfig.ChannelsConfig `json:"channels,omitempty"`
 }
 
 func main() {
@@ -288,12 +291,22 @@ func main() {
 	}
 	defer cronService.Stop()
 
-	// 启动 Web 服务器（可选）
+							// 启动 Web 服务器（可选）
 	var webSrv *web.Server
-	if cfg.Channels.Pico.Enabled {
+	// WebEnabled: nil (not configured) or true → enabled, explicit false → disabled.
+	webDisabled := cfg.WebEnabled != nil && !*cfg.WebEnabled
+	if cfg.Channels.Pico.Enabled && !webDisabled {
+		webPort := cfg.WebPort
+		if webPort == 0 {
+			webPort = 18800
+		}
+		webHost := cfg.WebHost
+		if webHost == "" {
+			webHost = "127.0.0.1"
+		}
 		webCfg := &web.Config{
-			Port:    18800,
-			Public:  false,
+			Port:    webPort,
+			Host:    webHost,
 			Enabled: true,
 		}
 		webSrv = web.NewServer(webCfg, agentLoop, msgBus, configPath, securityPath, clawDir)

--- a/claw/pkg/web/server.go
+++ b/claw/pkg/web/server.go
@@ -86,7 +86,8 @@ type Server struct {
 // Config is the configuration for the web server.
 type Config struct {
 	Port    int    // Port to listen on (default: 18800)
-	Public  bool   // Listen on all interfaces instead of localhost only
+	Host    string // Host to bind (default: "127.0.0.1", use "0.0.0.0" for all interfaces)
+	Public  bool   // Deprecated: use Host instead
 	Enabled bool   // Whether the web server is enabled
 }
 
@@ -94,7 +95,7 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Port:    18800,
-		Public:  false,
+		Host:    "127.0.0.1",
 		Enabled: true,
 	}
 }
@@ -105,13 +106,16 @@ func NewServer(cfg *Config, agentLoop *adapter.AgentLoop, msgBus *bus.MessageBus
 		cfg = DefaultConfig()
 	}
 
-	// Determine listen address
-	var addr string
-	if cfg.Public {
-		addr = fmt.Sprintf("0.0.0.0:%d", cfg.Port)
-	} else {
-		addr = fmt.Sprintf("127.0.0.1:%d", cfg.Port)
+			// Determine listen address: Host takes precedence over deprecated Public flag
+	host := cfg.Host
+	if host == "" {
+		if cfg.Public {
+			host = "0.0.0.0"
+		} else {
+			host = "127.0.0.1"
+		}
 	}
+	addr := fmt.Sprintf("%s:%d", host, cfg.Port)
 
 	return &Server{
 		addr:         addr,
@@ -146,9 +150,10 @@ func (s *Server) Start() (string, error) {
 	go func() {
 		fmt.Printf("\n")
 		fmt.Printf("╔═══════════════════════════════════════════════════════════════╗\n")
-		fmt.Printf("║  🌐 Claw Web Server                                         ║\n")
+				fmt.Printf("║  🌐 Claw Web Server                                         ║\n")
 		fmt.Printf("╠═══════════════════════════════════════════════════════════════╣\n")
-		fmt.Printf("║  Web UI: http://localhost:%d                              ║\n", 18800)
+		displayHost := s.addr
+		fmt.Printf("║  Web UI: http://%-43s║\n", displayHost)
 		fmt.Printf("║                                                           ║\n")
 		fmt.Printf("║  Press Ctrl+C to stop the server                          ║\n")
 		fmt.Printf("╚═══════════════════════════════════════════════════════════════╝\n")
@@ -973,9 +978,13 @@ func formatJSON(v any) string {
 
 // RunAsStandalone runs the web server in standalone mode (for testing).
 func RunAsStandalone(port int, public bool) error {
+	host := ""
+	if public {
+		host = "0.0.0.0"
+	}
 	cfg := &Config{
-		Port:   port,
-		Public: public,
+		Port:    port,
+		Host:    host,
 		Enabled: true,
 	}
 


### PR DESCRIPTION
## 问题

aiclaw 的 web server 端口硬编码为 18800，host 硬编码为 127.0.0.1（localhost），无法配置。

## 修复

在 `~/.aiclaw/config.json` 中新增 `web` 配置项：

```json
{
  "web": {
    "port": 18800,
    "host": "0.0.0.0",
    "enabled": true
  }
}
```

### 改动

1. **`claw/cmd/aiclaw/main.go`** — 新增 `WebConfig` 结构体（Port, Host, Enabled），加入 Config
2. **`claw/pkg/web/server.go`** — `web.Config` 新增 `Host` 字段，替代废弃的 `Public` bool；`NewServer` 中 Host 优先于 Public
3. 零值 WebConfig 默认启用（向后兼容——不配 web 字段时行为不变）

### 默认值

| 字段 | 默认值 | 说明 |
|------|--------|------|
| port | 18800 | |
| host | 127.0.0.1 | 设为 `0.0.0.0` 监听所有接口 |
| enabled | true | 零值视为 true（不配即启用） |