### PR TITLE
Fix: /context slash command shows all-zero data

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"io"
+	"math"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -1846,19 +1847,77 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	// /context — composite: returns state + session stats + available models
 	server.RegisterSlash("context", "Show current state, session stats, and available models", func(args string) (any, error) {
 		stateH, _ := server.GetSlashHandler("get_state")
-		statsH, _ := server.GetSlashHandler("get_session_stats")
 		modelsH, _ := server.GetSlashHandler("get_available_models")
 
 		stateResult, err := stateH("")
 		if err != nil {
 			return nil, err
 		}
-		statsResult, _ := statsH("")
 		modelsResult, _ := modelsH("")
+
+		// Compute session stats inline (get_session_stats was aliased to /session which
+		// returns SessionState, not SessionStats, causing all-zero data in the frontend).
+		messages := ag.GetMessages()
+		userCount, assistantCount, toolCalls, toolResults, tokenStats, cost := collectSessionUsage(messages)
+
+		activeWindowTokens := compactor.EstimateContextTokensOld(messages)
+		systemPromptTokens := 0
+		if systemPrompt != "" {
+			systemPromptTokens = int(math.Ceil(float64(len(systemPrompt)) / 4.0))
+		}
+		systemToolsTokens := ag.GetContext().EstimateToolsTokens()
+
+		tokenStats.ActiveWindowTokens = activeWindowTokens
+		tokenStats.SystemPromptTokens = systemPromptTokens
+		tokenStats.SystemToolsTokens = systemToolsTokens
+
+		// Populate input tokens from usage data
+		for _, msg := range messages {
+			if msg.Role == "assistant" && msg.Usage != nil {
+				tokenStats.Input += msg.Usage.InputTokens
+				tokenStats.CacheRead += msg.Usage.CacheRead
+				tokenStats.CacheWrite += msg.Usage.CacheWrite
+			}
+		}
+
+		stats := rpc.SessionStats{
+			SessionFile:       sess.GetPath(),
+			SessionID:         sessionID,
+			UserMessages:      userCount,
+			AssistantMessages: assistantCount,
+			ToolCalls:         toolCalls,
+			ToolResults:       toolResults,
+			TotalMessages:     userCount + assistantCount + toolResults,
+			CompactionCount:   sess.GetCompactionCount(),
+			Tokens:            tokenStats,
+			Cost:              cost,
+			Workspace:         ws.GetGitRoot(),
+			CurrentWorkdir:    ws.GetCWD(),
+		}
+
+		// Populate token rate from agent metrics if available
+		if metrics := ag.GetMetrics(); metrics != nil {
+			llmMetrics := metrics.GetLLMMetrics()
+			stats.TokenRate = &rpc.TokenRateStats{
+				ActiveInputPerSec:   llmMetrics.ActiveInputTokensPerSec,
+				ActiveOutputPerSec:  llmMetrics.ActiveOutputTokensPerSec,
+				ActiveTotalPerSec:   llmMetrics.ActiveTotalTokensPerSec,
+				WallInputPerSec:     llmMetrics.WallInputTokensPerSec,
+				WallOutputPerSec:    llmMetrics.WallOutputTokensPerSec,
+				WallTotalPerSec:     llmMetrics.WallTotalTokensPerSec,
+				LastInputPerSec:     llmMetrics.LastInputTokensPerSec,
+				LastOutputPerSec:    llmMetrics.LastOutputTokensPerSec,
+				LastTotalPerSec:     llmMetrics.LastTotalTokensPerSec,
+				RecentWindowSeconds: llmMetrics.RecentWindowSeconds,
+				RecentInputPerSec:   llmMetrics.RecentInputTokensPerSec,
+				RecentOutputPerSec:  llmMetrics.RecentOutputTokensPerSec,
+				RecentTotalPerSec:   llmMetrics.RecentTotalTokensPerSec,
+			}
+		}
 
 		return map[string]any{
 			"state":  stateResult,
-			"stats":  statsResult,
+			"stats":  stats,
 			"models": modelsResult,
 		}, nil
 	})


### PR DESCRIPTION
## Bug Fix

`/context` slash command returned all-zero stats data.

### Root Cause

The `/context` handler composed three sub-commands: `get_state`, `get_session_stats`, and `get_available_models`.
Both `get_state` and `get_session_stats` were aliased to the `/session` handler via `registerHiddenAlias`.
The `/session` handler returns `rpc.SessionState` (model info, streaming status, etc.).
But the frontend's `renderContext` in `pkg/run/conv.go` expects `rpc.SessionStats` (token counts, message counts, tool calls, cost, etc.).
Since `SessionState` unmarshals into `SessionStats`, all numeric fields were zero.

### Fix

Compute `SessionStats` directly in the `/context` handler instead of aliasing through `get_session_stats`:
- Use `collectSessionUsage()` for user/assistant/tool counts and output tokens
- Use `compactor.EstimateContextTokensOld()` for active window tokens
- Use `ag.GetContext().EstimateToolsTokens()` for system tools tokens estimate
- Use `agent metrics` for token rate stats (`TokenRateStats`)
- Use `sess.GetCompactionCount()` for compaction count

### Testing

- \`go build ./cmd/ai/...\` — compiles successfully
- \`go test ./cmd/ai/... ./pkg/rpc/...\` — all tests pass