### PR TITLE
Fix: [BUG] /context slash command shows all-zero stats

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -1677,7 +1677,10 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	registerHiddenAlias("get_messages", "Get session messages (internal)", "messages")
 	registerHiddenAlias("get_state", "Get agent state (internal)", "session")
 	registerHiddenAlias("get_commands", "List commands (internal)", "skills")
-	registerHiddenAlias("get_session_stats", "Get session stats (internal)", "session")
+	// get_session_stats: compute real SessionStats from messages and metrics.
+	server.RegisterHiddenSlash("get_session_stats", "Get session stats (internal)", func(args string) (any, error) {
+		return computeSessionStats(ag, sess, compactor, registry, currentContextWindow, systemPrompt, ws), nil
+	})
 	registerHiddenAlias("new_session", "Create new session (internal)", "new")
 	registerHiddenAlias("list_sessions", "List sessions (internal)", "resume")
 	registerHiddenAlias("switch_session", "Switch session (internal)", "resume")
@@ -2292,4 +2295,122 @@ func getWorkflowStatus(cwd string) (*rpc.WorkflowState, error) {
 	}
 
 	return state, nil
+}
+
+// computeSessionStats builds a SessionStats from live session data.
+func computeSessionStats(ag *agent.Agent, sess *session.Session, compactor *compact.Compactor, registry *tools.Registry, contextWindow int, systemPrompt string, ws *tools.Workspace) *rpc.SessionStats {
+	messages := ag.GetMessages()
+
+	var userMsgs, assistantMsgs, toolCalls, toolResults int
+	var totalInput, totalOutput, totalCacheRead, totalCacheWrite int
+	var totalCost float64
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case "user":
+			userMsgs++
+		case "assistant":
+			assistantMsgs++
+			// Count tool calls in assistant messages
+			calls := msg.ExtractToolCalls()
+			toolCalls += len(calls)
+		case "toolResult":
+			toolResults++
+		}
+
+		// Accumulate token usage from assistant messages
+		if msg.Usage != nil {
+			totalInput += msg.Usage.InputTokens
+			totalOutput += msg.Usage.OutputTokens
+			totalCacheRead += msg.Usage.CacheRead
+			totalCacheWrite += msg.Usage.CacheWrite
+			totalCost += msg.Usage.Cost.Total
+		}
+	}
+
+	// Estimate active window tokens
+	activeWindowTokens := 0
+	if compactor != nil {
+		activeWindowTokens = compactor.EstimateContextTokensOld(messages)
+	}
+
+	// Estimate system prompt tokens
+	systemPromptTokens := 0
+	if systemPrompt != "" {
+		systemPromptTokens = estimateTokenCount(systemPrompt)
+	}
+
+	// Estimate system tools tokens from tool definitions
+	systemToolsTokens := 0
+	if registry != nil {
+		toolDefs := registry.ToLLMTools()
+		if data, err := json.Marshal(toolDefs); err == nil {
+			systemToolsTokens = estimateTokenCount(string(data))
+		}
+	}
+
+	// Compute token rate from metrics
+	var tokenRate *rpc.TokenRateStats
+	if metrics := ag.GetMetrics(); metrics != nil {
+		llmMetrics := metrics.GetLLMMetrics()
+		tokenRate = &rpc.TokenRateStats{
+			ActiveInputPerSec:   llmMetrics.ActiveInputTokensPerSec,
+			ActiveOutputPerSec:  llmMetrics.ActiveOutputTokensPerSec,
+			ActiveTotalPerSec:   llmMetrics.ActiveTotalTokensPerSec,
+			WallInputPerSec:     llmMetrics.WallInputTokensPerSec,
+			WallOutputPerSec:    llmMetrics.WallOutputTokensPerSec,
+			WallTotalPerSec:     llmMetrics.WallTotalTokensPerSec,
+			LastInputPerSec:     llmMetrics.LastInputTokensPerSec,
+			LastOutputPerSec:    llmMetrics.LastOutputTokensPerSec,
+			LastTotalPerSec:     llmMetrics.LastTotalTokensPerSec,
+			RecentWindowSeconds: llmMetrics.RecentWindowSeconds,
+			RecentInputPerSec:   llmMetrics.RecentInputTokensPerSec,
+			RecentOutputPerSec:  llmMetrics.RecentOutputTokensPerSec,
+			RecentTotalPerSec:   llmMetrics.RecentTotalTokensPerSec,
+		}
+	}
+
+	compactionCount := 0
+	if sess != nil {
+		compactionCount = sess.GetCompactionCount()
+	}
+
+	var sessionFile, sessionID string
+	if sess != nil {
+		sessionFile = sess.GetPath()
+		sessionID = sess.GetID()
+	}
+
+	return &rpc.SessionStats{
+		SessionFile:       sessionFile,
+		SessionID:         sessionID,
+		UserMessages:      userMsgs,
+		AssistantMessages: assistantMsgs,
+		ToolCalls:         toolCalls,
+		ToolResults:       toolResults,
+		TotalMessages:     userMsgs + assistantMsgs + toolResults,
+		CompactionCount:   compactionCount,
+		Tokens: rpc.SessionTokenStats{
+			Input:              totalInput,
+			Output:             totalOutput,
+			CacheRead:          totalCacheRead,
+			CacheWrite:         totalCacheWrite,
+			Total:              totalInput + totalOutput,
+			ActiveWindowTokens: activeWindowTokens,
+			SystemPromptTokens: systemPromptTokens,
+			SystemToolsTokens:  systemToolsTokens,
+		},
+		TokenRate: tokenRate,
+		Cost:      totalCost,
+		Workspace: ws.GetGitRoot(),
+		CurrentWorkdir: ws.GetCWD(),
+	}
+}
+
+// estimateTokenCount provides a rough token estimation for a string.
+func estimateTokenCount(s string) int {
+	if len(s) == 0 {
+		return 0
+	}
+	return int(float64(len(s)) / 4.0)
 }

