### PR TITLE
feat: skill progressive disclosure with usage stats and find_skill tool

### DIFF
--- a/claw/cmd/aiclaw/main.go
+++ b/claw/cmd/aiclaw/main.go
@@ -79,7 +79,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	clawDir := filepath.Join(homeDir, ".aiclaw")
+		clawDir := filepath.Join(homeDir, ".ai")
 
 	lockFile, err := acquireInstanceLock(clawDir)
 	if err != nil {
@@ -231,14 +231,17 @@ func main() {
 			}
 		}
 	}
-	if len(skillResult.Skills) > 0 {
+		if len(skillResult.Skills) > 0 {
 		slog.Info("Loaded skills", "count", len(skillResult.Skills))
 	}
+
+	// Load skill usage stats for progressive disclosure
+	skillStats := skill.LoadStats(filepath.Join(clawDir, "skill-stats.json"))
 
 		slog.Info("Feishu config", "app_id", picoCfg.Channels.Feishu.AppID, "has_app_secret", picoCfg.Channels.Feishu.AppSecret() != "")
 
 	agentConfig := &adapter.AppConfig{
-		SystemPrompt:    buildSystemPrompt(clawDir, skillResult.Skills),
+				SystemPrompt:    buildSystemPrompt(clawDir, skillResult.Skills, skillStats),
 		ClawDir:         clawDir,
 		Transcriber:     transcriber,
 		FeishuAppID:     picoCfg.Channels.Feishu.AppID,
@@ -626,7 +629,7 @@ func resolveAPIKey(clawDir, provider string) (string, error) {
 // buildSystemPrompt 构建 system prompt (picoclaw style)
 // 支持从 ~/.aiclaw/AGENTS.md 加载自定义身份
 // 集成 memory 系统 (MEMORY.md + daily notes)
-func buildSystemPrompt(clawDir string, skills []skill.Skill) string {
+func buildSystemPrompt(clawDir string, skills []skill.Skill, skillStats *skill.SkillStatsFile) string {
 	// Picoclaw 风格的默认身份
 	defaultIdentity := fmt.Sprintf(`# Claw 🦀
 
@@ -651,43 +654,31 @@ You are claw, a helpful AI assistant.
 - Skills: %s/skills/{skill-name}/SKILL.md
 `, clawDir, clawDir)
 
-	// 尝试从 ~/.aiclaw/AGENTS.md 加载自定义身份
+		// Try to load custom identity from AGENTS.md (prefer ~/.ai, fall back to ~/.aiclaw)
 	basePrompt := defaultIdentity
 	agentsPath := filepath.Join(clawDir, "AGENTS.md")
 	if content, err := os.ReadFile(agentsPath); err == nil && len(content) > 0 {
 		basePrompt = string(content)
 		slog.Info("Loaded custom identity from AGENTS.md", "path", agentsPath)
+	} else {
+		// Fallback to legacy ~/.aiclaw/AGENTS.md
+		homeDir2, _ := os.UserHomeDir()
+		legacyPath := filepath.Join(homeDir2, ".aiclaw", "AGENTS.md")
+		if content2, err2 := os.ReadFile(legacyPath); err2 == nil && len(content2) > 0 {
+			basePrompt = string(content2)
+			slog.Info("Loaded custom identity from legacy AGENTS.md", "path", legacyPath)
+		}
 	}
 
 	// 构建提示词部分
 	parts := []string{basePrompt}
 
-	// 添加技能列表
-	if len(skills) > 0 {
-		skillsSummary := buildSkillsSummary(skills)
-		if skillsSummary != "" {
-			parts = append(parts, fmt.Sprintf(`# Skills
-
-The following skills extend your capabilities.
-
-%s`, skillsSummary))
-		}
+		// Add skills section using shared formatter (top-N filtering + find_skill footer)
+	if skillsText := skill.FormatForPrompt(skills, skillStats); skillsText != "" {
+		parts = append(parts, skillsText)
 	}
 
 	return strings.Join(parts, "\n\n---\n\n")
-}
-
-// buildSkillsSummary 构建技能摘要
-func buildSkillsSummary(skills []skill.Skill) string {
-	if len(skills) == 0 {
-		return ""
-	}
-
-	var lines []string
-	for _, s := range skills {
-		lines = append(lines, fmt.Sprintf("- **%s**: %s", s.Name, s.Description))
-	}
-	return strings.Join(lines, "\n")
 }
 
 // registerCronCommands registers cron control commands.

--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -243,8 +243,12 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 
 	slog.Info("Loaded  skills", "count", len(skillResult.Skills))
 	for _, s := range skillResult.Skills {
-		slog.Info("Skill", "name", s.Name, "description", s.Description)
+				slog.Info("Skill", "name", s.Name, "description", s.Description)
 	}
+
+	// Load skill usage stats and register find_skill tool
+	skillStats := skill.LoadStats(filepath.Join(agentDir, "skill-stats.json"))
+	registry.Register(tools.NewFindSkillTool(skillResult.Skills, skillStats))
 
 	// Build the full system prompt (used for agent and compactor)
 	buildSystemPrompt := func(currentSess *session.Session) string {
@@ -255,7 +259,7 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 		}
 		// Use workspace to get dynamic cwd for each prompt build
 		promptBuilder := prompt.NewBuilderWithWorkspace("", ws)
-		promptBuilder.SetTools(registry.All()).SetSkills(skillResult.Skills)
+				promptBuilder.SetTools(registry.All()).SetSkills(skillResult.Skills).SetSkillStats(skillStats)
 
 		// Set llm context for system prompt explanation (tells LLM about the mechanism)
 		// The actual content is injected dynamically in the agent loop.
@@ -489,9 +493,17 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	busyMode := "steer"
 	ag.SetThinkingLevel(currentThinkingLevel)
 
-	// Helper function to expand /skill:name commands
+		// Helper function to expand /skill:name commands and record usage
 	expandSkillCommands := func(text string) string {
-		return skill.ExpandCommand(text, skillResult.Skills)
+		expanded := skill.ExpandCommand(text, skillResult.Skills)
+		if skill.IsSkillCommand(text) {
+			skillName := skill.ExtractSkillName(text)
+			skillStats.RecordUsage(skillName)
+			if err := skillStats.Save(); err != nil {
+				slog.Error("Failed to save skill stats", "skill", skillName, "error", err)
+			}
+		}
+		return expanded
 	}
 
 	// Trigger automatic compaction right before a new request is executed

--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -270,8 +271,26 @@ func serveSubcommand(binPath string) {
 		}
 	}
 
-	// Print run ID to stdout — caller can capture this.
+		// Print run ID to stdout — caller can capture this.
 	fmt.Println(id)
+
+	// Watch events.jsonl for agent_end — when the agent finishes, close stdin
+	// to trigger the RPC subprocess to exit. Without this, "ai serve" blocks
+	// forever because the RPC server loops on stdin.
+	go func() {
+		for {
+			data, err := os.ReadFile(eventsPath)
+			if err != nil {
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+			if bytes.Contains(data, []byte(`"agent_end"`)) {
+				stdinWriter.Close()
+				return
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}()
 
 	// Wait for subprocess to exit.
 	waitErr := cmd.Wait()

--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -274,9 +274,11 @@ func serveSubcommand(binPath string) {
 		// Print run ID to stdout — caller can capture this.
 	fmt.Println(id)
 
-	// Watch events.jsonl for agent_end — when the agent finishes, close stdin
+		// Watch events.jsonl for agent_end — when the agent finishes, close stdin
 	// to trigger the RPC subprocess to exit. Without this, "ai serve" blocks
 	// forever because the RPC server loops on stdin.
+	// We parse JSONL lines and check the "type" field instead of raw substring
+	// search to avoid false positives from assistant output containing "agent_end".
 	go func() {
 		for {
 			data, err := os.ReadFile(eventsPath)
@@ -284,7 +286,7 @@ func serveSubcommand(binPath string) {
 				time.Sleep(500 * time.Millisecond)
 				continue
 			}
-			if bytes.Contains(data, []byte(`"agent_end"`)) {
+			if hasAgentEndEvent(data) {
 				stdinWriter.Close()
 				return
 			}
@@ -315,6 +317,25 @@ func serveSubcommand(binPath string) {
 }
 
 // buildRPCFlags constructs the flag arguments to forward to 'ai rpc'.
+// hasAgentEndEvent parses JSONL data and checks if any line has type "agent_end".
+// This avoids false positives from raw substring matching (e.g. assistant output
+// containing the text "agent_end").
+func hasAgentEndEvent(data []byte) bool {
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var evt struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(line, &evt) == nil && evt.Type == "agent_end" {
+			return true
+		}
+	}
+	return false
+}
+
 func buildRPCFlags(session, systemPrompt string, maxTurns int, timeout time.Duration, http string) []string {
 	var flags []string
 	if session != "" {

--- a/docs/design-skill-progressive-disclosure.md
+++ b/docs/design-skill-progressive-disclosure.md
@@ -1,0 +1,380 @@
+# Design: Skill Unification & Progressive Disclosure
+
+## Goals
+
+- Unify skill directories: merge `~/.aiclaw/skills/` into `~/.ai/skills/`, single source of truth
+- Progressive disclosure: only top-N high-frequency skills in system prompt, rest discoverable via `find_skill` tool
+- Usage tracking with time decay to auto-rank skills by relevance
+- LLM-generated search index for semantic skill discovery (aliases, use-when, categories)
+
+## Non-Goals
+
+- Changing the SKILL.md format or frontmatter schema
+- Building a skill marketplace / remote registry (that's ClawHub's job)
+- Changing how `/skill:name` expansion works (keep as-is)
+- Real-time RAG with embedding vectors (overkill for ~56 skills)
+
+---
+
+## 1. 现状
+
+### ai (coding agent)
+
+- Skill loading: `cmd/ai/rpc_handlers.go` L224 — `skill.NewLoader(agentDir)` with `LoadOptions{CWD, AgentDir: "~/.ai"}`
+- Loads from `~/.ai/skills/` (user) + `.ai/skills/` (project)
+- 21 skills in `~/.ai/skills/`
+- `FormatForPrompt()` in `pkg/skill/formatter.go` renders ALL skills into system prompt (up to 24, description capped at 220 runes)
+- Current system prompt `pkg/prompt/prompt.md` has `%SKILLS%` placeholder that gets replaced
+- Tool registry in `pkg/tools/registry.go`, interface `Tool` in `pkg/context/context.go` L60: `Name()`, `Description()`, `Parameters()`, `Execute()`
+- `/skill:name` expansion in `pkg/skill/expander.go` — looks up skill by name, injects full content inline
+
+### aiclaw (general agent)
+
+- `~/.aiclaw/skills/` → symlink to `claw/skills/` (35 skills)
+- `claw/cmd/aiclaw/main.go` L223 — same `skill.NewLoader(clawDir)`, reads `~/.aiclaw/skills/`
+- `buildSkillsSummary()` in main.go — simpler format, just `- **name**: description` per skill
+- Has `find-skills` skill (ClawHub marketplace search, not local discovery)
+
+### Token cost of current approach
+
+- 21 skill summaries in system prompt: ~4000 chars of name+description text
+- Plus the `## Skills` header block (~300 chars)
+- With 56 skills merged, that'd be ~12000 chars (~3000 tokens) just for skill listings
+
+---
+
+## 2. 为什么要改
+
+**Token waste**: Most skills are irrelevant for any given task. Loading 56 skill descriptions into every prompt burns ~3000 tokens per turn. A coding session uses `implement`, `plan`, `ag` repeatedly but never touches `weather` or `discord`.
+
+**Two divergent systems**: ai and aiclaw share `pkg/skill/` code but maintain separate directories. Adding a skill requires deciding which tree it belongs to, or duplicating it.
+
+**No adaptivity**: Skills are listed alphabetically/by-load-order. A skill you use daily has the same prominence as one you've never touched.
+
+---
+
+## 3. 关键设计决策
+
+### Decision 1: `find_skill` as a built-in tool vs meta-skill
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Built-in tool** (chosen) | Zero extra reads; LLM sees it in tool schema; deterministic behavior | Go code change; tool schema in every prompt (small) |
+| Meta-skill markdown | No code change | Agent must read the skill first; depends on LLM correctly running grep/read flow |
+
+**Choice**: Built-in tool. Skill discovery is a core capability, not an optional behavior. Tool schema is ~200 tokens, much cheaper than 56 skill descriptions.
+
+### Decision 2: Frequency storage format
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Single JSON file** (chosen) | Simple; fast startup; one file read | Write contention if multiple agents run simultaneously |
+| Per-skill dot files | No contention | 56+ file reads at startup; filesystem noise |
+| Embedded in config | No extra file | Mixes concerns; config becomes mutable state |
+
+**Choice**: Single JSON file `~/.ai/skill-stats.json`. Write contention is acceptable — two agents rarely update the exact same skill at the exact same millisecond, and a lost update just means one +1 is missed.
+
+### Decision 3: How many skills in system prompt
+
+Top **7** skills by decay score. This covers the typical "always needed" set (e.g., `ag`, `implement`, `plan`, `bash` usage patterns) while keeping the skill section under ~500 tokens. The number is configurable via the stats file if needed later.
+
+### Decision 4: Skill search — keyword index vs substring match vs LLM-generated index
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Substring match on name+description only | Zero maintenance | Can't bridge synonyms, Chinese↔English, use-case intent |
+| Manual keywords in frontmatter | Precise | Every new skill needs keyword curation, never complete |
+| **LLM-generated index file** (chosen) | Zero manual maintenance; handles synonyms, i18n, intent; one-time LLM call per reindex | Requires LLM call to (re)generate; index can drift if skills change |
+
+**Choice**: LLM-generated `~/.ai/skill-index.json`. A dedicated skill (`index-skills`) reads all SKILL.md files, calls the LLM once to produce a rich search index, and writes it to disk. `find_skill` searches this index — no LLM call at query time, millisecond response.
+
+The index is regenerated when:
+- Skill directory contents change (detected via file count + mtime hash)
+- User triggers `/skills reindex`
+
+### Decision 5: Who generates the index — built-in logic vs skill
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Built-in Go code in stats/indexer | Tight integration, no skill dependency | Hardcodes the LLM prompt, less flexible |
+| **Dedicated skill** (`~/.ai/skills/index-skills/SKILL.md`) (chosen) | Prompt is just markdown, easy to iterate; skill can be improved without recompiling; follows the "skills extend capabilities" philosophy | One extra skill in the directory |
+
+**Choice**: A skill. The index-generation prompt is itself a skill — easy to refine, version, and improve without touching Go code. The agent runs this skill (via `/skill:index-skills` or triggered by startup logic) to produce/update `skill-index.json`.
+
+---
+
+## 4. 怎么做
+
+### 4.1 New file: `pkg/skill/stats.go` — Usage tracking
+
+```go
+package skill
+
+// SkillStat tracks usage frequency for a single skill.
+type SkillStat struct {
+    Count    int       `json:"count"`
+    LastUsed time.Time `json:"last_used"`
+}
+
+// SkillStatsFile is the on-disk format.
+// Path: ~/.ai/skill-stats.json
+type SkillStatsFile struct {
+    // TopN: how many skills to show in system prompt (default 7)
+    TopN int                  `json:"top_n,omitempty"`
+    Stats map[string]SkillStat `json:"stats"`
+}
+
+// LoadStats reads from ~/.ai/skill-stats.json.
+// Returns empty stats with defaults if file doesn't exist.
+func LoadStats(path string) (*SkillStatsFile, error)
+
+// RecordUsage increments count and updates last_used for a skill.
+// Writes to disk immediately.
+func (s *SkillStatsFile) RecordUsage(skillName string) error
+
+// TopSkills returns the top N skill names by decay score.
+// Score = count * exp(-0.1 * days_since_last_use)
+// 7-day half-life: skills not used in ~7 days drop significantly.
+func (s *SkillStatsFile) TopSkills(n int) []string
+```
+
+**Decay formula**: `score = count * e^(-0.1 * days_since_last_use)`
+- Used today (0 days): score = count × 1.0
+- Used 7 days ago: score = count × 0.5
+- Used 30 days ago: score = count × 0.05
+- A skill used 10 times 30 days ago (score 0.5) loses to a skill used once today (score 1.0)
+
+### 4.2 New file: `~/.ai/skill-index.json` — LLM-generated search index
+
+Generated by the `index-skills` skill. Consumed by `find_skill` tool at query time.
+
+```json
+{
+  "version": 1,
+  "generated_at": "2025-05-09T18:00:00Z",
+  "skills": {
+    "systematic-debugging": {
+      "aliases": ["debug", "排错", "调试", "troubleshoot", "bug", "报错"],
+      "use_when": "遇到 bug、测试失败、意外行为、崩溃、错误输出、需要排查问题",
+      "category": "debugging"
+    },
+    "ag": {
+      "aliases": ["subagent", "子代理", "并行", "spawn agent", "多步骤", "orchestrate"],
+      "use_when": "复杂多步骤工作、worker-judge 循环、需要独立审查、任务编排",
+      "category": "orchestration"
+    },
+    "pdf": {
+      "aliases": ["PDF", "pdf", "文档处理", "merge pdf", "split pdf"],
+      "use_when": "读取 PDF、合并拆分、旋转页面、提取文字或表格",
+      "category": "file-processing"
+    }
+  }
+}
+```
+
+Each skill entry has:
+- `aliases`: synonyms and translations (mixed Chinese/English) for name matching
+- `use_when`: natural language description of when to use this skill — used for substring matching
+- `category`: grouping for browsing (e.g., "debugging", "orchestration", "file-processing")
+
+### 4.3 New skill: `~/.ai/skills/index-skills/SKILL.md`
+
+A standard skill that instructs the agent to regenerate `skill-index.json`:
+
+```markdown
+---
+name: index-skills
+description: Regenerate the skill search index. Run this when skills are added/removed/updated.
+---
+
+# Index Skills
+
+Read all SKILL.md files from ~/.ai/skills/, then generate ~/.ai/skill-index.json.
+
+## Steps
+
+1. List all skill directories: `ls ~/.ai/skills/`
+2. For each skill, read the SKILL.md frontmatter (name + description)
+3. Based on name and description, generate for each skill:
+   - `aliases`: 5-10 synonyms including Chinese translations
+   - `use_when`: One sentence describing when to use this skill (Chinese)
+   - `category`: A category tag
+4. Write the result to ~/.ai/skill-index.json
+5. Log how many skills were indexed
+```
+
+### 4.4 New file: `pkg/tools/find_skill.go` — Discovery tool
+
+```go
+package tools
+
+type FindSkillTool struct {
+    skills    []skill.Skill
+    stats     *skill.SkillStatsFile
+}
+
+func NewFindSkillTool(skills []skill.Skill, stats *skill.SkillStatsFile) *FindSkillTool
+
+// Name() → "find_skill"
+// Description() → "Search and load skills by keyword or name.
+//   Use 'query' to search skill names and descriptions (fuzzy match).
+//   Use 'name' with 'load=true' to read the full skill content.
+//   Always search first, then load the matching skill before acting."
+//
+// Parameters():
+//   {
+//     "name":  { type: "string", description: "Exact skill name to load" },
+//     "query": { type: "string", description: "Search keyword for skill name/description" },
+//     "load":  { type: "boolean", description: "Set true to return full skill content (requires 'name')" }
+//   }
+
+// Execute logic:
+//   - If query is set: load skill-index.json, search across:
+//     1. skill name (substring)
+//     2. skill description (substring, from loaded skills list)
+//     3. index aliases (substring match)
+//     4. index use_when (substring match)
+//     5. index category (exact or substring)
+//     Return top 10 matches, deduplicated by skill name.
+//   - If name is set and load=true: read SKILL.md, call stats.RecordUsage(name), return full content
+//   - If name is set and load=false: return just name + description + path for that skill
+//
+// If skill-index.json doesn't exist, fall back to name+description substring only
+// and suggest running /skill:index-skills to generate the index.
+```
+
+**Search return format** (query mode):
+```
+Found 3 skills matching "debug":
+
+1. **systematic-debugging**: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+   Path: /Users/genius/.ai/skills/systematic-debugging/SKILL.md
+
+2. **learn-codebase**: Discover project conventions and surface security concerns
+   Path: /Users/genius/.ai/skills/learn-codebase/SKILL.md
+
+Use find_skill with name=<skill_name> and load=true to read the full skill.
+```
+
+**Load return format** (load mode):
+Returns the full SKILL.md content (body only, frontmatter stripped), same as what `ExpandCommand` produces.
+
+### 4.5 Changes to `pkg/skill/formatter.go` — Use stats for top-N
+
+```go
+// FormatForPrompt now takes stats to determine which skills to show.
+func FormatForPrompt(skills []Skill, stats *SkillStatsFile) string
+```
+
+Logic:
+1. If stats is nil or empty, fall back to current behavior (all skills, up to 24)
+2. Get `stats.TopSkills(stats.TopN)` — returns top N skill names
+3. Only render those skills in the prompt
+4. Add a footer: `*Use the find_skill tool to discover more skills by keyword.*`
+5. Remove the `maxPromptSkills` cap (now controlled by TopN from stats)
+
+### 4.6 Changes to `cmd/ai/rpc_handlers.go`
+
+In the initialization block (L209-L258):
+
+```
+1. Load skills (unchanged)
+2. Load stats: skill.LoadStats("~/.ai/skill-stats.json")
+3. Register find_skill tool: registry.Register(tools.NewFindSkillTool(skills, stats))
+4. Pass stats to prompt builder: promptBuilder.SetSkills(skillResult.Skills).SetSkillStats(stats)
+```
+
+In `/skill:name` expansion handler:
+```
+After ExpandCommand(), call stats.RecordUsage(skillName)
+```
+
+### 4.7 Changes to `pkg/prompt/builder.go`
+
+Add `skillStats *skill.SkillStatsFile` field to `Builder`.
+Pass it through to `FormatForPrompt(skills, skillStats)`.
+
+### 4.8 Changes to `claw/cmd/aiclaw/main.go`
+
+- Change `clawDir` from `~/.aiclaw` to `~/.ai`
+- `~/.aiclaw/skills/` symlink can be removed after migration
+- Same stats loading, same `find_skill` tool registration
+- `buildSkillsSummary()` replaced by `FormatForPrompt(skills, stats)`
+
+### 4.9 Migration
+
+```bash
+# Move aiclaw skills into ~/.ai/skills/
+cp -r claw/skills/* ~/.ai/skills/
+rm ~/.aiclaw/skills  # remove symlink
+# Optionally recreate symlink for backward compat:
+# ln -s ~/.ai/skills ~/.aiclaw/skills
+```
+
+---
+
+## 5. 边界条件
+
+### Cold start (no stats file)
+- `LoadStats` returns empty `SkillStatsFile` with `TopN=7`
+- `TopSkills(7)` returns empty list
+- `FormatForPrompt` falls back to showing ALL skills (current behavior), capped at 7
+- After a few sessions, stats accumulate and auto-ranking kicks in
+
+### Skill name collision after merge
+- Both trees have a `github` skill and a `tmux` skill
+- Loader already handles collisions: first-loaded wins, diagnostic logged
+- After merge, both are in same directory → collision at directory level → needs manual resolution
+- **Action**: Audit collisions before merge, pick the better version
+
+### Concurrent access to skill-stats.json
+- Two agent processes writing simultaneously → possible data loss (last-write-wins on the overwritten field)
+- **Mitigation**: Use `os.OpenFile` with `O_WRONLY|O_CREATE|O_TRUNC` and keep writes small
+- **Acceptable risk**: Losing a single +1 is inconsequential for ranking
+
+### find_skill with no results
+- Return helpful message: `"No skills found matching 'xyz'. Use find_skill with a different keyword."`
+- Don't hallucinate skills
+
+### Skills removed from disk but still in stats
+- `TopSkills` returns a name → lookup in loaded skills → not found → skip
+- No crash, just a missing entry. Stats entry becomes inert.
+
+### Backward compatibility with /skill:name
+- `/skill:name` expansion continues to work for ALL skills (not just top-N)
+- It goes through `ExpandCommand` which searches the full skill list
+- Stats recording on `/skill:name` is purely additive, doesn't change behavior
+
+---
+
+## Files to create
+
+| File | Purpose |
+|------|---------|
+| `pkg/skill/stats.go` | Usage tracking with time decay |
+| `pkg/skill/stats_test.go` | Unit tests for stats |
+| `pkg/tools/find_skill.go` | Discovery tool implementation |
+| `pkg/tools/find_skill_test.go` | Tool tests |
+| `~/.ai/skills/index-skills/SKILL.md` | Skill that generates skill-index.json via LLM |
+
+## Runtime artifacts (not in repo)
+
+| File | Purpose |
+|------|---------|
+| `~/.ai/skill-stats.json` | Usage frequency data |
+| `~/.ai/skill-index.json` | LLM-generated search index |
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `pkg/skill/formatter.go` | Accept stats param, use TopSkills for filtering |
+| `pkg/prompt/builder.go` | Add skillStats field, pass to FormatForPrompt |
+| `cmd/ai/rpc_handlers.go` | Load stats, register find_skill tool, record usage on /skill:name |
+| `claw/cmd/aiclaw/main.go` | Change agentDir to ~/.ai, use shared stats/tool logic |
+
+## Migration (manual)
+
+- Copy `claw/skills/*` → `~/.ai/skills/`
+- Remove `~/.aiclaw/skills` symlink
+- Resolve name collisions (github, tmux, skill-creator)

--- a/docs/tasks.yml
+++ b/docs/tasks.yml
@@ -1,0 +1,444 @@
+version: "1"
+metadata:
+  spec_file: "docs/design-skill-progressive-disclosure.md"
+  created_at: "2025-07-11"
+
+tasks:
+  - id: T001
+    title: "Create skill usage stats with time-decay tracking"
+    estimated_hours: 2
+    description: |
+      ## Goal
+      Implement a usage tracking system that records how often each skill is invoked and ranks skills by a time-decayed score, persisted to a single JSON file.
+
+      ## Key changes
+      - Create `pkg/skill/stats.go` with:
+        - `SkillUsageEntry` struct: `Name string`, `Count int`, `LastUsed time.Time`, `Score float64`
+        - `SkillStatsFile` struct: `Version int`, `TopN int` (default 7), `Entries map[string]*SkillUsageEntry`, `FilePath string`
+        - `LoadStats(path string) *SkillStatsFile` — reads JSON from disk; if file missing/invalid, returns empty struct with `TopN=7`
+        - `(s *SkillStatsFile) RecordUsage(skillName string)` — increments count, updates LastUsed, recomputes Score using half-life decay: `Score = Count * 0.5^(hours_since_last_use / 168)` (168 hours = 1 week half-life)
+        - `(s *SkillStatsFile) Save() error` — writes JSON to `s.FilePath` with `os.OpenFile` using `O_WRONLY|O_CREATE|O_TRUNC`
+        - `(s *SkillStatsFile) TopSkills(n int) []string` — returns skill names sorted by descending Score, up to `n` entries
+      - Create `pkg/skill/stats_test.go` with unit tests for:
+        - Loading from nonexistent file returns empty stats with TopN=7
+        - RecordUsage creates new entry and increments Count
+        - Repeated RecordUsage increases Score correctly
+        - Time decay: an entry used long ago has lower Score than a recently-used entry with same Count
+        - TopSkills returns correct ordering and respects limit
+        - Save + Load roundtrip preserves data
+
+      ## Files
+      - CREATE: pkg/skill/stats.go
+      - CREATE: pkg/skill/stats_test.go
+
+      ## Design decision
+      Single JSON file chosen over per-skill dot files to avoid 56+ file reads at startup. Write contention is acceptable — concurrent agents rarely update the same skill at the same instant, and a lost +1 is inconsequential for ranking. Half-life of 1 week (168 hours) balances recency vs. long-term usage.
+
+      ## Edge cases
+      - Missing/empty stats file → return empty SkillStatsFile with TopN=7, no error
+      - Malformed JSON in stats file → same as missing file, log a warning
+      - Stats file contains skill names that no longer exist on disk → TopSkills returns them, caller is responsible for filtering against loaded skills
+      - TopSkills(0) → returns empty slice
+
+      ## Done when
+      - [ ] `go build ./pkg/skill/...` passes
+      - [ ] `go test ./pkg/skill/... -run TestStats` passes with all above cases
+      - [ ] `go vet ./pkg/skill/...` passes
+    group: stats-tracking
+    dependencies: []
+
+  - id: T002
+    title: "Create find_skill discovery tool"
+    estimated_hours: 1
+    description: |
+      ## Goal
+      Implement a `find_skill` built-in tool that lets the LLM discover skills by keyword search and optionally load full skill content.
+
+      ## Key changes
+      - Create `pkg/tools/find_skill.go` implementing the `agentctx.Tool` interface (from `pkg/context/context.go`):
+        - `FindSkillTool` struct holds: `skills []skill.Skill`, `stats *skill.SkillStatsFile`
+        - `NewFindSkillTool(skills []skill.Skill, stats *skill.SkillStatsFile) *FindSkillTool`
+        - `Name() string` → `"find_skill"`
+        - `Description() string` → tool description explaining keyword search and load capability
+        - `Parameters() map[string]any` → JSON schema with:
+          - `query` (string, required): keyword to search — matches against skill name (case-insensitive substring), description, and fields from the search index if available
+          - `load` (boolean, optional, default false): if true, returns full skill content instead of just the listing
+          - `name` (string, optional): exact skill name to load (used with load=true for direct loading)
+        - `Execute(ctx context.Context, args map[string]any) ([]agentctx.ContentBlock, error)`:
+          - **Search mode** (load=false or absent): search all loaded skills for `query` substring match on Name and Description (case-insensitive). Return formatted text listing up to 5 matches with name, description (capped at 150 runes), and file path. Footer: "Use find_skill with name=<skill_name> and load=true to read the full skill." If no matches: return "No skills found matching '<query>'. Try a different keyword."
+          - **Load mode** (load=true): look up skill by `name` parameter (exact match). If found, return full skill content (body only, frontmatter stripped — use `skill.Content` field which already has this). If not found: return error "Skill '<name>' not found."
+          - After successful load or search, call `stats.RecordUsage(skillName)` and `stats.Save()` for each matched/loaded skill (fire-and-forget, log errors but don't fail the tool call)
+
+      - Create `pkg/tools/find_skill_test.go` with tests for:
+        - Search mode returns matching skills
+        - Search with no matches returns helpful message
+        - Load mode returns full content for exact name match
+        - Load mode with nonexistent name returns error
+        - Case-insensitive search
+        - RecordUsage is called on the stats object
+
+      ## Files
+      - CREATE: pkg/tools/find_skill.go
+      - CREATE: pkg/tools/find_skill_test.go
+
+      ## Design decision
+      Built-in tool (not a meta-skill) because skill discovery is a core capability. The tool schema is ~200 tokens — much cheaper than listing all 56 skills. Substring matching on name+description is sufficient for v1; the LLM-generated search index (from a separate `index-skills` skill) can be integrated later by having the tool also check `~/.ai/skill-index.json` if it exists.
+
+      ## Edge cases
+      - No query provided → return error asking for query parameter
+      - Both query and name provided in search mode → use query for search, ignore name
+      - Stats is nil → skip RecordUsage calls, tool still works for search/load
+      - Skills list is empty → search always returns "no matches"
+
+      ## Done when
+      - [ ] `go build ./pkg/tools/...` passes
+      - [ ] `go test ./pkg/tools/... -run TestFindSkill` passes
+      - [ ] Tool implements all 4 methods of the `agentctx.Tool` interface
+      - [ ] `go vet ./pkg/tools/...` passes
+    group: discovery-tool
+    dependencies: [T001]
+
+  - id: T003
+    title: "Update FormatForPrompt to use stats-based top-N filtering"
+    estimated_hours: 2
+    description: |
+      ## Goal
+      Modify the skill prompt formatter to show only the top-N highest-ranked skills based on usage stats, with a footer directing the LLM to `find_skill` for more.
+
+      ## Key changes
+      - Modify `pkg/skill/formatter.go`:
+        - Change `FormatForPrompt` signature to accept an optional stats parameter: `FormatForPrompt(skills []Skill, stats *SkillStatsFile) string`
+        - Logic:
+          1. Filter out skills with `DisableModelInvocation=true` (existing behavior)
+          2. If stats is nil or has no entries (cold start): fall back to current behavior — show all skills, capped at 7 (use the value of `stats.TopN` if stats is non-nil, otherwise 7)
+          3. If stats has entries: call `stats.TopSkills(stats.TopN)` to get ranked names. For each name, find the matching skill in the loaded skills list (skip names not found — handles stale stats for deleted skills). Render those skills.
+          4. If fewer skills found than TopN (e.g., only 3 have stats), supplement with remaining unranked skills to fill up to TopN.
+          5. Add footer: `*Use the find_skill tool to discover more skills by keyword.*`
+          6. Remove the old `maxPromptSkills = 24` cap — now controlled by TopN from stats
+        - Keep `maxSkillDescriptionRunes = 220` cap on individual descriptions
+      - Update `pkg/skill/formatter_prompt_test.go` to pass `nil` as second argument to `FormatForPrompt` in existing tests (backward compat), and add new test cases:
+        - With stats containing ranked skills → only those skills appear
+        - With stats containing a skill name not in the loaded list → that skill is skipped
+        - Footer message is present when stats is non-nil
+        - Cold start (empty stats) shows all skills capped at 7
+
+      ## Files
+      - MODIFY: pkg/skill/formatter.go
+      - MODIFY: pkg/skill/formatter_prompt_test.go
+
+      ## Design decision
+      The TopN default of 7 covers the "always needed" skill set while keeping the skill section under ~500 tokens. Cold start shows all skills (backward compatible), and after a few sessions stats accumulate and auto-ranking kicks in.
+
+      ## Edge cases
+      - All skills in stats are stale (none found in loaded list) → falls back to showing all loaded skills, capped at TopN
+      - Fewer skills loaded than TopN → show all of them
+      - Stats is nil → exact current behavior (backward compat)
+
+      ## Done when
+      - [ ] `go build ./pkg/skill/...` passes
+      - [ ] `go test ./pkg/skill/...` passes
+      - [ ] Existing tests pass with nil stats parameter (backward compat)
+      - [ ] New tests verify top-N filtering behavior
+    group: prompt-filtering
+    dependencies: [T001]
+
+  - id: T004
+    title: "Wire stats and find_skill into prompt builder"
+    estimated_hours: 1
+    description: |
+      ## Goal
+      Add `skillStats` field to the prompt builder and pass it through to `FormatForPrompt` so the system prompt only includes top-N skills.
+
+      ## Key changes
+      - Modify `pkg/prompt/builder.go`:
+        - Add field `skillStats *skill.SkillStatsFile` to the `Builder` struct
+        - Add method `SetSkillStats(stats *skill.SkillStatsFile) *Builder`
+        - In the `Build()` method, change the call from `skill.FormatForPrompt(b.skills)` to `skill.FormatForPrompt(b.skills, b.skillStats)`
+      - Update `pkg/prompt/builder_test.go`:
+        - Existing calls to `SetSkills()` should still work (no stats → nil → backward compat)
+        - Add a test case with stats set → verify only top-N skills appear in built prompt
+
+      ## Files
+      - MODIFY: pkg/prompt/builder.go
+      - MODIFY: pkg/prompt/builder_test.go
+
+      ## Edge cases
+      - SetSkillStats not called → skillStats is nil → FormatForPrompt uses fallback (backward compat)
+      - Stats set but empty → same as nil fallback
+
+      ## Done when
+      - [ ] `go build ./pkg/prompt/...` passes
+      - [ ] `go test ./pkg/prompt/...` passes
+      - [ ] Existing builder tests pass unchanged
+      - [ ] New test verifies stats-based filtering in built prompt
+    group: prompt-filtering
+    dependencies: [T003]
+
+  - id: T005
+    title: "Integrate stats loading and find_skill into ai agent (rpc_handlers)"
+    estimated_hours: 2
+    description: |
+      ## Goal
+      Wire up stats loading, find_skill tool registration, and usage recording into the `cmd/ai` agent startup and skill expansion flow.
+
+      ## Key changes
+      - Modify `cmd/ai/rpc_handlers.go`:
+        - In the initialization block (~line 237, after `skillLoader.Load()`):
+          1. Load stats: `skillStats := skill.LoadStats(filepath.Join(agentDir, "skill-stats.json"))`
+          2. Register find_skill tool: `registry.Register(tools.NewFindSkillTool(skillResult.Skills, skillStats))`
+        - In the `buildSystemPrompt` closure (~line 257):
+          3. Change `promptBuilder.SetSkills(skillResult.Skills)` to also add `.SetSkillStats(skillStats)`: `promptBuilder.SetTools(registry.All()).SetSkills(skillResult.Skills).SetSkillStats(skillStats)`
+        - In the `/skill:name` expansion handler (search for `ExpandCommand` or `IsSkillCommand` usage):
+          4. After `ExpandCommand()` is called, extract the skill name using `skill.ExtractSkillName(text)` and call `skillStats.RecordUsage(skillName)` then `skillStats.Save()`. Log errors from Save but don't fail the expansion.
+
+      ## Files
+      - MODIFY: cmd/ai/rpc_handlers.go
+
+      ## Design decision
+      Stats loading happens once at startup. The find_skill tool gets a pointer to the same stats object so it can record usage from search/load calls. The /skill:name expansion also records usage for the most common skill invocation path.
+
+      ## Edge cases
+      - Stats file doesn't exist on first run → LoadStats returns empty struct → find_skill still works, FormatForPrompt falls back
+      - Multiple concurrent agents writing stats → acceptable last-write-wins risk per design
+      - /skill:name for a skill not in the loader → ExtractSkillName returns the name, RecordUsage creates a new entry (harmless)
+
+      ## Done when
+      - [ ] `go build ./cmd/ai/...` passes
+      - [ ] find_skill tool appears in tool registry at startup (verify via log or manual test)
+      - [ ] System prompt only contains top-N skills when stats file has entries
+      - [ ] /skill:name expansion records usage to skill-stats.json
+    group: ai-integration
+    dependencies: [T002, T004]
+
+  - id: T006
+    title: "Integrate stats and find_skill into aiclaw agent"
+    estimated_hours: 2
+    description: |
+      ## Goal
+      Wire up the same stats loading, find_skill tool registration, and shared `FormatForPrompt` into the `claw/cmd/aiclaw` agent, replacing its custom `buildSkillsSummary` function.
+
+      ## Key changes
+      - Modify `claw/cmd/aiclaw/main.go`:
+        - Change `clawDir` from `~/.aiclaw` to `~/.ai` (the `homeDir/.ai` pattern, same as ai agent). This is the directory unification step.
+        - In the skill loading block (~line 222):
+          1. After `skillLoader.Load()`, load stats: `skillStats := skill.LoadStats(filepath.Join(clawDir, "skill-stats.json"))`
+          2. Register find_skill tool into the agent's tool registry (if aiclaw has a tool registry; otherwise, the find_skill tool is available via the shared adapter layer)
+        - In `buildSystemPrompt` function (~line 642):
+          3. Replace the `buildSkillsSummary(skills)` call and surrounding `# Skills` block with `skill.FormatForPrompt(skills, skillStats)` which now produces the properly formatted skills section with top-N filtering and find_skill footer
+          4. Remove the `buildSkillsSummary` function entirely (it's replaced by the shared formatter)
+        - Update the `agentConfig` struct initialization to pass `skillStats` if the adapter needs it
+
+      ## Important context about existing code
+      - `buildSystemPrompt(clawDir string, skills []skill.Skill) string` at line 642 builds the full system prompt with identity, rules, and skills
+      - `buildSkillsSummary(skills []skill.Skill) string` at line 694 just does `- **name**: description` per skill — this is what gets replaced
+      - The function signature may need to accept stats: `buildSystemPrompt(clawDir string, skills []skill.Skill, skillStats *skill.SkillStatsFile) string`
+      - `clawDir` is currently set to `~/.aiclaw` — after change it should use `~/.ai`
+
+      ## Files
+      - MODIFY: claw/cmd/aiclaw/main.go
+
+      ## Edge cases
+      - clawDir change from ~/.aiclaw to ~/.ai: existing `~/.aiclaw/AGENTS.md` and other config files should still be checked. Consider falling back to `~/.aiclaw` for AGENTS.md loading if not found in `~/.ai`
+      - Skills may still physically live in `claw/skills/` directory — the loader should handle this via the AgentDir pointing to `~/.ai` (skills will need to be migrated there first, or symlinked)
+
+      ## Done when
+      - [ ] `go build ./claw/cmd/aiclaw/...` passes
+      - [ ] `go test ./claw/cmd/aiclaw/...` passes
+      - [ ] `buildSkillsSummary` function is removed
+      - [ ] `skill.FormatForPrompt` is used instead for skill listing
+      - [ ] Stats file is loaded from `~/.ai/skill-stats.json`
+    group: aiclaw-integration
+    dependencies: [T004, T005]
+
+  - id: T007
+    title: "Create index-skills SKILL.md for LLM-generated search index"
+    estimated_hours: 1
+    description: |
+      ## Goal
+      Create the `index-skills` skill that, when invoked by the agent, reads all SKILL.md files and generates a rich search index file (`~/.ai/skill-index.json`) via a single LLM call.
+
+      ## Key changes
+      - Create `~/.ai/skills/index-skills/SKILL.md` (this is a runtime artifact, but should also be placed in the repo's equivalent skill directory for versioning — check if the repo has a `skills/` directory or if skills are only in `~/.ai/skills/`)
+      - The SKILL.md content should instruct the agent to:
+        1. Read all SKILL.md files from `~/.ai/skills/` (using the read tool or glob)
+        2. For each skill, extract: name, description, key use-cases, aliases (synonyms, Chinese↔English equivalents), categories
+        3. Produce a JSON file at `~/.ai/skill-index.json` with this schema:
+           ```json
+           {
+             "version": 1,
+             "generated_at": "2025-07-11T...",
+             "entries": [
+               {
+                 "name": "systematic-debugging",
+                 "description": "...",
+                 "aliases": ["debug", "fix bug", "troubleshoot", "调试"],
+                 "use_when": ["encountering bugs", "test failures", "unexpected behavior"],
+                 "categories": ["debugging", "development"]
+               }
+             ]
+           }
+           ```
+        4. Write the JSON file using the write tool
+        5. Report how many skills were indexed
+
+      ## Files
+      - CREATE: ~/.ai/skills/index-skills/SKILL.md
+
+      ## Design decision
+      This is a skill (not code) because it's a one-time maintenance operation that benefits from LLM intelligence for synonym generation and categorization. The generated index is consumed by the find_skill tool in future searches — the tool can optionally read `~/.ai/skill-index.json` and match against aliases/use_when fields in addition to name/description substring matching.
+
+      ## Edge cases
+      - Skill invoked when no skills exist → empty index file
+      - Skill invoked twice → overwrites previous index (idempotent)
+
+      ## Done when
+      - [ ] SKILL.md file exists with proper frontmatter (name, description)
+      - [ ] Invoking `/skill:index-skills` produces a valid skill-index.json file
+      - [ ] The index file contains entries for all discovered skills
+    group: search-index
+    dependencies: []
+
+  - id: T008
+    title: "Enhance find_skill to use LLM-generated search index"
+    estimated_hours: 1
+    description: |
+      ## Goal
+      Extend the find_skill tool to also search the LLM-generated `~/.ai/skill-index.json` for richer matching (aliases, use-when, categories, cross-language synonyms).
+
+      ## Key changes
+      - Modify `pkg/tools/find_skill.go`:
+        - Add a `SkillIndexEntry` struct: `Name string`, `Aliases []string`, `UseWhen []string`, `Categories []string`
+        - Add a `SkillIndex` struct: `Version int`, `Entries []SkillIndexEntry`
+        - Add a `loadSkillIndex(path string) *SkillIndex` function that reads `~/.ai/skill-index.json` (cached per invocation, or loaded once at tool creation)
+        - In the `Execute` method's search mode:
+          1. First do the existing substring match on loaded skills' Name and Description
+          2. Then load the index file from `filepath.Join(os.UserHomeDir(), ".ai", "skill-index.json")` if it exists
+          3. For each index entry, check if `query` matches any Alias, UseWhen, or Category (case-insensitive substring)
+          4. Add index-matched skills to results (deduplicate by name against already-found skills)
+          5. Sort results: exact name matches first, then alias matches, then category matches, then description matches
+        - Update tests in `pkg/tools/find_skill_test.go` to cover:
+          - Search finds skill via alias from index
+          - Search finds skill via use_when from index
+          - No index file → falls back to name/description matching only
+          - Deduplication between direct match and index match
+
+      ## Files
+      - MODIFY: pkg/tools/find_skill.go
+      - MODIFY: pkg/tools/find_skill_test.go
+
+      ## Design decision
+      The index file is optional — find_skill works without it via basic substring matching. When the index exists, it enriches results with semantic aliases. The index is loaded per search call (not cached) because it's small (~56 entries) and may have been regenerated between calls.
+
+      ## Edge cases
+      - Index file doesn't exist → skip index search, only use name/description matching
+      - Index file is malformed → log warning, skip index search
+      - Index references a skill not loaded → still show in results with a note that it may not be available
+
+      ## Done when
+      - [ ] `go build ./pkg/tools/...` passes
+      - [ ] `go test ./pkg/tools/... -run TestFindSkill` passes with index-aware tests
+      - [ ] find_skill returns results matching aliases from index
+      - [ ] find_skill works without index file (backward compat)
+    group: search-index
+    dependencies: [T002, T007]
+
+  - id: T009
+    title: "Fix FormatForPrompt callers across codebase"
+    estimated_hours: 2
+    description: |
+      ## Goal
+      Update all callers of `skill.FormatForPrompt` that pass the old single-argument signature to pass the new two-argument signature `(skills, stats)`, ensuring the entire codebase compiles.
+
+      ## Key changes
+      - Search all files that call `skill.FormatForPrompt` (other than those already updated in T004/T005/T006)
+      - Known callers to check and update:
+        - `pkg/context/context.go` — `NewAgentContextWithSkills` function at ~line 261 calls `skill.FormatForPrompt(skills)` — update to `skill.FormatForPrompt(skills, nil)` (backward compat, no stats available in this context)
+        - `pkg/prompt/system_test.go` — test code that calls FormatForPrompt indirectly via the builder
+        - Any other test files that call FormatForPrompt directly
+      - For all callers that don't have stats available, pass `nil` as the second argument (triggers fallback behavior showing all skills)
+
+      ## Files
+      - MODIFY: pkg/context/context.go (pass nil for stats)
+      - MODIFY: any test files that call FormatForPrompt directly
+
+      ## Edge cases
+      - All callers that pass nil get the fallback behavior (show all skills) — this is correct for contexts where stats aren't available
+
+      ## Done when
+      - [ ] `go build ./...` passes with zero errors across entire repo
+      - [ ] `go test ./pkg/... ./cmd/... ./claw/...` passes
+      - [ ] No remaining callers of the old single-argument `FormatForPrompt`
+    group: compat-fixup
+    dependencies: [T003, T004, T005, T006]
+
+groups:
+  - name: stats-tracking
+    title: "Skill Usage Stats Infrastructure"
+    estimated_hours: 2
+    description: "Core stats tracking with time-decay scoring, persisted to JSON. Foundation for all other groups."
+    tasks: [T001]
+    commit_message: "feat(skill): add usage tracking with time-decay scoring"
+
+  - name: discovery-tool
+    title: "find_skill Discovery Tool"
+    estimated_hours: 2
+    description: "Built-in tool for skill search and loading with usage recording."
+    tasks: [T002]
+    commit_message: "feat(tools): add find_skill tool for skill discovery"
+
+  - name: prompt-filtering
+    title: "Top-N Skill Filtering in System Prompt"
+    estimated_hours: 2
+    description: "Formatter and prompt builder changes to show only top-N ranked skills, reducing token waste."
+    tasks: [T003, T004]
+    commit_message: "feat(skill): progressive disclosure — show top-N skills in system prompt"
+
+  - name: ai-integration
+    title: "AI Agent Integration"
+    estimated_hours: 2
+    description: "Wire stats loading, find_skill tool, and usage recording into the coding agent."
+    tasks: [T005]
+    commit_message: "feat(ai): integrate skill stats and find_skill tool"
+
+  - name: aiclaw-integration
+    title: "Aiclaw Agent Integration & Directory Unification"
+    estimated_hours: 2
+    description: "Wire shared stats/tool logic into aiclaw, replace custom buildSkillsSummary, unify to ~/.ai directory."
+    tasks: [T006]
+    commit_message: "feat(aiclaw): unify skill directory to ~/.ai and use shared stats/formatting"
+
+  - name: search-index
+    title: "LLM-Generated Search Index"
+    estimated_hours: 2
+    description: "Skill for generating rich search index and enhanced find_skill with alias/category matching."
+    tasks: [T007, T008]
+    commit_message: "feat(skill): add index-skills and enhanced semantic search"
+
+  - name: compat-fixup
+    title: "Cross-Repo Compatibility Fixup"
+    estimated_hours: 2
+    description: "Update all remaining callers of FormatForPrompt to the new signature, ensuring full compilation."
+    tasks: [T009]
+    commit_message: "fix(skill): update all FormatForPrompt callers for new stats parameter"
+
+group_order: [stats-tracking, discovery-tool, prompt-filtering, ai-integration, aiclaw-integration, search-index, compat-fixup]
+risks:
+  - area: "Cold start experience"
+    risk: "New users or clean installs have no stats file, so the system prompt may show too many or too few skills initially"
+    mitigation: "FormatForPrompt falls back to current behavior (show all, capped at TopN=7) when stats is empty. After a few sessions, stats accumulate naturally."
+
+  - area: "Concurrent stats file writes"
+    risk: "Two agent processes writing skill-stats.json simultaneously could lose data (last-write-wins)"
+    mitigation: "Acceptable risk per design — losing a single +1 count is inconsequential for ranking. Keep writes small and fast."
+
+  - area: "Skill name collisions after merge"
+    risk: "Both ai and aiclaw skill trees have skills named 'github', 'tmux', 'skill-creator'. Merging into one directory causes file-level collision."
+    mitigation: "Loader already handles collisions (first-loaded wins, diagnostic logged). Manual audit needed before migration — this is a manual step outside the task plan."
+
+  - area: "aiclaw directory migration"
+    risk: "Changing clawDir from ~/.aiclaw to ~/.ai breaks existing aiclaw setups that have config, memory, and cron jobs in ~/.aiclaw"
+    mitigation: "Maintain backward compatibility by checking ~/.aiclaw as fallback for AGENTS.md and other config. Migration is gradual — skills can be copied, not moved initially."
+
+  - area: "Search index staleness"
+    risk: "skill-index.json drifts out of sync as skills are added/removed/updated"
+    mitigation: "The index-skills skill is idempotent and can be re-run at any time. Future enhancement could auto-trigger reindex on skill directory change detection."

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -144,7 +144,7 @@ func NewAgentContextWithSkills(systemPrompt string, skills []skill.Skill) *Agent
 
 	// Append skills to system prompt
 	if len(skills) > 0 {
-		skillsText := skill.FormatForPrompt(skills)
+		skillsText := skill.FormatForPrompt(skills, nil)
 		if skillsText != "" {
 			ctx.SystemPrompt = systemPrompt + skillsText
 		}

--- a/pkg/prompt/builder.go
+++ b/pkg/prompt/builder.go
@@ -74,8 +74,11 @@ type Builder struct {
 	// Available tools (for Tooling section)
 	tools []ToolInfo
 
-	// Skills (for Skills section)
+		// Skills (for Skills section)
 	skills []skill.Skill
+
+	// Skill usage stats (optional, for progressive disclosure)
+	skillStats *skill.SkillStatsFile
 
 	// Context meta (for runtime_state telemetry, set by agent loop)
 	contextMeta string
@@ -153,6 +156,12 @@ func (b *Builder) SetSkills(skills []skill.Skill) *Builder {
 	return b
 }
 
+// SetSkillStats sets the skill usage statistics for progressive disclosure.
+func (b *Builder) SetSkillStats(stats *skill.SkillStatsFile) *Builder {
+	b.skillStats = stats
+	return b
+}
+
 // SetContextMeta sets the runtime_state telemetry metadata.
 func (b *Builder) SetContextMeta(meta string) *Builder {
 	b.contextMeta = meta
@@ -185,7 +194,7 @@ Use change_workspace for persistent directory switches; "cd <dir> && <command>" 
 	// Replace skills (optional section)
 	skills := ""
 	if !b.minimal && len(b.skills) > 0 {
-		if skillsText := skill.FormatForPrompt(b.skills); skillsText != "" {
+						if skillsText := skill.FormatForPrompt(b.skills, b.skillStats); skillsText != "" {
 			skills = skillsText
 		}
 	}

--- a/pkg/prompt/builder_test.go
+++ b/pkg/prompt/builder_test.go
@@ -282,6 +282,75 @@ func TestNoWorkspaceMode(t *testing.T) {
 	}
 }
 
+func TestBuilderWithSkillStats(t *testing.T) {
+	cwd := "/workspace"
+
+	skills := []skill.Skill{
+		{Name: "popular", Description: "A popular skill", FilePath: "/tmp/popular/SKILL.md"},
+		{Name: "unpopular", Description: "An unpopular skill", FilePath: "/tmp/unpopular/SKILL.md"},
+		{Name: "medium", Description: "A medium skill", FilePath: "/tmp/medium/SKILL.md"},
+	}
+
+	stats := &skill.SkillStatsFile{
+		Version: 1,
+		TopN:    2,
+		Entries: map[string]*skill.SkillUsageEntry{
+			"popular":   {Name: "popular", Count: 100, Score: 100.0},
+			"unpopular": {Name: "unpopular", Count: 1, Score: 1.0},
+		},
+	}
+
+	b := NewBuilder("", cwd)
+	b.SetSkills(skills)
+	b.SetSkillStats(stats)
+	result := b.Build()
+
+	if !contains(result, "## Skills") {
+		t.Error("Skills section missing")
+	}
+
+	// With TopN=2 and "popular" ranked highest, "medium" should not appear
+	// because it has no stats entry and popular + unpopular fill the top 2.
+	// Actually, let's check: popular (ranked), unpopular (ranked) → top 2 from stats.
+	// "medium" has no stats → it gets added as unranked supplement only if room.
+	// TopN=2, ranked=2 → selected has 2 → medium is excluded.
+	if !contains(result, "**popular**") {
+		t.Error("popular skill should appear")
+	}
+	if contains(result, "**medium**") {
+		t.Error("medium skill should be filtered out (TopN=2, not in top entries)")
+	}
+
+	// Stats present → should include find_skill hint
+	if !contains(result, "find_skill") {
+		t.Error("find_skill hint should appear when stats are set")
+	}
+}
+
+func TestBuilderWithSkillStatsNil(t *testing.T) {
+	cwd := "/workspace"
+
+	skills := []skill.Skill{
+		{Name: "test", Description: "A test skill", FilePath: "/tmp/test/SKILL.md"},
+	}
+
+	b := NewBuilder("", cwd)
+	b.SetSkills(skills)
+	// SetSkillStats not called → skillStats is nil → backward compat
+	result := b.Build()
+
+	if !contains(result, "## Skills") {
+		t.Error("Skills section missing")
+	}
+	if !contains(result, "A test skill") {
+		t.Error("Skill description missing")
+	}
+	// No stats → should NOT show find_skill hint
+	if contains(result, "find_skill") {
+		t.Error("find_skill hint should not appear when stats are nil")
+	}
+}
+
 // Helper function
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)

--- a/pkg/skill/formatter.go
+++ b/pkg/skill/formatter.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	maxSkillDescriptionRunes = 220
-		defaultPromptTopN        = 10
+	defaultPromptTopN        = 10
 )
 
 // FormatForPrompt formats skills for inclusion in a system prompt.
@@ -108,8 +108,11 @@ func FormatForPrompt(skills []Skill, stats *SkillStatsFile) string {
 		"When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
 	)
 
-	if stats != nil {
-		lines = append(lines, "*Use the find_skill tool to discover more skills by keyword.*")
+	if stats != nil && len(stats.Entries) > 0 {
+		// Hint about discoverable skills so LLM knows what to search for.
+		// Keep it short — this is a cold-start bridge, not an exhaustive list.
+		lines = append(lines, "",
+			"*Additional skills are available via `find_skill`. Try keywords: coding, debug, browser, git, mobile, device, PDF, Obsidian, notes, orchestration, architecture, review, planning, brainstorm, security, hardware.*")
 	} else if len(visibleSkills) > topN {
 		omitted := len(visibleSkills) - topN
 		lines = append(lines, fmt.Sprintf("*Note: %d additional skills omitted for brevity.*", omitted))

--- a/pkg/skill/formatter.go
+++ b/pkg/skill/formatter.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	maxSkillDescriptionRunes = 220
-	defaultPromptTopN        = 7
+		defaultPromptTopN        = 10
 )
 
 // FormatForPrompt formats skills for inclusion in a system prompt.

--- a/pkg/skill/formatter.go
+++ b/pkg/skill/formatter.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	maxPromptSkills          = 24
 	maxSkillDescriptionRunes = 220
+	defaultPromptTopN        = 7
 )
 
 // FormatForPrompt formats skills for inclusion in a system prompt.
@@ -16,9 +16,13 @@ const (
 //
 // Skills with DisableModelInvocation=true are excluded from the prompt
 // (they can only be invoked explicitly via /skill:name commands).
-func FormatForPrompt(skills []Skill) string {
+//
+// If stats is non-nil and has entries, only the top-N ranked skills from
+// stats are shown. Otherwise (cold start / nil stats), all visible skills
+// are shown capped at defaultPromptTopN.
+func FormatForPrompt(skills []Skill, stats *SkillStatsFile) string {
 	// Filter out skills that shouldn't be auto-included
-	visibleSkills := []Skill{}
+	visibleSkills := make([]Skill, 0, len(skills))
 	for _, skill := range skills {
 		if !skill.DisableModelInvocation {
 			visibleSkills = append(visibleSkills, skill)
@@ -29,10 +33,63 @@ func FormatForPrompt(skills []Skill) string {
 		return ""
 	}
 
-	omitted := 0
-	if len(visibleSkills) > maxPromptSkills {
-		omitted = len(visibleSkills) - maxPromptSkills
-		visibleSkills = visibleSkills[:maxPromptSkills]
+	topN := defaultPromptTopN
+	if stats != nil && stats.TopN > 0 {
+		topN = stats.TopN
+	}
+
+	// Determine which skills to show
+	var selected []Skill
+
+	if stats != nil && len(stats.Entries) > 0 {
+		// Stats-based ranking: use TopSkills to determine order
+		topNames := stats.TopSkills(topN)
+		nameSet := make(map[string]bool, len(topNames))
+		for _, n := range topNames {
+			nameSet[n] = true
+		}
+
+		// Build lookup by name
+		skillByName := make(map[string]*Skill, len(visibleSkills))
+		for i := range visibleSkills {
+			skillByName[visibleSkills[i].Name] = &visibleSkills[i]
+		}
+
+		// Add ranked skills that exist in the loaded list (in rank order)
+		for _, name := range topNames {
+			if s, ok := skillByName[name]; ok {
+				selected = append(selected, *s)
+				delete(skillByName, name)
+			}
+		}
+
+		// Supplement with unranked skills to fill up to topN
+		for _, s := range visibleSkills {
+			if len(selected) >= topN {
+				break
+			}
+			if _, ok := skillByName[s.Name]; ok {
+				selected = append(selected, s)
+				delete(skillByName, s.Name)
+			}
+		}
+
+		// Edge case: all stats were stale (none matched loaded skills)
+		// → fall back to showing all loaded skills, capped at topN
+		if len(selected) == 0 {
+			if len(visibleSkills) > topN {
+				selected = visibleSkills[:topN]
+			} else {
+				selected = visibleSkills
+			}
+		}
+	} else {
+		// Cold start / nil stats: show all visible skills capped at topN
+		if len(visibleSkills) > topN {
+			selected = visibleSkills[:topN]
+		} else {
+			selected = visibleSkills
+		}
 	}
 
 	lines := []string{
@@ -42,7 +99,7 @@ func FormatForPrompt(skills []Skill) string {
 		"",
 	}
 
-	for _, skill := range visibleSkills {
+	for _, skill := range selected {
 		description := trimRunes(strings.TrimSpace(skill.Description), maxSkillDescriptionRunes)
 		lines = append(lines, fmt.Sprintf("- **%s**: %s (%s)", skill.Name, description, skill.FilePath))
 	}
@@ -51,7 +108,10 @@ func FormatForPrompt(skills []Skill) string {
 		"When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
 	)
 
-	if omitted > 0 {
+	if stats != nil {
+		lines = append(lines, "*Use the find_skill tool to discover more skills by keyword.*")
+	} else if len(visibleSkills) > topN {
+		omitted := len(visibleSkills) - topN
 		lines = append(lines, fmt.Sprintf("*Note: %d additional skills omitted for brevity.*", omitted))
 	}
 

--- a/pkg/skill/formatter_prompt_test.go
+++ b/pkg/skill/formatter_prompt_test.go
@@ -20,12 +20,12 @@ func TestFormatForPromptLimitsSkillCount(t *testing.T) {
 	out := FormatForPrompt(skills, nil)
 	// Count markdown list items (- **skill-N**:)
 	skillCount := strings.Count(out, "- **skill-")
-	// With nil stats, default topN is 7
-	if skillCount != 7 {
-		t.Fatalf("expected 7 skills in prompt (nil stats, default cap), got %d", skillCount)
+	// With nil stats, default topN is 10
+		if skillCount != 10 {
+		t.Fatalf("expected 10 skills in prompt (nil stats, default cap), got %d", skillCount)
 	}
-	// 30 - 7 = 23 omitted
-	if !strings.Contains(out, "*Note: 23 additional skills omitted for brevity.*") {
+	// 30 - 10 = 20 omitted
+	if !strings.Contains(out, "*Note: 20 additional skills omitted for brevity.*") {
 		t.Fatalf("expected 23 omitted note, got output: %s", out)
 	}
 	// No footer when stats is nil
@@ -174,19 +174,19 @@ func TestFormatForPromptColdStart(t *testing.T) {
 		})
 	}
 
-	// Stats with empty entries (cold start)
+		// Stats with empty entries (cold start)
 	stats := &SkillStatsFile{
 		Version: 1,
-		TopN:    7,
+		TopN:    10,
 		Entries: map[string]*SkillUsageEntry{},
 	}
 
 	out := FormatForPrompt(skills, stats)
 
-	// Should show all skills capped at TopN=7
+	// Should show all skills capped at TopN=10
 	skillCount := strings.Count(out, "- **skill-")
-	if skillCount != 7 {
-		t.Fatalf("expected 7 skills in prompt (cold start, capped at TopN), got %d", skillCount)
+	if skillCount != 10 {
+		t.Fatalf("expected 10 skills in prompt (cold start, capped at TopN), got %d", skillCount)
 	}
 	// Footer should be present (stats is non-nil)
 	if !strings.Contains(out, "*Use the find_skill tool to discover more skills by keyword.*") {

--- a/pkg/skill/formatter_prompt_test.go
+++ b/pkg/skill/formatter_prompt_test.go
@@ -21,7 +21,7 @@ func TestFormatForPromptLimitsSkillCount(t *testing.T) {
 	// Count markdown list items (- **skill-N**:)
 	skillCount := strings.Count(out, "- **skill-")
 	// With nil stats, default topN is 10
-		if skillCount != 10 {
+	if skillCount != 10 {
 		t.Fatalf("expected 10 skills in prompt (nil stats, default cap), got %d", skillCount)
 	}
 	// 30 - 10 = 20 omitted
@@ -96,8 +96,8 @@ func TestFormatForPromptWithStatsRanked(t *testing.T) {
 	}
 
 	// Footer should be present
-	if !strings.Contains(out, "*Use the find_skill tool to discover more skills by keyword.*") {
-		t.Error("expected find_skill footer when stats is non-nil")
+	if !strings.Contains(out, "Additional skills are available via `find_skill`") {
+		t.Error("expected find_skill hint when stats is non-nil")
 	}
 }
 
@@ -159,8 +159,8 @@ func TestFormatForPromptWithStatsAllStale(t *testing.T) {
 		t.Error("expected beta in output (all-stale fallback)")
 	}
 	// Footer should still be present (stats is non-nil)
-	if !strings.Contains(out, "*Use the find_skill tool to discover more skills by keyword.*") {
-		t.Error("expected find_skill footer")
+	if !strings.Contains(out, "Additional skills are available via `find_skill`") {
+		t.Error("expected find_skill hint")
 	}
 }
 
@@ -174,7 +174,7 @@ func TestFormatForPromptColdStart(t *testing.T) {
 		})
 	}
 
-		// Stats with empty entries (cold start)
+	// Stats with empty entries (cold start)
 	stats := &SkillStatsFile{
 		Version: 1,
 		TopN:    10,
@@ -188,9 +188,13 @@ func TestFormatForPromptColdStart(t *testing.T) {
 	if skillCount != 10 {
 		t.Fatalf("expected 10 skills in prompt (cold start, capped at TopN), got %d", skillCount)
 	}
-	// Footer should be present (stats is non-nil)
-	if !strings.Contains(out, "*Use the find_skill tool to discover more skills by keyword.*") {
-		t.Error("expected find_skill footer")
+	// Footer should show omitted count (cold start with empty stats)
+	if !strings.Contains(out, "5 additional skills omitted for brevity") {
+		t.Error("expected '5 additional skills omitted for brevity' footer for cold start with empty stats")
+	}
+	// Should NOT show find_skill hint (no stats entries = no ranking data)
+	if strings.Contains(out, "find_skill") {
+		t.Error("cold start with empty stats should not show find_skill hint")
 	}
 }
 

--- a/pkg/skill/formatter_prompt_test.go
+++ b/pkg/skill/formatter_prompt_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFormatForPromptLimitsSkillCount(t *testing.T) {
@@ -16,14 +17,20 @@ func TestFormatForPromptLimitsSkillCount(t *testing.T) {
 		})
 	}
 
-	out := FormatForPrompt(skills)
+	out := FormatForPrompt(skills, nil)
 	// Count markdown list items (- **skill-N**:)
 	skillCount := strings.Count(out, "- **skill-")
-	if skillCount != maxPromptSkills {
-		t.Fatalf("expected %d skills in prompt, got %d", maxPromptSkills, skillCount)
+	// With nil stats, default topN is 7
+	if skillCount != 7 {
+		t.Fatalf("expected 7 skills in prompt (nil stats, default cap), got %d", skillCount)
 	}
-	if !strings.Contains(out, "*Note: 6 additional skills omitted for brevity.*") {
-		t.Fatalf("expected omitted-skills note, got output: %s", out)
+	// 30 - 7 = 23 omitted
+	if !strings.Contains(out, "*Note: 23 additional skills omitted for brevity.*") {
+		t.Fatalf("expected 23 omitted note, got output: %s", out)
+	}
+	// No footer when stats is nil
+	if strings.Contains(out, "find_skill") {
+		t.Fatalf("expected no find_skill footer when stats is nil, got: %s", out)
 	}
 }
 
@@ -33,7 +40,7 @@ func TestFormatForPromptTruncatesDescription(t *testing.T) {
 		Name:        "demo",
 		Description: longDesc,
 		FilePath:    "/tmp/demo/SKILL.md",
-	}})
+	}}, nil)
 
 	// Check markdown format: - **demo**: <description> (/path)
 	expectedPrefix := "- **demo**:"
@@ -50,5 +57,172 @@ func TestFormatForPromptTruncatesDescription(t *testing.T) {
 	desc := strings.TrimSpace(out[start:end])
 	if len([]rune(desc)) != maxSkillDescriptionRunes {
 		t.Fatalf("expected description length=%d, got %d", maxSkillDescriptionRunes, len([]rune(desc)))
+	}
+}
+
+func TestFormatForPromptWithStatsRanked(t *testing.T) {
+	// Create skills
+	skills := []Skill{
+		{Name: "alpha", Description: "Alpha skill", FilePath: "/tmp/alpha/SKILL.md"},
+		{Name: "beta", Description: "Beta skill", FilePath: "/tmp/beta/SKILL.md"},
+		{Name: "gamma", Description: "Gamma skill", FilePath: "/tmp/gamma/SKILL.md"},
+		{Name: "delta", Description: "Delta skill", FilePath: "/tmp/delta/SKILL.md"},
+	}
+
+	// Stats rank gamma and alpha as top-2
+	stats := &SkillStatsFile{
+		Version: 1,
+		TopN:    2,
+		Entries: map[string]*SkillUsageEntry{
+			"gamma": {Name: "gamma", Count: 10, LastUsed: time.Now(), Score: 10},
+			"alpha": {Name: "alpha", Count: 5, LastUsed: time.Now(), Score: 5},
+		},
+	}
+
+	out := FormatForPrompt(skills, stats)
+
+	// Only gamma and alpha should appear
+	if !strings.Contains(out, "- **gamma**") {
+		t.Error("expected gamma in output")
+	}
+	if !strings.Contains(out, "- **alpha**") {
+		t.Error("expected alpha in output")
+	}
+	if strings.Contains(out, "- **beta**") {
+		t.Error("beta should not appear (not in top-2)")
+	}
+	if strings.Contains(out, "- **delta**") {
+		t.Error("delta should not appear (not in top-2)")
+	}
+
+	// Footer should be present
+	if !strings.Contains(out, "*Use the find_skill tool to discover more skills by keyword.*") {
+		t.Error("expected find_skill footer when stats is non-nil")
+	}
+}
+
+func TestFormatForPromptWithStatsStaleEntry(t *testing.T) {
+	skills := []Skill{
+		{Name: "alpha", Description: "Alpha skill", FilePath: "/tmp/alpha/SKILL.md"},
+		{Name: "beta", Description: "Beta skill", FilePath: "/tmp/beta/SKILL.md"},
+	}
+
+	// Stats reference a deleted skill "deleted-skill" and "alpha"
+	stats := &SkillStatsFile{
+		Version: 1,
+		TopN:    3,
+		Entries: map[string]*SkillUsageEntry{
+			"deleted-skill": {Name: "deleted-skill", Count: 20, LastUsed: time.Now(), Score: 20},
+			"alpha":         {Name: "alpha", Count: 5, LastUsed: time.Now(), Score: 5},
+		},
+	}
+
+	out := FormatForPrompt(skills, stats)
+
+	// deleted-skill should be skipped (not in loaded list)
+	if strings.Contains(out, "deleted-skill") {
+		t.Error("deleted-skill should not appear in output")
+	}
+	// alpha should appear (it's ranked and exists)
+	if !strings.Contains(out, "- **alpha**") {
+		t.Error("expected alpha in output")
+	}
+	// beta should appear as supplement (topN=3, only 1 ranked found, 1 supplement needed)
+	if !strings.Contains(out, "- **beta**") {
+		t.Error("expected beta in output (supplemented to fill topN)")
+	}
+}
+
+func TestFormatForPromptWithStatsAllStale(t *testing.T) {
+	skills := []Skill{
+		{Name: "alpha", Description: "Alpha skill", FilePath: "/tmp/alpha/SKILL.md"},
+		{Name: "beta", Description: "Beta skill", FilePath: "/tmp/beta/SKILL.md"},
+	}
+
+	// All stats reference skills not in loaded list
+	stats := &SkillStatsFile{
+		Version: 1,
+		TopN:    7,
+		Entries: map[string]*SkillUsageEntry{
+			"old-1": {Name: "old-1", Count: 10, LastUsed: time.Now(), Score: 10},
+			"old-2": {Name: "old-2", Count: 5, LastUsed: time.Now(), Score: 5},
+		},
+	}
+
+	out := FormatForPrompt(skills, stats)
+
+	// Should fall back to showing all loaded skills
+	if !strings.Contains(out, "- **alpha**") {
+		t.Error("expected alpha in output (all-stale fallback)")
+	}
+	if !strings.Contains(out, "- **beta**") {
+		t.Error("expected beta in output (all-stale fallback)")
+	}
+	// Footer should still be present (stats is non-nil)
+	if !strings.Contains(out, "*Use the find_skill tool to discover more skills by keyword.*") {
+		t.Error("expected find_skill footer")
+	}
+}
+
+func TestFormatForPromptColdStart(t *testing.T) {
+	skills := make([]Skill, 0, 15)
+	for i := 0; i < 15; i++ {
+		skills = append(skills, Skill{
+			Name:        fmt.Sprintf("skill-%d", i),
+			Description: "desc",
+			FilePath:    "/tmp/skill",
+		})
+	}
+
+	// Stats with empty entries (cold start)
+	stats := &SkillStatsFile{
+		Version: 1,
+		TopN:    7,
+		Entries: map[string]*SkillUsageEntry{},
+	}
+
+	out := FormatForPrompt(skills, stats)
+
+	// Should show all skills capped at TopN=7
+	skillCount := strings.Count(out, "- **skill-")
+	if skillCount != 7 {
+		t.Fatalf("expected 7 skills in prompt (cold start, capped at TopN), got %d", skillCount)
+	}
+	// Footer should be present (stats is non-nil)
+	if !strings.Contains(out, "*Use the find_skill tool to discover more skills by keyword.*") {
+		t.Error("expected find_skill footer")
+	}
+}
+
+func TestFormatForPromptSupplementFillsTopN(t *testing.T) {
+	skills := []Skill{
+		{Name: "ranked", Description: "Ranked skill", FilePath: "/tmp/ranked/SKILL.md"},
+		{Name: "unranked-a", Description: "Unranked A", FilePath: "/tmp/ua/SKILL.md"},
+		{Name: "unranked-b", Description: "Unranked B", FilePath: "/tmp/ub/SKILL.md"},
+	}
+
+	// Only 1 skill in stats, TopN=3
+	stats := &SkillStatsFile{
+		Version: 1,
+		TopN:    3,
+		Entries: map[string]*SkillUsageEntry{
+			"ranked": {Name: "ranked", Count: 5, LastUsed: time.Now(), Score: 5},
+		},
+	}
+
+	out := FormatForPrompt(skills, stats)
+
+	// All 3 should appear: 1 ranked + 2 supplemented
+	if strings.Count(out, "- **") != 3 {
+		t.Fatalf("expected 3 skills (1 ranked + 2 supplemented), got %d", strings.Count(out, "- **"))
+	}
+	if !strings.Contains(out, "- **ranked**") {
+		t.Error("expected ranked skill")
+	}
+	if !strings.Contains(out, "- **unranked-a**") {
+		t.Error("expected unranked-a (supplement)")
+	}
+	if !strings.Contains(out, "- **unranked-b**") {
+		t.Error("expected unranked-b (supplement)")
 	}
 }

--- a/pkg/skill/integration_test.go
+++ b/pkg/skill/integration_test.go
@@ -37,7 +37,7 @@ func TestIntegrationRealSkills(t *testing.T) {
 
 	// Format for prompt
 	if len(result.Skills) > 0 {
-		prompt := FormatForPrompt(result.Skills)
+		prompt := FormatForPrompt(result.Skills, nil)
 		t.Logf("Skills in prompt:\n%s", prompt)
 	}
 }

--- a/pkg/skill/skill_test.go
+++ b/pkg/skill/skill_test.go
@@ -259,7 +259,7 @@ func TestFormatForPrompt(t *testing.T) {
 		},
 	}
 
-	result := FormatForPrompt(skills)
+	result := FormatForPrompt(skills, nil)
 
 	if !strings.Contains(result, "test-skill") {
 		t.Error("expected test-skill in output")
@@ -280,7 +280,7 @@ func TestFormatForPrompt(t *testing.T) {
 }
 
 func TestFormatForPromptEmpty(t *testing.T) {
-	result := FormatForPrompt([]Skill{})
+	result := FormatForPrompt([]Skill{}, nil)
 	if result != "" {
 		t.Errorf("expected empty string for no skills, got %q", result)
 	}
@@ -293,7 +293,7 @@ func TestFormatForPromptEmpty(t *testing.T) {
 		},
 	}
 
-	result = FormatForPrompt(skills)
+	result = FormatForPrompt(skills, nil)
 	if result != "" {
 		t.Errorf("expected empty string when all skills disabled, got %q", result)
 	}

--- a/pkg/skill/stats.go
+++ b/pkg/skill/stats.go
@@ -26,13 +26,13 @@ type SkillStatsFile struct {
 
 const (
 	statsVersion       = 1
-	defaultTopN        = 7
+		defaultTopN        = 10
 	decayHalfLifeHours = 168.0 // 1 week
 )
 
 // LoadStats reads skill usage statistics from a JSON file at path.
 // If the file is missing or contains invalid JSON, it returns an empty
-// SkillStatsFile with TopN=7 and no error.
+// SkillStatsFile with TopN=10 and no error.
 func LoadStats(path string) *SkillStatsFile {
 	s := &SkillStatsFile{
 		Version:  statsVersion,

--- a/pkg/skill/stats.go
+++ b/pkg/skill/stats.go
@@ -1,0 +1,156 @@
+package skill
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"sort"
+	"time"
+)
+
+// SkillUsageEntry tracks usage statistics for a single skill.
+type SkillUsageEntry struct {
+	Name     string    `json:"name"`
+	Count    int       `json:"count"`
+	LastUsed time.Time `json:"lastUsed"`
+	Score    float64   `json:"score"`
+}
+
+// SkillStatsFile holds persisted skill usage statistics.
+type SkillStatsFile struct {
+	Version  int                         `json:"version"`
+	TopN     int                         `json:"topN"`
+	Entries  map[string]*SkillUsageEntry `json:"entries"`
+	FilePath string                      `json:"-"`
+}
+
+const (
+	statsVersion       = 1
+	defaultTopN        = 7
+	decayHalfLifeHours = 168.0 // 1 week
+)
+
+// LoadStats reads skill usage statistics from a JSON file at path.
+// If the file is missing or contains invalid JSON, it returns an empty
+// SkillStatsFile with TopN=7 and no error.
+func LoadStats(path string) *SkillStatsFile {
+	s := &SkillStatsFile{
+		Version:  statsVersion,
+		TopN:     defaultTopN,
+		Entries:  make(map[string]*SkillUsageEntry),
+		FilePath: path,
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return s
+	}
+
+	if len(data) == 0 {
+		return s
+	}
+
+	var file struct {
+		Version int                         `json:"version"`
+		TopN    int                         `json:"topN"`
+		Entries map[string]*SkillUsageEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		return s
+	}
+
+	s.Version = file.Version
+	if file.TopN > 0 {
+		s.TopN = file.TopN
+	}
+	if file.Entries != nil {
+		s.Entries = file.Entries
+	}
+
+	return s
+}
+
+// RecordUsage increments the usage count for skillName, updates LastUsed,
+// and recomputes Score using half-life decay:
+//
+//	Score = Count * 0.5^(hours_since_last_use / 168)
+//
+// For a new entry, hours_since_last_use is 0 so Score = Count.
+// For an existing entry, the previous LastUsed determines decay before
+// the increment. After incrementing Count and setting LastUsed to now,
+// Score is recomputed as the new Count (since hours since new LastUsed = 0).
+func (s *SkillStatsFile) RecordUsage(skillName string) {
+	now := time.Now()
+
+	entry, ok := s.Entries[skillName]
+	if !ok {
+		entry = &SkillUsageEntry{Name: skillName}
+		s.Entries[skillName] = entry
+	}
+
+	entry.Count++
+	entry.LastUsed = now
+	entry.Score = float64(entry.Count)
+}
+
+// Save writes the stats to s.FilePath as JSON.
+func (s *SkillStatsFile) Save() error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(s.FilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(data)
+	return err
+}
+
+// TopSkills returns up to n skill names sorted by descending time-decayed score.
+// The effective score for ranking applies decay based on time elapsed since
+// each skill's LastUsed:
+//
+//	effectiveScore = Score * 0.5^(hours_since_last_use / 168)
+//
+// which equals Count * 0.5^(hours_since_last_use / 168).
+// If n <= 0, it returns an empty slice.
+func (s *SkillStatsFile) TopSkills(n int) []string {
+	if n <= 0 {
+		return nil
+	}
+
+	now := time.Now()
+
+	type scored struct {
+		name  string
+		score float64
+	}
+
+	candidates := make([]scored, 0, len(s.Entries))
+	for name, entry := range s.Entries {
+		hoursSince := now.Sub(entry.LastUsed).Hours()
+		effectiveScore := entry.Score * math.Pow(0.5, hoursSince/decayHalfLifeHours)
+		candidates = append(candidates, scored{name: name, score: effectiveScore})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return candidates[i].name < candidates[j].name
+	})
+
+	if n > len(candidates) {
+		n = len(candidates)
+	}
+
+	result := make([]string, n)
+	for i := range n {
+		result[i] = candidates[i].name
+	}
+	return result
+}

--- a/pkg/skill/stats.go
+++ b/pkg/skill/stats.go
@@ -2,8 +2,10 @@ package skill
 
 import (
 	"encoding/json"
+	"log/slog"
 	"math"
 	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -45,10 +47,17 @@ func LoadStats(path string) *SkillStatsFile {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			// File exists but unreadable — log but don't overwrite on Save.
+			slog.Warn("[SkillStats] failed to read stats file, starting fresh",
+				"path", path, "error", err)
+		}
 		return s
 	}
 
 	if len(data) == 0 {
+		slog.Warn("[SkillStats] stats file is empty, starting fresh",
+			"path", path)
 		return s
 	}
 
@@ -58,6 +67,8 @@ func LoadStats(path string) *SkillStatsFile {
 		Entries map[string]*SkillUsageEntry `json:"entries"`
 	}
 	if err := json.Unmarshal(data, &file); err != nil {
+		slog.Warn("[SkillStats] stats file has invalid JSON, starting fresh",
+			"path", path, "error", err)
 		return s
 	}
 
@@ -98,8 +109,8 @@ func (s *SkillStatsFile) RecordUsage(skillName string) {
 	entry.Score = float64(entry.Count)
 }
 
-// Save writes the stats to s.FilePath as JSON.
-// Caller must NOT hold s.mu; Save acquires it internally.
+// Save writes the stats to s.FilePath atomically using write-to-temp + rename.
+// The caller must NOT hold s.mu; Save acquires it internally.
 func (s *SkillStatsFile) Save() error {
 	s.mu.Lock()
 	data, err := json.MarshalIndent(s, "", "  ")
@@ -108,14 +119,27 @@ func (s *SkillStatsFile) Save() error {
 		return err
 	}
 
-	f, err := os.OpenFile(s.FilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	// Atomic write: temp file in same directory, then rename.
+	// This prevents concurrent Save() calls from corrupting the file
+	// (e.g. O_TRUNC race leaving a 0-byte file).
+	dir := filepath.Dir(s.FilePath)
+	tmp, err := os.CreateTemp(dir, ".skill-stats-*.tmp")
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	tmpPath := tmp.Name()
 
-	_, err = f.Write(data)
-	return err
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+
+	return os.Rename(tmpPath, s.FilePath)
 }
 
 // TopSkills returns up to n skill names sorted by descending time-decayed score.

--- a/pkg/skill/stats.go
+++ b/pkg/skill/stats.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -18,6 +19,7 @@ type SkillUsageEntry struct {
 
 // SkillStatsFile holds persisted skill usage statistics.
 type SkillStatsFile struct {
+	mu       sync.Mutex                   `json:"-"`
 	Version  int                         `json:"version"`
 	TopN     int                         `json:"topN"`
 	Entries  map[string]*SkillUsageEntry `json:"entries"`
@@ -80,6 +82,9 @@ func LoadStats(path string) *SkillStatsFile {
 // the increment. After incrementing Count and setting LastUsed to now,
 // Score is recomputed as the new Count (since hours since new LastUsed = 0).
 func (s *SkillStatsFile) RecordUsage(skillName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	now := time.Now()
 
 	entry, ok := s.Entries[skillName]
@@ -94,8 +99,11 @@ func (s *SkillStatsFile) RecordUsage(skillName string) {
 }
 
 // Save writes the stats to s.FilePath as JSON.
+// Caller must NOT hold s.mu; Save acquires it internally.
 func (s *SkillStatsFile) Save() error {
+	s.mu.Lock()
 	data, err := json.MarshalIndent(s, "", "  ")
+	s.mu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -119,6 +127,9 @@ func (s *SkillStatsFile) Save() error {
 // which equals Count * 0.5^(hours_since_last_use / 168).
 // If n <= 0, it returns an empty slice.
 func (s *SkillStatsFile) TopSkills(n int) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if n <= 0 {
 		return nil
 	}

--- a/pkg/skill/stats_test.go
+++ b/pkg/skill/stats_test.go
@@ -19,6 +19,48 @@ func TestStatsLoadNonexistentFile(t *testing.T) {
 	}
 	if s.Version != statsVersion {
 		t.Errorf("expected Version=%d, got %d", statsVersion, s.Version)
+		}
+}
+
+func TestStatsConcurrentRecordUsage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.json")
+	s := LoadStats(path)
+
+	// Simulate 15 concurrent find_skill calls all calling RecordUsage + Save
+	const concurrency = 15
+	done := make(chan error, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func(idx int) {
+			name := []string{
+				"skill", "agent", "web", "automate", "code",
+				"debug", "plan", "tool", "notes", "docs",
+				"search", "analyze", "security", "test", "deploy",
+			}[idx]
+			s.RecordUsage(name)
+			done <- s.Save()
+		}(i)
+	}
+
+	for i := 0; i < concurrency; i++ {
+		if err := <-done; err != nil {
+			t.Errorf("goroutine %d: Save failed: %v", i, err)
+		}
+	}
+
+	// Verify all 15 entries were recorded
+	if len(s.Entries) != concurrency {
+		t.Errorf("expected %d entries, got %d", concurrency, len(s.Entries))
+	}
+
+	// Verify file is valid JSON
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("saved file is not valid JSON: %v", err)
 	}
 }
 

--- a/pkg/skill/stats_test.go
+++ b/pkg/skill/stats_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestStatsLoadNonexistentFile(t *testing.T) {
 	s := LoadStats("/tmp/ai-skill-stats-nonexistent-" + t.Name() + ".json")
-	if s.TopN != 7 {
-		t.Errorf("expected TopN=7, got %d", s.TopN)
+	if s.TopN != 10 {
+		t.Errorf("expected TopN=10, got %d", s.TopN)
 	}
 	if len(s.Entries) != 0 {
 		t.Errorf("expected empty entries, got %d", len(s.Entries))
@@ -28,8 +28,8 @@ func TestStatsLoadEmptyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := LoadStats(path)
-	if s.TopN != 7 {
-		t.Errorf("expected TopN=7, got %d", s.TopN)
+	if s.TopN != 10 {
+		t.Errorf("expected TopN=10, got %d", s.TopN)
 	}
 	if len(s.Entries) != 0 {
 		t.Errorf("expected empty entries, got %d", len(s.Entries))
@@ -42,8 +42,8 @@ func TestStatsLoadMalformedJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := LoadStats(path)
-	if s.TopN != 7 {
-		t.Errorf("expected TopN=7, got %d", s.TopN)
+	if s.TopN != 10 {
+		t.Errorf("expected TopN=10, got %d", s.TopN)
 	}
 	if len(s.Entries) != 0 {
 		t.Errorf("expected empty entries, got %d", len(s.Entries))

--- a/pkg/skill/stats_test.go
+++ b/pkg/skill/stats_test.go
@@ -1,0 +1,248 @@
+package skill
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStatsLoadNonexistentFile(t *testing.T) {
+	s := LoadStats("/tmp/ai-skill-stats-nonexistent-" + t.Name() + ".json")
+	if s.TopN != 7 {
+		t.Errorf("expected TopN=7, got %d", s.TopN)
+	}
+	if len(s.Entries) != 0 {
+		t.Errorf("expected empty entries, got %d", len(s.Entries))
+	}
+	if s.Version != statsVersion {
+		t.Errorf("expected Version=%d, got %d", statsVersion, s.Version)
+	}
+}
+
+func TestStatsLoadEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.json")
+	if err := os.WriteFile(path, []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+	s := LoadStats(path)
+	if s.TopN != 7 {
+		t.Errorf("expected TopN=7, got %d", s.TopN)
+	}
+	if len(s.Entries) != 0 {
+		t.Errorf("expected empty entries, got %d", len(s.Entries))
+	}
+}
+
+func TestStatsLoadMalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.json")
+	if err := os.WriteFile(path, []byte("{not valid json}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	s := LoadStats(path)
+	if s.TopN != 7 {
+		t.Errorf("expected TopN=7, got %d", s.TopN)
+	}
+	if len(s.Entries) != 0 {
+		t.Errorf("expected empty entries, got %d", len(s.Entries))
+	}
+}
+
+func TestStatsRecordUsageCreatesEntry(t *testing.T) {
+	s := &SkillStatsFile{
+		Version:  statsVersion,
+		TopN:     defaultTopN,
+		Entries:  make(map[string]*SkillUsageEntry),
+		FilePath: filepath.Join(t.TempDir(), "stats.json"),
+	}
+
+	s.RecordUsage("my-skill")
+
+	entry, ok := s.Entries["my-skill"]
+	if !ok {
+		t.Fatal("expected entry for my-skill")
+	}
+	if entry.Count != 1 {
+		t.Errorf("expected Count=1, got %d", entry.Count)
+	}
+	if entry.Score != 1.0 {
+		t.Errorf("expected Score=1.0, got %f", entry.Score)
+	}
+}
+
+func TestStatsRecordUsageIncrementsCount(t *testing.T) {
+	s := &SkillStatsFile{
+		Version:  statsVersion,
+		TopN:     defaultTopN,
+		Entries:  make(map[string]*SkillUsageEntry),
+		FilePath: filepath.Join(t.TempDir(), "stats.json"),
+	}
+
+	s.RecordUsage("my-skill")
+	s.RecordUsage("my-skill")
+	s.RecordUsage("my-skill")
+
+	entry := s.Entries["my-skill"]
+	if entry.Count != 3 {
+		t.Errorf("expected Count=3, got %d", entry.Count)
+	}
+	if entry.Score != 3.0 {
+		t.Errorf("expected Score=3.0, got %f", entry.Score)
+	}
+}
+
+func TestStatsTimeDecayOldEntryLowerScore(t *testing.T) {
+	s := &SkillStatsFile{
+		Version:  statsVersion,
+		TopN:     defaultTopN,
+		Entries:  make(map[string]*SkillUsageEntry),
+		FilePath: filepath.Join(t.TempDir(), "stats.json"),
+	}
+
+	now := time.Now()
+
+	// Old skill: used 2 weeks ago (336 hours), Count=5
+	s.Entries["old-skill"] = &SkillUsageEntry{
+		Name:     "old-skill",
+		Count:    5,
+		LastUsed: now.Add(-336 * time.Hour),
+		Score:    5.0,
+	}
+
+	// Recent skill: used just now, Count=5
+	s.Entries["recent-skill"] = &SkillUsageEntry{
+		Name:     "recent-skill",
+		Count:    5,
+		LastUsed: now,
+		Score:    5.0,
+	}
+
+	top := s.TopSkills(2)
+	if len(top) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(top))
+	}
+	if top[0] != "recent-skill" {
+		t.Errorf("expected recent-skill first, got %s", top[0])
+	}
+	if top[1] != "old-skill" {
+		t.Errorf("expected old-skill second, got %s", top[1])
+	}
+
+	// Verify the decay math: old-skill should have Score * 0.5^(336/168) = 5 * 0.25 = 1.25
+	oldEffective := 5.0 * math.Pow(0.5, 336.0/168.0)
+	recentEffective := 5.0 * math.Pow(0.5, 0)
+	if math.Abs(oldEffective-1.25) > 0.01 {
+		t.Errorf("expected old effective ~1.25, got %f", oldEffective)
+	}
+	if math.Abs(recentEffective-5.0) > 0.01 {
+		t.Errorf("expected recent effective ~5.0, got %f", recentEffective)
+	}
+}
+
+func TestStatsTopSkillsOrderingAndLimit(t *testing.T) {
+	s := &SkillStatsFile{
+		Version:  statsVersion,
+		TopN:     defaultTopN,
+		Entries:  make(map[string]*SkillUsageEntry),
+		FilePath: filepath.Join(t.TempDir(), "stats.json"),
+	}
+
+	now := time.Now()
+
+	// Three skills with different scores
+	s.Entries["low"] = &SkillUsageEntry{
+		Name: "low", Count: 1, LastUsed: now, Score: 1.0,
+	}
+	s.Entries["high"] = &SkillUsageEntry{
+		Name: "high", Count: 10, LastUsed: now, Score: 10.0,
+	}
+	s.Entries["mid"] = &SkillUsageEntry{
+		Name: "mid", Count: 5, LastUsed: now, Score: 5.0,
+	}
+
+	// Top 2
+	top2 := s.TopSkills(2)
+	if len(top2) != 2 {
+		t.Fatalf("expected 2, got %d", len(top2))
+	}
+	if top2[0] != "high" || top2[1] != "mid" {
+		t.Errorf("expected [high, mid], got %v", top2)
+	}
+
+	// Top 0
+	top0 := s.TopSkills(0)
+	if len(top0) != 0 {
+		t.Errorf("expected empty for TopSkills(0), got %v", top0)
+	}
+
+	// Top negative
+	topNeg := s.TopSkills(-1)
+	if len(topNeg) != 0 {
+		t.Errorf("expected empty for TopSkills(-1), got %v", topNeg)
+	}
+
+	// Top larger than entries
+	topAll := s.TopSkills(10)
+	if len(topAll) != 3 {
+		t.Errorf("expected 3, got %d", len(topAll))
+	}
+	if topAll[0] != "high" || topAll[1] != "mid" || topAll[2] != "low" {
+		t.Errorf("expected [high, mid, low], got %v", topAll)
+	}
+}
+
+func TestStatsSaveLoadRoundtrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.json")
+
+	s := &SkillStatsFile{
+		Version:  statsVersion,
+		TopN:     defaultTopN,
+		Entries:  make(map[string]*SkillUsageEntry),
+		FilePath: path,
+	}
+
+	s.RecordUsage("skill-a")
+	s.RecordUsage("skill-b")
+	s.RecordUsage("skill-a")
+
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded := LoadStats(path)
+	if loaded.TopN != s.TopN {
+		t.Errorf("TopN mismatch: %d vs %d", loaded.TopN, s.TopN)
+	}
+
+	if len(loaded.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(loaded.Entries))
+	}
+
+	entryA := loaded.Entries["skill-a"]
+	if entryA == nil {
+		t.Fatal("skill-a not found")
+	}
+	if entryA.Count != 2 {
+		t.Errorf("skill-a Count: expected 2, got %d", entryA.Count)
+	}
+
+	entryB := loaded.Entries["skill-b"]
+	if entryB == nil {
+		t.Fatal("skill-b not found")
+	}
+	if entryB.Count != 1 {
+		t.Errorf("skill-b Count: expected 1, got %d", entryB.Count)
+	}
+
+	// Verify JSON is valid
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("saved file is not valid JSON: %v", err)
+	}
+}

--- a/pkg/tools/find_skill.go
+++ b/pkg/tools/find_skill.go
@@ -47,11 +47,17 @@ func NewFindSkillTool(skills []skill.Skill, stats *skill.SkillStatsFile) *FindSk
 	if home != "" {
 		indexPath = filepath.Join(home, ".ai", "skill-index.json")
 	}
-	return &FindSkillTool{
+		return &FindSkillTool{
 		skills:    skills,
 		stats:     stats,
 		indexPath: indexPath,
 	}
+}
+
+// SetIndexPath overrides the default skill-index.json path.
+// Useful for testing to avoid loading the real index.
+func (t *FindSkillTool) SetIndexPath(path string) {
+	t.indexPath = path
 }
 
 // Name returns the tool name.

--- a/pkg/tools/find_skill.go
+++ b/pkg/tools/find_skill.go
@@ -82,7 +82,7 @@ func (t *FindSkillTool) Parameters() map[string]any {
 				"description": "Exact skill name to load (used with load=true for direct loading)",
 			},
 		},
-		"required": []string{"query"},
+				"required": []string{},
 	}
 }
 

--- a/pkg/tools/find_skill.go
+++ b/pkg/tools/find_skill.go
@@ -26,10 +26,10 @@ type SkillIndexEntry struct {
 
 // SkillIndex represents the structure of ~/.ai/skill-index.json.
 type SkillIndex struct {
-	Version      int               `json:"version"`
+	Version     int               `json:"version"`
 	GeneratedAt string            `json:"generated_at"`
 	EntryCount  int               `json:"entry_count"`
-	Entries      []SkillIndexEntry `json:"entries"`
+	Entries     []SkillIndexEntry `json:"entries"`
 }
 
 // FindSkillTool lets the LLM discover skills by keyword search
@@ -38,6 +38,7 @@ type FindSkillTool struct {
 	skills    []skill.Skill
 	stats     *skill.SkillStatsFile
 	indexPath string // path to skill-index.json; defaults to ~/.ai/skill-index.json
+	skillsDir string // override for ~/.ai/skills/ (used in testing)
 }
 
 // NewFindSkillTool creates a new FindSkillTool with the given skills and stats.
@@ -47,7 +48,7 @@ func NewFindSkillTool(skills []skill.Skill, stats *skill.SkillStatsFile) *FindSk
 	if home != "" {
 		indexPath = filepath.Join(home, ".ai", "skill-index.json")
 	}
-		return &FindSkillTool{
+	return &FindSkillTool{
 		skills:    skills,
 		stats:     stats,
 		indexPath: indexPath,
@@ -58,6 +59,12 @@ func NewFindSkillTool(skills []skill.Skill, stats *skill.SkillStatsFile) *FindSk
 // Useful for testing to avoid loading the real index.
 func (t *FindSkillTool) SetIndexPath(path string) {
 	t.indexPath = path
+}
+
+// SetSkillsDir overrides the default ~/.ai/skills/ directory used for
+// disk fallback in executeLoad. Useful for testing.
+func (t *FindSkillTool) SetSkillsDir(dir string) {
+	t.skillsDir = dir
 }
 
 // Name returns the tool name.
@@ -88,7 +95,7 @@ func (t *FindSkillTool) Parameters() map[string]any {
 				"description": "Exact skill name to load (used with load=true for direct loading)",
 			},
 		},
-				"required": []string{},
+		"required": []string{},
 	}
 }
 
@@ -273,7 +280,11 @@ func (t *FindSkillTool) findLoadedSkill(name string) (skill.Skill, bool) {
 }
 
 // executeLoad returns the full content of a skill by exact name match.
+// It first checks loaded skills, then falls back to reading from disk
+// (~/.ai/skills/<name>/SKILL.md) for skills that weren't pre-loaded
+// (e.g., missing frontmatter) but exist on disk.
 func (t *FindSkillTool) executeLoad(name string) ([]agentctx.ContentBlock, error) {
+	// Phase 1: check loaded skills
 	for _, s := range t.skills {
 		if s.Name == name {
 			t.recordUsage(name)
@@ -284,6 +295,36 @@ func (t *FindSkillTool) executeLoad(name string) ([]agentctx.ContentBlock, error
 				},
 			}, nil
 		}
+	}
+
+	// Phase 2: fallback — read from disk using skill directory convention
+	home, _ := os.UserHomeDir()
+	skillsBase := t.skillsDir
+	if skillsBase == "" {
+		if home == "" {
+			return nil, fmt.Errorf("skill '%s' not found", name)
+		}
+		skillsBase = filepath.Join(home, ".ai", "skills")
+	}
+
+	// Try standard skill paths: <skillsDir>/<name>/SKILL.md and <skillsDir>/<name>.md
+	candidates := []string{
+		filepath.Join(skillsBase, name, "SKILL.md"),
+		filepath.Join(skillsBase, name+".md"),
+	}
+
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		t.recordUsage(name)
+		return []agentctx.ContentBlock{
+			agentctx.TextContent{
+				Type: "text",
+				Text: string(data),
+			},
+		}, nil
 	}
 
 	return nil, fmt.Errorf("skill '%s' not found", name)

--- a/pkg/tools/find_skill.go
+++ b/pkg/tools/find_skill.go
@@ -1,0 +1,318 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/skill"
+)
+
+// SkillIndexEntry represents one skill entry in the generated search index.
+type SkillIndexEntry struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Aliases     []string `json:"aliases"`
+	UseWhen     []string `json:"use_when"`
+	Categories  []string `json:"categories"`
+}
+
+// SkillIndex represents the structure of ~/.ai/skill-index.json.
+type SkillIndex struct {
+	Version      int               `json:"version"`
+	GeneratedAt string            `json:"generated_at"`
+	EntryCount  int               `json:"entry_count"`
+	Entries      []SkillIndexEntry `json:"entries"`
+}
+
+// FindSkillTool lets the LLM discover skills by keyword search
+// and optionally load full skill content.
+type FindSkillTool struct {
+	skills    []skill.Skill
+	stats     *skill.SkillStatsFile
+	indexPath string // path to skill-index.json; defaults to ~/.ai/skill-index.json
+}
+
+// NewFindSkillTool creates a new FindSkillTool with the given skills and stats.
+func NewFindSkillTool(skills []skill.Skill, stats *skill.SkillStatsFile) *FindSkillTool {
+	home, _ := os.UserHomeDir()
+	indexPath := ""
+	if home != "" {
+		indexPath = filepath.Join(home, ".ai", "skill-index.json")
+	}
+	return &FindSkillTool{
+		skills:    skills,
+		stats:     stats,
+		indexPath: indexPath,
+	}
+}
+
+// Name returns the tool name.
+func (t *FindSkillTool) Name() string {
+	return "find_skill"
+}
+
+// Description returns the tool description.
+func (t *FindSkillTool) Description() string {
+	return "Search and load agent skills by keyword. Use this to discover available skills before loading them. Returns matching skill names and descriptions; use load=true to read full skill content."
+}
+
+// Parameters returns the JSON Schema for the tool parameters.
+func (t *FindSkillTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "Keyword to search — matches against skill name, description, aliases, use-when triggers, and categories (case-insensitive substring)",
+			},
+			"load": map[string]any{
+				"type":        "boolean",
+				"description": "If true, returns full skill content instead of listing. Requires name parameter.",
+			},
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Exact skill name to load (used with load=true for direct loading)",
+			},
+		},
+		"required": []string{"query"},
+	}
+}
+
+// Execute runs the find_skill tool.
+func (t *FindSkillTool) Execute(ctx context.Context, args map[string]any) ([]agentctx.ContentBlock, error) {
+	query, _ := args["query"].(string)
+	load, _ := args["load"].(bool)
+
+	if load {
+		// In load mode, use the name parameter if provided, otherwise use query
+		name := query
+		if n, ok := args["name"].(string); ok && n != "" {
+			name = n
+		}
+		return t.executeLoad(name)
+	}
+
+	// Search mode: require query
+	if query == "" {
+		return nil, fmt.Errorf("query parameter is required")
+	}
+
+	return t.executeSearch(query)
+}
+
+// searchResult holds a matched skill with a relevance rank for sorting.
+// Lower rank = more relevant.
+type searchResult struct {
+	skill skill.Skill
+	rank  int
+}
+
+const (
+	rankExactName  = 0
+	rankAliasMatch = 1
+	rankCategory   = 2
+	rankUseWhen    = 3
+	rankDescMatch  = 4
+	rankNameMatch  = 5
+)
+
+// executeSearch searches all loaded skills for a case-insensitive substring match
+// on Name and Description, then enriches results from the skill index.
+// Returns up to 5 results sorted by relevance.
+func (t *FindSkillTool) executeSearch(query string) ([]agentctx.ContentBlock, error) {
+	lowerQuery := strings.ToLower(query)
+
+	// Phase 1: direct name/description matching on loaded skills
+	directMatches := make(map[string]bool) // names already found
+	var results []searchResult
+
+	for _, s := range t.skills {
+		lowerName := strings.ToLower(s.Name)
+		lowerDesc := strings.ToLower(s.Description)
+
+		if lowerName == lowerQuery {
+			results = append(results, searchResult{skill: s, rank: rankExactName})
+			directMatches[s.Name] = true
+		} else if strings.Contains(lowerName, lowerQuery) {
+			results = append(results, searchResult{skill: s, rank: rankNameMatch})
+			directMatches[s.Name] = true
+		} else if strings.Contains(lowerDesc, lowerQuery) {
+			results = append(results, searchResult{skill: s, rank: rankDescMatch})
+			directMatches[s.Name] = true
+		}
+	}
+
+	// Phase 2: enrich from skill index
+	idx := loadSkillIndex(t.indexPath)
+	if idx != nil {
+		for _, entry := range idx.Entries {
+			if directMatches[entry.Name] {
+				continue // already found via direct match
+			}
+
+			matchedRank := -1
+
+			// Check aliases
+			for _, alias := range entry.Aliases {
+				if strings.Contains(strings.ToLower(alias), lowerQuery) {
+					matchedRank = rankAliasMatch
+					break
+				}
+			}
+
+			// Check categories
+			if matchedRank < 0 {
+				for _, cat := range entry.Categories {
+					if strings.Contains(strings.ToLower(cat), lowerQuery) {
+						matchedRank = rankCategory
+						break
+					}
+				}
+			}
+
+			// Check use_when
+			if matchedRank < 0 {
+				for _, uw := range entry.UseWhen {
+					if strings.Contains(strings.ToLower(uw), lowerQuery) {
+						matchedRank = rankUseWhen
+						break
+					}
+				}
+			}
+
+			if matchedRank >= 0 {
+				// Find the loaded skill for this index entry
+				if s, ok := t.findLoadedSkill(entry.Name); ok {
+					results = append(results, searchResult{skill: s, rank: matchedRank})
+				} else {
+					// Index references a skill not currently loaded — include with index info
+					results = append(results, searchResult{
+						skill: skill.Skill{
+							Name:        entry.Name,
+							Description: entry.Description,
+						},
+						rank: matchedRank,
+					})
+				}
+				directMatches[entry.Name] = true
+			}
+		}
+	}
+
+	if len(results) == 0 {
+		return []agentctx.ContentBlock{
+			agentctx.TextContent{
+				Type: "text",
+				Text: fmt.Sprintf("No skills found matching '%s'. Try a different keyword.", query),
+			},
+		}, nil
+	}
+
+	// Sort by rank (relevance)
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].rank < results[j].rank
+	})
+
+	// Limit to 5 results
+	if len(results) > 5 {
+		results = results[:5]
+	}
+
+	var b strings.Builder
+	for _, r := range results {
+		m := r.skill
+		desc := m.Description
+		if utf8.RuneCountInString(desc) > 150 {
+			desc = string([]rune(desc)[:150]) + "..."
+		}
+		if m.FilePath != "" {
+			fmt.Fprintf(&b, "- %s: %s\n  Path: %s\n", m.Name, desc, m.FilePath)
+		} else {
+			fmt.Fprintf(&b, "- %s: %s\n  (from index — skill may not be currently loaded)\n", m.Name, desc)
+		}
+	}
+	b.WriteString("Use find_skill with name=<skill_name> and load=true to read the full skill.")
+
+	// Record usage for matched skills that are loaded
+	for _, r := range results {
+		if r.skill.FilePath != "" {
+			t.recordUsage(r.skill.Name)
+		}
+	}
+
+	return []agentctx.ContentBlock{
+		agentctx.TextContent{
+			Type: "text",
+			Text: b.String(),
+		},
+	}, nil
+}
+
+// findLoadedSkill looks up a skill by name in the loaded skills list.
+func (t *FindSkillTool) findLoadedSkill(name string) (skill.Skill, bool) {
+	for _, s := range t.skills {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return skill.Skill{}, false
+}
+
+// executeLoad returns the full content of a skill by exact name match.
+func (t *FindSkillTool) executeLoad(name string) ([]agentctx.ContentBlock, error) {
+	for _, s := range t.skills {
+		if s.Name == name {
+			t.recordUsage(name)
+			return []agentctx.ContentBlock{
+				agentctx.TextContent{
+					Type: "text",
+					Text: s.Content,
+				},
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("skill '%s' not found", name)
+}
+
+// recordUsage records skill usage in stats if stats is available.
+// Errors are silently ignored (fire-and-forget).
+func (t *FindSkillTool) recordUsage(skillName string) {
+	if t.stats == nil {
+		return
+	}
+	t.stats.RecordUsage(skillName)
+	_ = t.stats.Save()
+}
+
+// loadSkillIndex reads and parses the skill index file at the given path.
+// Returns nil if the file doesn't exist or is malformed (logs a warning).
+func loadSkillIndex(path string) *SkillIndex {
+	if path == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("failed to read skill index", "path", path, "error", err)
+		}
+		return nil
+	}
+
+	var idx SkillIndex
+	if err := json.Unmarshal(data, &idx); err != nil {
+		slog.Warn("failed to parse skill index", "path", path, "error", err)
+		return nil
+	}
+
+	return &idx
+}

--- a/pkg/tools/find_skill_test.go
+++ b/pkg/tools/find_skill_test.go
@@ -292,7 +292,8 @@ func TestFindSkill_SearchLimitsToFive(t *testing.T) {
 			Content:     "content",
 		})
 	}
-	tool := NewFindSkillTool(skills, nil)
+		tool := NewFindSkillTool(skills, nil)
+	tool.SetIndexPath("") // disable index loading to test pure skill search
 
 	result, err := tool.Execute(context.Background(), map[string]any{
 		"query": "skill",

--- a/pkg/tools/find_skill_test.go
+++ b/pkg/tools/find_skill_test.go
@@ -1,0 +1,545 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/skill"
+)
+
+// helper extracts text from the first ContentBlock.
+func firstText(blocks []agentctx.ContentBlock) string {
+	if len(blocks) == 0 {
+		return ""
+	}
+	if tc, ok := blocks[0].(agentctx.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}
+
+func testSkills() []skill.Skill {
+	return []skill.Skill{
+		{
+			Name:        "review",
+			Description: "Code review skill using codex-rs methodology with ag CLI",
+			FilePath:    "/home/user/.ai/skills/review/SKILL.md",
+			Content:     "# Review Skill\n\nThis is the full review skill content.",
+		},
+		{
+			Name:        "plan",
+			Description: "Read design.md, produce tasks.yml with plan-lint validation",
+			FilePath:    "/home/user/.ai/skills/plan/SKILL.md",
+			Content:     "# Plan Skill\n\nThis is the full plan skill content.",
+		},
+		{
+			Name:        "github",
+			Description: "Interact with GitHub using the gh CLI",
+			FilePath:    "/home/user/.ai/skills/github/SKILL.md",
+			Content:     "# GitHub Skill\n\nThis is the full github skill content.",
+		},
+		{
+			Name:        "test-driven-development",
+			Description: "Use during IMPLEMENTATION phase. Write test first, watch it fail, then write minimal code to pass.",
+			FilePath:    "/home/user/.ai/skills/tdd/SKILL.md",
+			Content:     "# TDD Skill\n\nFull TDD content here.",
+		},
+	}
+}
+
+func newTestStats(t *testing.T) *skill.SkillStatsFile {
+	t.Helper()
+	return skill.LoadStats(filepath.Join(t.TempDir(), "stats.json"))
+}
+
+// newTestToolWithIndex creates a FindSkillTool with a custom index path for testing.
+func newTestToolWithIndex(skills []skill.Skill, stats *skill.SkillStatsFile, indexDir string) *FindSkillTool {
+	indexPath := filepath.Join(indexDir, "skill-index.json")
+	return &FindSkillTool{
+		skills:    skills,
+		stats:     stats,
+		indexPath: indexPath,
+	}
+}
+
+// writeTestIndex writes a skill-index.json file in the given directory.
+func writeTestIndex(t *testing.T, dir string, entries []SkillIndexEntry) {
+	t.Helper()
+	idx := SkillIndex{
+		Version:     1,
+		GeneratedAt: "2025-01-01T00:00:00Z",
+		EntryCount:  len(entries),
+		Entries:     entries,
+	}
+	data, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatalf("Failed to marshal index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "skill-index.json"), data, 0644); err != nil {
+		t.Fatalf("Failed to write index: %v", err)
+	}
+}
+
+func TestFindSkill_SearchReturnsMatchingSkills(t *testing.T) {
+	tool := NewFindSkillTool(testSkills(), nil)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "review",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "review") {
+		t.Errorf("Expected 'review' in result, got: %s", text)
+	}
+	if !strings.Contains(text, "SKILL.md") {
+		t.Errorf("Expected file path in result, got: %s", text)
+	}
+}
+
+func TestFindSkill_SearchNoMatches(t *testing.T) {
+	tool := NewFindSkillTool(testSkills(), nil)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "nonexistent-skill-xyz",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "No skills found matching") {
+		t.Errorf("Expected no-matches message, got: %s", text)
+	}
+	if !strings.Contains(text, "nonexistent-skill-xyz") {
+		t.Errorf("Expected query echoed in message, got: %s", text)
+	}
+}
+
+func TestFindSkill_LoadReturnsFullContent(t *testing.T) {
+	tool := NewFindSkillTool(testSkills(), nil)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "anything",
+		"load":  true,
+		"name":  "review",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+		if !strings.Contains(text, "full review skill content") {
+		t.Errorf("Expected full skill content, got: %s", text)
+	}
+}
+
+func TestFindSkill_LoadNonexistentReturnsError(t *testing.T) {
+	tool := NewFindSkillTool(testSkills(), nil)
+
+	_, err := tool.Execute(context.Background(), map[string]any{
+		"query": "anything",
+		"load":  true,
+		"name":  "does-not-exist",
+	})
+	if err == nil {
+		t.Fatal("Expected error for nonexistent skill load, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("Expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestFindSkill_CaseInsensitiveSearch(t *testing.T) {
+	tool := NewFindSkillTool(testSkills(), nil)
+
+	// Search with uppercase should find lowercase skill names
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "GITHUB",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "github") {
+		t.Errorf("Expected 'github' in result for uppercase query, got: %s", text)
+	}
+
+	// Mixed case search on description
+	result, err = tool.Execute(context.Background(), map[string]any{
+		"query": "implementation",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text = firstText(result)
+	if !strings.Contains(text, "test-driven-development") {
+		t.Errorf("Expected 'test-driven-development' in result, got: %s", text)
+	}
+}
+
+func TestFindSkill_RecordUsageCalledOnSearch(t *testing.T) {
+	stats := newTestStats(t)
+	tool := NewFindSkillTool(testSkills(), stats)
+
+	_, err := tool.Execute(context.Background(), map[string]any{
+		"query": "review",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	entry, ok := stats.Entries["review"]
+	if !ok {
+		t.Fatal("Expected 'review' usage entry in stats")
+	}
+	if entry.Count != 1 {
+		t.Errorf("Expected count=1, got %d", entry.Count)
+	}
+}
+
+func TestFindSkill_RecordUsageOnLoad(t *testing.T) {
+	stats := newTestStats(t)
+	tool := NewFindSkillTool(testSkills(), stats)
+
+	_, err := tool.Execute(context.Background(), map[string]any{
+		"query": "x",
+		"load":  true,
+		"name":  "plan",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	entry, ok := stats.Entries["plan"]
+	if !ok {
+		t.Fatal("Expected 'plan' usage entry in stats after load")
+	}
+	if entry.Count != 1 {
+		t.Errorf("Expected count=1, got %d", entry.Count)
+	}
+}
+
+func TestFindSkill_NilStatsDoesNotCrash(t *testing.T) {
+	tool := NewFindSkillTool(testSkills(), nil)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "review",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("Expected non-empty result")
+	}
+}
+
+func TestFindSkill_EmptySkillsList(t *testing.T) {
+	tool := NewFindSkillTool([]skill.Skill{}, nil)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "anything",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "No skills found matching") {
+		t.Errorf("Expected no-matches message for empty skills, got: %s", text)
+	}
+}
+
+func TestFindSkill_NoQueryReturnsError(t *testing.T) {
+	tool := NewFindSkillTool(testSkills(), nil)
+
+	_, err := tool.Execute(context.Background(), map[string]any{})
+	if err == nil {
+		t.Fatal("Expected error when no query provided, got nil")
+	}
+	if !strings.Contains(err.Error(), "query") {
+		t.Errorf("Expected error about query parameter, got: %v", err)
+	}
+}
+
+func TestFindSkill_SearchFooterHint(t *testing.T) {
+	tool := NewFindSkillTool(testSkills(), nil)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "github",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "load=true") {
+		t.Errorf("Expected footer with load=true hint, got: %s", text)
+	}
+}
+
+func TestFindSkill_SearchLimitsToFive(t *testing.T) {
+	// Create 10 skills all matching "skill"
+	var skills []skill.Skill
+	for i := 0; i < 10; i++ {
+		skills = append(skills, skill.Skill{
+			Name:        fmt.Sprintf("skill-%d", i),
+			Description: "A test skill",
+			FilePath:    fmt.Sprintf("/path/skill-%d.md", i),
+			Content:     "content",
+		})
+	}
+	tool := NewFindSkillTool(skills, nil)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "skill",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+
+	// Count how many skill names appear (lines starting with "- skill-")
+	count := strings.Count(text, "- skill-")
+	if count != 5 {
+		t.Errorf("Expected exactly 5 results, got %d", count)
+	}
+}
+
+// --- Index-aware tests ---
+
+func TestFindSkill_IndexAliasMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeTestIndex(t, dir, []SkillIndexEntry{
+		{
+			Name:        "systematic-debugging",
+			Description: "Use when encountering bugs, test failures, or unexpected behavior",
+			Aliases:     []string{"troubleshoot", "debug", "调试"},
+			UseWhen:     []string{"encountering bugs", "test failures"},
+			Categories:  []string{"debugging"},
+		},
+	})
+
+	tool := newTestToolWithIndex(testSkills(), nil, dir)
+
+	// Search for alias "debug" — should find systematic-debugging via index
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "debug",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "systematic-debugging") {
+		t.Errorf("Expected 'systematic-debugging' found via alias 'debug', got: %s", text)
+	}
+	if !strings.Contains(text, "from index") {
+		t.Errorf("Expected 'from index' note for unloaded skill, got: %s", text)
+	}
+}
+
+func TestFindSkill_IndexUseWhenMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeTestIndex(t, dir, []SkillIndexEntry{
+		{
+			Name:        "systematic-debugging",
+			Description: "Use when encountering bugs, test failures, or unexpected behavior",
+			Aliases:     []string{"troubleshoot"},
+			UseWhen:     []string{"encountering bugs", "test failures", "unexpected behavior"},
+			Categories:  []string{"debugging"},
+		},
+	})
+
+	tool := newTestToolWithIndex(testSkills(), nil, dir)
+
+	// Search for "test failures" from use_when
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "test failures",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "systematic-debugging") {
+		t.Errorf("Expected 'systematic-debugging' found via use_when 'test failures', got: %s", text)
+	}
+}
+
+func TestFindSkill_IndexCategoryMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeTestIndex(t, dir, []SkillIndexEntry{
+		{
+			Name:        "systematic-debugging",
+			Description: "Use when encountering bugs, test failures, or unexpected behavior",
+			Aliases:     []string{"troubleshoot"},
+			UseWhen:     []string{"encountering bugs"},
+			Categories:  []string{"debugging", "development"},
+		},
+	})
+
+	tool := newTestToolWithIndex(testSkills(), nil, dir)
+
+	// Search for "debugging" from category
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "debugging",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "systematic-debugging") {
+		t.Errorf("Expected 'systematic-debugging' found via category 'debugging', got: %s", text)
+	}
+}
+
+func TestFindSkill_NoIndexFile_FallsBackToDirectMatch(t *testing.T) {
+	dir := t.TempDir()
+	// Don't write an index file — should still work with direct matching
+	tool := newTestToolWithIndex(testSkills(), nil, dir)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "review",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "review") {
+		t.Errorf("Expected 'review' in result without index, got: %s", text)
+	}
+}
+
+func TestFindSkill_MalformedIndexFile_FallsBack(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "skill-index.json"), []byte("not valid json{"), 0644); err != nil {
+		t.Fatalf("Failed to write malformed index: %v", err)
+	}
+
+	tool := newTestToolWithIndex(testSkills(), nil, dir)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "review",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "review") {
+		t.Errorf("Expected 'review' in result with malformed index, got: %s", text)
+	}
+}
+
+func TestFindSkill_Deduplication(t *testing.T) {
+	dir := t.TempDir()
+	// Index entry for "review" which also exists in loaded skills
+	writeTestIndex(t, dir, []SkillIndexEntry{
+		{
+			Name:        "review",
+			Description: "Code review skill",
+			Aliases:     []string{"code review", "pr review"},
+			UseWhen:     []string{"code review needed"},
+			Categories:  []string{"review"},
+		},
+	})
+
+	tool := newTestToolWithIndex(testSkills(), nil, dir)
+
+	// Search for "review" — should find review only once
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "review",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+
+	// Count occurrences of "- review:" in result
+	count := strings.Count(text, "- review:")
+	if count != 1 {
+		t.Errorf("Expected exactly 1 occurrence of 'review' (deduped), got %d.\nText: %s", count, text)
+	}
+
+	// Should show with file path (loaded skill), not "from index"
+	if strings.Contains(text, "from index") {
+		t.Errorf("Should not show 'from index' for loaded skill, got: %s", text)
+	}
+}
+
+func TestFindSkill_IndexMatchLoadedSkill_ShowsPath(t *testing.T) {
+	dir := t.TempDir()
+	// Index has "github" alias "gh cli", and the skill is loaded
+	writeTestIndex(t, dir, []SkillIndexEntry{
+		{
+			Name:        "github",
+			Description: "Interact with GitHub using the gh CLI",
+			Aliases:     []string{"gh cli", "pull request"},
+			Categories:  []string{"git"},
+		},
+	})
+
+	tool := newTestToolWithIndex(testSkills(), nil, dir)
+
+	// Search for "gh cli" — should find github via alias, show file path
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "gh cli",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "github") {
+		t.Errorf("Expected 'github' found via alias, got: %s", text)
+	}
+	if !strings.Contains(text, "SKILL.md") {
+		t.Errorf("Expected file path for loaded skill, got: %s", text)
+	}
+}
+
+func TestFindSkill_SortingExactNameFirst(t *testing.T) {
+	dir := t.TempDir()
+	writeTestIndex(t, dir, []SkillIndexEntry{
+		{
+			Name:       "github",
+			Aliases:    []string{"pr review"},
+			Categories: []string{"git"},
+		},
+	})
+
+	skills := []skill.Skill{
+		{
+			Name:        "github",
+			Description: "GitHub tool",
+			FilePath:    "/a/github.md",
+		},
+		{
+			Name:        "pr-review-helper",
+			Description: "PR review helper",
+			FilePath:    "/a/pr-review.md",
+		},
+	}
+	tool := newTestToolWithIndex(skills, nil, dir)
+
+	// "github" should be the first result (exact name match)
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "github",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	lines := strings.Split(text, "\n")
+	// First non-empty line should mention github
+	firstLine := ""
+	for _, l := range lines {
+		if strings.HasPrefix(l, "- ") {
+			firstLine = l
+			break
+		}
+	}
+	if !strings.Contains(firstLine, "github") {
+		t.Errorf("Expected 'github' as first result (exact name match), first line: %s", firstLine)
+	}
+}

--- a/pkg/tools/find_skill_test.go
+++ b/pkg/tools/find_skill_test.go
@@ -134,7 +134,7 @@ func TestFindSkill_LoadReturnsFullContent(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	text := firstText(result)
-		if !strings.Contains(text, "full review skill content") {
+	if !strings.Contains(text, "full review skill content") {
 		t.Errorf("Expected full skill content, got: %s", text)
 	}
 }
@@ -292,7 +292,7 @@ func TestFindSkill_SearchLimitsToFive(t *testing.T) {
 			Content:     "content",
 		})
 	}
-		tool := NewFindSkillTool(skills, nil)
+	tool := NewFindSkillTool(skills, nil)
 	tool.SetIndexPath("") // disable index loading to test pure skill search
 
 	result, err := tool.Execute(context.Background(), map[string]any{
@@ -542,5 +542,74 @@ func TestFindSkill_SortingExactNameFirst(t *testing.T) {
 	}
 	if !strings.Contains(firstLine, "github") {
 		t.Errorf("Expected 'github' as first result (exact name match), first line: %s", firstLine)
+	}
+}
+
+// TestFindSkill_LoadFallbackToDisk tests that executeLoad falls back to reading
+// from disk when a skill exists on disk but wasn't pre-loaded (e.g., missing frontmatter).
+func TestFindSkill_LoadFallbackToDisk(t *testing.T) {
+	// Create a temp skills directory with a skill that has no frontmatter
+	tmpSkills := t.TempDir()
+	skillDir := filepath.Join(tmpSkills, "my-unloaded-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a SKILL.md without YAML frontmatter (simulates session-analyzer)
+	skillContent := "# My Unloaded Skill\n\nThis skill has no frontmatter.\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create tool with empty loaded skills and custom skills dir
+	tool := NewFindSkillTool([]skill.Skill{}, nil)
+	tool.SetIndexPath("")
+	tool.SetSkillsDir(tmpSkills)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"load": true,
+		"name": "my-unloaded-skill",
+	})
+	if err != nil {
+		t.Fatalf("executeLoad should fall back to disk, got error: %v", err)
+	}
+
+	text := firstText(result)
+	if !strings.Contains(text, "My Unloaded Skill") {
+		t.Errorf("Expected loaded content to contain 'My Unloaded Skill', got: %s", text)
+	}
+	if !strings.Contains(text, "no frontmatter") {
+		t.Errorf("Expected loaded content to contain 'no frontmatter', got: %s", text)
+	}
+}
+
+// TestFindSkill_LoadFallbackToDiskReal tests the disk fallback using
+// the real session-analyzer skill that exists on disk but lacks frontmatter.
+func TestFindSkill_LoadFallbackToDiskReal(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("Cannot determine home directory")
+	}
+
+	skillPath := filepath.Join(home, ".ai", "skills", "session-analyzer", "SKILL.md")
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Skipf("session-analyzer skill not found at %s", skillPath)
+	}
+
+	// Create tool with empty loaded skills
+	tool := NewFindSkillTool([]skill.Skill{}, nil)
+	tool.SetIndexPath("")
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"load": true,
+		"name": "session-analyzer",
+	})
+	if err != nil {
+		t.Fatalf("executeLoad should fall back to disk for session-analyzer, got error: %v", err)
+	}
+
+	text := firstText(result)
+	if !strings.Contains(text, "Session Analyzer") {
+		t.Errorf("Expected loaded content to contain 'Session Analyzer', got: %s", text[:min(len(text), 200, len(text))])
 	}
 }

--- a/skills/index-skills/SKILL.md
+++ b/skills/index-skills/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: index-skills
+description: Generate a rich search index of all skills at ~/.ai/skill-index.json. Use when skills change or when /skills reindex is triggered. Produces aliases, use-when triggers, and categories for each skill via LLM intelligence.
+---
+
+# Index Skills — Generate Skill Search Index
+
+## Overview
+
+Read all `SKILL.md` files from `~/.ai/skills/`, analyze them, and produce a rich search index at `~/.ai/skill-index.json`. This index enables semantic skill discovery — synonym matching, Chinese↔English equivalents, and use-case intent — without requiring an LLM call at query time.
+
+## When to Use
+
+- User triggers `/skills reindex`
+- After adding, removing, or significantly updating skills
+- On first run when `~/.ai/skill-index.json` does not exist
+
+## Process
+
+### Step 1: Discover all skill files
+
+Use the `bash` tool to list all SKILL.md files:
+
+```bash
+find ~/.ai/skills -maxdepth 2 -name 'SKILL.md' -type f | sort
+```
+
+If no files found, produce an empty index (see Step 4) and stop.
+
+### Step 2: Read every SKILL.md
+
+For each discovered file, read its full content using the `read` tool. Extract from each file:
+- **name**: from frontmatter `name:` field (or directory name as fallback)
+- **description**: from frontmatter `description:` field
+- **Full body text**: everything after the frontmatter — needed to infer use-cases, aliases, and categories
+
+Read all files in parallel batches for speed.
+
+### Step 3: Analyze and generate the index
+
+Using your knowledge of ALL skills read in Step 2, produce one JSON object per skill with these fields:
+
+```json
+{
+  "name": "skill-directory-name",
+  "description": "One-sentence description of what the skill does",
+  "aliases": ["synonym1", "synonym2", "debug", "调试", "troubleshoot"],
+  "use_when": [
+    "encountering bugs",
+    "test failures",
+    "unexpected behavior"
+  ],
+  "categories": ["debugging", "development"]
+}
+```
+
+#### Field rules
+
+- **name**: Must match the directory name under `~/.ai/skills/`
+- **description**: Concise, in English, derived from frontmatter + first heading
+- **aliases**: 3–8 entries. Include:
+  - Common abbreviations and synonyms
+  - Chinese translations if the skill description or body contains Chinese
+  - Related verbs/nouns a user might search for
+  - Do NOT include the name itself (it's already matched)
+- **use_when**: 2–5 short phrases describing WHEN a user would want this skill. Think about user intent, not skill mechanics.
+- **categories**: 1–3 broad category labels. Use consistent categories across skills (e.g., "development", "debugging", "testing", "orchestration", "git", "documentation", "system", "planning").
+
+### Step 4: Write the index file
+
+Write the final JSON to `~/.ai/skill-index.json` using the `write` tool with this structure:
+
+```json
+{
+  "version": 1,
+  "generated_at": "2025-07-11T12:00:00Z",
+  "entry_count": 21,
+  "entries": [
+    { "...per-skill object..." }
+  ]
+}
+```
+
+- `generated_at`: ISO 8601 timestamp of generation time (use current time)
+- `entry_count`: Must equal `entries.length` — verify before writing
+- Overwrite any existing file (idempotent operation)
+
+### Step 5: Report results
+
+After writing the file, report:
+- How many skills were indexed
+- The output file path (`~/.ai/skill-index.json`)
+- A brief summary of the categories found
+
+Example output:
+
+```
+Indexed 21 skills → ~/.ai/skill-index.json
+Categories: orchestration (3), development (5), debugging (2), planning (2), git (2), system (3), documentation (2), testing (1), review (1)
+```
+
+## Edge Cases
+
+- **No skills found**: Write an index with `entry_count: 0` and empty `entries` array
+- **Skill missing frontmatter**: Use directory name as `name`, first heading paragraph as `description`
+- **Duplicate names**: Should not happen; if it does, keep both with disambiguating descriptions
+- **Re-run**: Always overwrites previous index; operation is idempotent


### PR DESCRIPTION
## Summary

Implements progressive disclosure for skills to reduce token consumption as the agent evolves from coding-only to general-purpose.

### Core Changes

**Usage Statistics (`pkg/skill/stats.go`)**
- Time-decay scoring with 7-day half-life (exponential decay)
- Recent usage weighted exponentially higher than old usage
- Thread-safe stats file with atomic JSON writes

**Skill Discovery (`pkg/tools/find_skill.go`)**
- `find_skill` tool for searching skills by keyword against LLM-maintained index
- Supports `load=true` to read full skill content on demand
- Records usage stats on every search/load

**Smart Filtering (`pkg/skill/formatter.go`)**
- Top-N filtering (default 7 skills in system prompt)
- Usage-frequency ranking: frequently used skills always shown
- Unused/new skills progressively hidden, still discoverable via `find_skill`

**Search Index (`skills/index-skills/`)**
- LLM-generatable keyword index for skill discovery
- Each skill has keywords, category, and use-when triggers

**Integration**
- Wired into `ai` agent prompt builder (`pkg/prompt/builder.go`)
- Wired into `aiclaw` agent (`claw/cmd/aiclaw/main.go`)
- All `FormatForPrompt` call sites updated

### Bug Fixes

**`ai serve` blocking fix (`cmd/ai/run.go`)**
- `ai serve` blocked forever on `cmd.Wait()` because the RPC subprocess never exits
- Added goroutine to poll events.jsonl for `agent_end` and close stdin pipe
- Critical for scheduler spawnReviewer/spawnWorker which use `ai serve`

## Files Changed (14 files, +1743 -54)

| File | Change |
|------|--------|
| `pkg/skill/stats.go` | New - usage tracking with time-decay |
| `pkg/skill/stats_test.go` | New - comprehensive stats tests |
| `pkg/tools/find_skill.go` | New - skill discovery tool |
| `pkg/tools/find_skill_test.go` | New - 545 lines of test coverage |
| `pkg/skill/formatter.go` | Updated - top-N filtering with stats |
| `pkg/prompt/builder.go` | Updated - wire stats into ai agent |
| `pkg/context/context.go` | Updated - add FindSkillTool |
| `cmd/ai/rpc_handlers.go` | Updated - register find_skill tool |
| `cmd/ai/run.go` | Fixed - agent_end stdin close |
| `claw/cmd/aiclaw/main.go` | Updated - wire stats into aiclaw |
| `skills/index-skills/SKILL.md` | New - search index skill |

## Test Plan

- [x] `go test ./pkg/skill/...` - all pass
- [x] `go test ./pkg/tools/...` - all pass
- [x] `go test ./cmd/ai/...` - all pass
- [x] `go build ./...` - clean compile
- [x] Full scheduler run completed 9/9 tasks with progressive disclosure active