--- a/cmd/ai/session_stats_test.go
+++ b/cmd/ai/session_stats_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tiancaiamao/ai/pkg/agent"
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/compact"
+	"github.com/tiancaiamao/ai/pkg/llm"
+	"github.com/tiancaiamao/ai/pkg/rpc"
+	"github.com/tiancaiamao/ai/pkg/session"
+	"github.com/tiancaiamao/ai/pkg/tools"
+)
+
+func TestComputeSessionStats_BasicCounts(t *testing.T) {
+	// Create a workspace
+	ws, err := tools.NewWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create workspace: %v", err)
+	}
+
+	// Create an agent with messages
+	ctx := agentctx.NewAgentContext("system prompt")
+	// Add user message
+	ctx.AddMessage(agentctx.AgentMessage{
+		Role:      "user",
+		Content:   []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "hello"}},
+	})
+	// Add assistant message with usage
+	assistantMsg := agentctx.AgentMessage{
+		Role: "assistant",
+		Content: []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "hi there"},
+		},
+		Usage: &agentctx.Usage{
+			InputTokens:  10,
+			OutputTokens: 20,
+			CacheRead:    5,
+			Cost:         agentctx.Cost{Total: 0.01},
+		},
+	}
+	ctx.AddMessage(assistantMsg)
+	// Add tool result
+	ctx.AddMessage(agentctx.AgentMessage{
+		Role:       "toolResult",
+		ToolCallID: "call_1",
+		ToolName:   "bash",
+		Content:    []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "output"}},
+	})
+
+	ag := agent.NewAgentFromConfigWithContext(
+		llm.Model{ID: "test", ContextWindow: 200000},
+		"test-key",
+		ctx,
+		agent.DefaultLoopConfig(),
+	)
+
+	// Create session
+	sess := session.NewSession("")
+
+	// Create compactor
+	compactor := compact.NewCompactor(compact.DefaultConfig(), llm.Model{ID: "test"}, "", "system prompt", 200000)
+
+	// Create registry
+	registry := tools.NewRegistry()
+
+	stats := computeSessionStats(ag, sess, compactor, registry, 200000, "system prompt", ws)
+
+	// Verify message counts
+	if stats.UserMessages != 1 {
+		t.Errorf("expected UserMessages=1, got %d", stats.UserMessages)
+	}
+	if stats.AssistantMessages != 1 {
+		t.Errorf("expected AssistantMessages=1, got %d", stats.AssistantMessages)
+	}
+	if stats.ToolResults != 1 {
+		t.Errorf("expected ToolResults=1, got %d", stats.ToolResults)
+	}
+	if stats.TotalMessages != 3 {
+		t.Errorf("expected TotalMessages=3, got %d", stats.TotalMessages)
+	}
+
+	// Verify token stats
+	if stats.Tokens.Input != 10 {
+		t.Errorf("expected Input=10, got %d", stats.Tokens.Input)
+	}
+	if stats.Tokens.Output != 20 {
+		t.Errorf("expected Output=20, got %d", stats.Tokens.Output)
+	}
+	if stats.Tokens.CacheRead != 5 {
+		t.Errorf("expected CacheRead=5, got %d", stats.Tokens.CacheRead)
+	}
+	if stats.Tokens.Total != 30 {
+		t.Errorf("expected Total=30, got %d", stats.Tokens.Total)
+	}
+
+	// Verify cost
+	if stats.Cost != 0.01 {
+		t.Errorf("expected Cost=0.01, got %f", stats.Cost)
+	}
+
+	// Verify active window tokens are > 0
+	if stats.Tokens.ActiveWindowTokens <= 0 {
+		t.Errorf("expected ActiveWindowTokens > 0, got %d", stats.Tokens.ActiveWindowTokens)
+	}
+
+	// Verify system prompt tokens
+	if stats.Tokens.SystemPromptTokens <= 0 {
+		t.Errorf("expected SystemPromptTokens > 0, got %d", stats.Tokens.SystemPromptTokens)
+	}
+}
+
+func TestComputeSessionStats_EmptySession(t *testing.T) {
+	ws, err := tools.NewWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create workspace: %v", err)
+	}
+
+	ctx := agentctx.NewAgentContext("system prompt")
+	ag := agent.NewAgentFromConfigWithContext(
+		llm.Model{ID: "test", ContextWindow: 200000},
+		"test-key",
+		ctx,
+		agent.DefaultLoopConfig(),
+	)
+	sess := session.NewSession("")
+	compactor := compact.NewCompactor(compact.DefaultConfig(), llm.Model{ID: "test"}, "", "system prompt", 200000)
+	registry := tools.NewRegistry()
+
+	stats := computeSessionStats(ag, sess, compactor, registry, 200000, "system prompt", ws)
+
+	if stats.UserMessages != 0 {
+		t.Errorf("expected UserMessages=0, got %d", stats.UserMessages)
+	}
+	if stats.AssistantMessages != 0 {
+		t.Errorf("expected AssistantMessages=0, got %d", stats.AssistantMessages)
+	}
+	if stats.TotalMessages != 0 {
+		t.Errorf("expected TotalMessages=0, got %d", stats.TotalMessages)
+	}
+	if stats.Tokens.Input != 0 {
+		t.Errorf("expected Input=0, got %d", stats.Tokens.Input)
+	}
+	if stats.Tokens.Output != 0 {
+		t.Errorf("expected Output=0, got %d", stats.Tokens.Output)
+	}
+	if stats.Tokens.Total != 0 {
+		t.Errorf("expected Total=0, got %d", stats.Tokens.Total)
+	}
+}
+
+func TestComputeSessionStats_ToolCallsCounted(t *testing.T) {
+	ws, err := tools.NewWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create workspace: %v", err)
+	}
+
+	ctx := agentctx.NewAgentContext("system prompt")
+
+	// Add an assistant message with 2 tool calls
+	ctx.AddMessage(agentctx.AgentMessage{
+		Role: "assistant",
+		Content: []agentctx.ContentBlock{
+			agentctx.ToolCallContent{Type: "tool_call", ID: "call_1", Name: "bash", Arguments: map[string]any{"command": "ls"}},
+			agentctx.ToolCallContent{Type: "tool_call", ID: "call_2", Name: "read", Arguments: map[string]any{"path": "foo.go"}},
+		},
+	})
+
+	ag := agent.NewAgentFromConfigWithContext(
+		llm.Model{ID: "test", ContextWindow: 200000},
+		"test-key",
+		ctx,
+		agent.DefaultLoopConfig(),
+	)
+	sess := session.NewSession("")
+	compactor := compact.NewCompactor(compact.DefaultConfig(), llm.Model{ID: "test"}, "", "system prompt", 200000)
+	registry := tools.NewRegistry()
+
+	stats := computeSessionStats(ag, sess, compactor, registry, 200000, "system prompt", ws)
+
+	if stats.ToolCalls != 2 {
+		t.Errorf("expected ToolCalls=2, got %d", stats.ToolCalls)
+	}
+}
+
+func TestComputeSessionStats_ReturnsSessionStatsType(t *testing.T) {
+	// This test verifies the function returns a *rpc.SessionStats,
+	// not a *rpc.SessionState (the bug being fixed).
+	ws, err := tools.NewWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create workspace: %v", err)
+	}
+
+	ctx := agentctx.NewAgentContext("system prompt")
+	ag := agent.NewAgentFromConfigWithContext(
+		llm.Model{ID: "test", ContextWindow: 200000},
+		"test-key",
+		ctx,
+		agent.DefaultLoopConfig(),
+	)
+	sess := session.NewSession("")
+	compactor := compact.NewCompactor(compact.DefaultConfig(), llm.Model{ID: "test"}, "", "system prompt", 200000)
+	registry := tools.NewRegistry()
+
+	stats := computeSessionStats(ag, sess, compactor, registry, 200000, "system prompt", ws)
+
+	// Verify it's the correct type with expected fields
+	var _ *rpc.SessionStats = stats
+
+	// Ensure the key fields exist and are not pointing to wrong type
+	if stats.Tokens.ActiveWindowTokens == 0 && stats.Tokens.SystemPromptTokens == 0 {
+		// Even empty sessions should have system prompt tokens
+		t.Error("SessionStats should have SystemPromptTokens > 0")
+	}
+}


### PR DESCRIPTION
## Summary

The `/context` slash command displays all-zero stats because `get_session_stats` was aliased to the `/session` handler which returns `SessionState` instead of `SessionStats`.

## Root Cause

- Line 1680: `registerHiddenAlias("get_session_stats", ..., "session")` — aliased to session handler
- Session handler returns `*rpc.SessionState` (model, streaming status, etc.)
- Frontend expects `*rpc.SessionStats` (message counts, token stats, tool calls, etc.)
- Type mismatch → all stats fields serialize as zero values

## Fix

Replace the alias with a proper `get_session_stats` handler that computes real `SessionStats`:

- **Message counts**: user, assistant, toolCalls, toolResults from `ag.GetMessages()`
- **Token stats**: input, output, cacheRead, cacheWrite from message `Usage` fields
- **Active window tokens**: from `compactor.EstimateContextTokensOld()`
- **System prompt/tools tokens**: estimated from string length
- **Token rate**: from `ag.GetMetrics().GetLLMMetrics()`
- **Compaction count**: from `sess.GetCompactionCount()`
- **Cost**: accumulated from message `Usage.Cost`

## Test Plan

- [x] `TestComputeSessionStats_BasicCounts` — verifies message counts and token accumulation
- [x] `TestComputeSessionStats_EmptySession` — verifies zero state
- [x] `TestComputeSessionStats_ToolCallsCounted` — verifies tool call extraction
- [x] `TestComputeSessionStats_ReturnsSessionStatsType` — verifies correct return type
- [x] All existing tests pass (`go test ./cmd/ai/... ./pkg/rpc/... ./pkg/agent/... ./pkg/session/... ./pkg/compact/...`)