### PR TITLE
Fix: [BUG] /messages slash command returns raw JSON dump — needs formatted display

### DIFF
--- a/cmd/ai/messages_handler_test.go
+++ b/cmd/ai/messages_handler_test.go
@@ -9,9 +9,6 @@ import (
 	"github.com/tiancaiamao/ai/pkg/rpc"
 )
 
-// helper to create a bool pointer
-func boolPtr(b bool) *bool { return &b }
-
 func TestFormatMessagesForDisplay_BasicUserMessage(t *testing.T) {
 	msgs := []agentctx.AgentMessage{
 		agentctx.NewUserMessage("Hello, world!"),

--- a/cmd/ai/messages_handler_test.go
+++ b/cmd/ai/messages_handler_test.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/rpc"
+)
+
+// helper to create a bool pointer
+func boolPtr(b bool) *bool { return &b }
+
+func TestFormatMessagesForDisplay_BasicUserMessage(t *testing.T) {
+	msgs := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("Hello, world!"),
+	}
+
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if result.Total != 1 {
+		t.Errorf("Expected Total=1, got %d", result.Total)
+	}
+	if result.Showing != 1 {
+		t.Errorf("Expected Showing=1, got %d", result.Showing)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("Expected 1 message, got %d", len(result.Messages))
+	}
+	m := result.Messages[0]
+	if m.Index != 0 {
+		t.Errorf("Expected Index=0, got %d", m.Index)
+	}
+	if m.Role != "user" {
+		t.Errorf("Expected Role=user, got %s", m.Role)
+	}
+	if m.Preview != "Hello, world!" {
+		t.Errorf("Expected Preview='Hello, world!', got '%s'", m.Preview)
+	}
+}
+
+func TestFormatMessagesForDisplay_Truncation(t *testing.T) {
+	longText := strings.Repeat("a", 300)
+	msgs := []agentctx.AgentMessage{
+		agentctx.NewUserMessage(longText),
+	}
+
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("Expected 1 message, got %d", len(result.Messages))
+	}
+	expected := strings.Repeat("a", 200) + "..."
+	if result.Messages[0].Preview != expected {
+		t.Errorf("Expected preview truncated to 200 chars + '...', got length %d", len(result.Messages[0].Preview))
+	}
+}
+
+func TestFormatMessagesForDisplay_CountLimit(t *testing.T) {
+	msgs := make([]agentctx.AgentMessage, 50)
+	for i := range msgs {
+		msgs[i] = agentctx.NewUserMessage("msg")
+	}
+
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if result.Total != 50 {
+		t.Errorf("Expected Total=50, got %d", result.Total)
+	}
+	if result.Showing != 20 {
+		t.Errorf("Expected Showing=20, got %d", result.Showing)
+	}
+	if len(result.Messages) != 20 {
+		t.Fatalf("Expected 20 messages, got %d", len(result.Messages))
+	}
+	// First message should have index 30 (50-20)
+	if result.Messages[0].Index != 30 {
+		t.Errorf("Expected first message Index=30, got %d", result.Messages[0].Index)
+	}
+	// Last message should have index 49
+	if result.Messages[19].Index != 49 {
+		t.Errorf("Expected last message Index=49, got %d", result.Messages[19].Index)
+	}
+}
+
+func TestFormatMessagesForDisplay_CountExceedsTotal(t *testing.T) {
+	msgs := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("msg1"),
+		agentctx.NewUserMessage("msg2"),
+	}
+
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if result.Total != 2 {
+		t.Errorf("Expected Total=2, got %d", result.Total)
+	}
+	if result.Showing != 2 {
+		t.Errorf("Expected Showing=2, got %d", result.Showing)
+	}
+	if len(result.Messages) != 2 {
+		t.Fatalf("Expected 2 messages, got %d", len(result.Messages))
+	}
+}
+
+func TestFormatMessagesForDisplay_EmptyMessages(t *testing.T) {
+	msgs := []agentctx.AgentMessage{}
+
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if result.Total != 0 {
+		t.Errorf("Expected Total=0, got %d", result.Total)
+	}
+	if result.Showing != 0 {
+		t.Errorf("Expected Showing=0, got %d", result.Showing)
+	}
+	if len(result.Messages) != 0 {
+		t.Errorf("Expected 0 messages, got %d", len(result.Messages))
+	}
+}
+
+func TestFormatMessagesForDisplay_ToolCalls(t *testing.T) {
+	msg := agentctx.NewAssistantMessage()
+	msg.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:   "call_1",
+			Type: "toolCall",
+			Name: "bash",
+			Arguments: map[string]any{
+				"command": "ls -la",
+			},
+		},
+		agentctx.ToolCallContent{
+			ID:   "call_2",
+			Type: "toolCall",
+			Name: "read",
+			Arguments: map[string]any{
+				"path": "/tmp/test.txt",
+			},
+		},
+		agentctx.TextContent{
+			Type: "text",
+			Text: "Let me check the files",
+		},
+	}
+
+	msgs := []agentctx.AgentMessage{msg}
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("Expected 1 message, got %d", len(result.Messages))
+	}
+	m := result.Messages[0]
+	if m.Role != "assistant" {
+		t.Errorf("Expected Role=assistant, got %s", m.Role)
+	}
+	if m.Preview != "Let me check the files" {
+		t.Errorf("Expected Preview='Let me check the files', got '%s'", m.Preview)
+	}
+	if len(m.ToolCalls) != 2 {
+		t.Fatalf("Expected 2 tool calls, got %d", len(m.ToolCalls))
+	}
+	if m.ToolCalls[0] != "bash" {
+		t.Errorf("Expected ToolCalls[0]='bash', got '%s'", m.ToolCalls[0])
+	}
+	if m.ToolCalls[1] != "read" {
+		t.Errorf("Expected ToolCalls[1]='read', got '%s'", m.ToolCalls[1])
+	}
+}
+
+func TestFormatMessagesForDisplay_ToolResult(t *testing.T) {
+	msg := agentctx.NewToolResultMessage("call_1", "bash", []agentctx.ContentBlock{
+		agentctx.TextContent{Type: "text", Text: "file1.txt\nfile2.txt"},
+	}, false)
+
+	msgs := []agentctx.AgentMessage{msg}
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("Expected 1 message, got %d", len(result.Messages))
+	}
+	m := result.Messages[0]
+	if m.Role != "toolResult" {
+		t.Errorf("Expected Role=toolResult, got %s", m.Role)
+	}
+	if m.ToolName != "bash" {
+		t.Errorf("Expected ToolName='bash', got '%s'", m.ToolName)
+	}
+	if m.Preview != "file1.txt\nfile2.txt" {
+		t.Errorf("Expected Preview='file1.txt\\nfile2.txt', got '%s'", m.Preview)
+	}
+	if m.IsError {
+		t.Error("Expected IsError=false")
+	}
+}
+
+func TestFormatMessagesForDisplay_ToolResultError(t *testing.T) {
+	msg := agentctx.NewToolResultMessage("call_1", "bash", []agentctx.ContentBlock{
+		agentctx.TextContent{Type: "text", Text: "command not found"},
+	}, true)
+
+	msgs := []agentctx.AgentMessage{msg}
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("Expected 1 message, got %d", len(result.Messages))
+	}
+	if !result.Messages[0].IsError {
+		t.Error("Expected IsError=true")
+	}
+}
+
+func TestFormatMessagesForDisplay_ThinkingFallback(t *testing.T) {
+	msg := agentctx.NewAssistantMessage()
+	msg.Content = []agentctx.ContentBlock{
+		agentctx.ThinkingContent{
+			Type:     "thinking",
+			Thinking: "I should analyze the problem first",
+		},
+	}
+
+	msgs := []agentctx.AgentMessage{msg}
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("Expected 1 message, got %d", len(result.Messages))
+	}
+	m := result.Messages[0]
+	if m.Preview != "(thinking) I should analyze the problem first" {
+		t.Errorf("Expected thinking preview, got '%s'", m.Preview)
+	}
+}
+
+func TestFormatMessagesForDisplay_MixedMessages(t *testing.T) {
+	userMsg := agentctx.NewUserMessage("Fix the bug")
+	assistantMsg := agentctx.NewAssistantMessage()
+	assistantMsg.Content = []agentctx.ContentBlock{
+		agentctx.ToolCallContent{
+			ID:   "call_1",
+			Type: "toolCall",
+			Name: "bash",
+			Arguments: map[string]any{"command": "go test ./..."},
+		},
+	}
+	toolResultMsg := agentctx.NewToolResultMessage("call_1", "bash", []agentctx.ContentBlock{
+		agentctx.TextContent{Type: "text", Text: "PASS"},
+	}, false)
+
+	msgs := []agentctx.AgentMessage{userMsg, assistantMsg, toolResultMsg}
+	result := formatMessagesForDisplay(msgs, 20, 200)
+
+	if result.Total != 3 {
+		t.Errorf("Expected Total=3, got %d", result.Total)
+	}
+	if result.Showing != 3 {
+		t.Errorf("Expected Showing=3, got %d", result.Showing)
+	}
+
+	// Verify JSON serialization matches expected structure
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("Failed to marshal result: %v", err)
+	}
+	var parsed rpc.MessagesResult
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+	if parsed.Total != 3 {
+		t.Errorf("Round-trip: Expected Total=3, got %d", parsed.Total)
+	}
+}

--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -919,14 +919,21 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 		}, nil
 	})
 
-	server.RegisterSlash("messages", "Get all messages in the current session", func(args string) (any, error) {
-		slog.Info("Received get_messages")
-		messages := ag.GetMessages()
-		result := make([]any, len(messages))
-		for i, msg := range messages {
-			result[i] = msg
+	server.RegisterSlash("messages", "Get formatted message summaries for the current session", func(args string) (any, error) {
+		slog.Info("Received get_messages", "args", args)
+		const defaultCount = 20
+		const maxPreviewLen = 200
+
+		count := defaultCount
+		args = strings.TrimSpace(args)
+		if args != "" {
+			if n, err := strconv.Atoi(args); err == nil && n > 0 {
+				count = n
+			}
 		}
-		return map[string]any{"messages": result}, nil
+
+		messages := ag.GetMessages()
+		return formatMessagesForDisplay(messages, count, maxPreviewLen), nil
 	})
 
 	server.RegisterSlash("compact", "Compact conversation history to reduce context size", func(args string) (any, error) {
@@ -2292,4 +2299,62 @@ func getWorkflowStatus(cwd string) (*rpc.WorkflowState, error) {
 	}
 
 	return state, nil
+}
+
+// formatMessagesForDisplay converts AgentMessages into a structured summary for the /messages command.
+// It returns the last `count` messages with previews truncated to maxPreviewLen characters.
+func formatMessagesForDisplay(messages []agentctx.AgentMessage, count int, maxPreviewLen int) rpc.MessagesResult {
+	total := len(messages)
+
+	start := total - count
+	if start < 0 {
+		start = 0
+	}
+	showing := total - start
+
+	formatted := make([]rpc.FormattedMessage, 0, showing)
+	for i := start; i < total; i++ {
+		msg := messages[i]
+		fm := rpc.FormattedMessage{
+			Index: i,
+			Role:  msg.Role,
+		}
+
+		// Build preview from text content
+		preview := msg.ExtractText()
+		if preview == "" {
+			// Try thinking content as fallback for assistant messages
+			if thinking := msg.ExtractThinking(); thinking != "" {
+				preview = "(thinking) " + thinking
+			}
+		}
+		if len(preview) > maxPreviewLen {
+			preview = preview[:maxPreviewLen] + "..."
+		}
+		fm.Preview = preview
+
+		// Extract tool call names for assistant messages
+		toolCalls := msg.ExtractToolCalls()
+		if len(toolCalls) > 0 {
+			names := make([]string, 0, len(toolCalls))
+			for _, tc := range toolCalls {
+				names = append(names, tc.Name)
+			}
+			fm.ToolCalls = names
+		}
+
+		// Include tool name for tool results
+		if msg.ToolName != "" {
+			fm.ToolName = msg.ToolName
+		}
+		fm.IsError = msg.IsError
+
+		formatted = append(formatted, fm)
+	}
+
+	return rpc.MessagesResult{
+		Total:    total,
+		Showing:  showing,
+		Messages: formatted,
+	}
 }

--- a/pkg/rpc/types.go
+++ b/pkg/rpc/types.go
@@ -176,6 +176,23 @@ type CycleModelResult struct {
 	ScopedProvider string    `json:"scopedProvider,omitempty"`
 }
 
+// FormattedMessage represents a summarized message for display purposes.
+type FormattedMessage struct {
+	Index     int      `json:"index"`
+	Role      string   `json:"role"`
+	Preview   string   `json:"preview"`
+	ToolCalls []string `json:"toolCalls,omitempty"`
+	ToolName  string   `json:"toolName,omitempty"`
+	IsError   bool     `json:"isError,omitempty"`
+}
+
+// MessagesResult represents the result of the /messages slash command.
+type MessagesResult struct {
+	Total    int               `json:"total"`
+	Showing  int               `json:"showing"`
+	Messages []FormattedMessage `json:"messages"`
+}
+
 // BashResult represents a shell execution result.
 type BashResult struct {
 	ExitCode int    `json:"exitCode"`

--- a/pkg/run/conv.go
+++ b/pkg/run/conv.go
@@ -860,6 +860,13 @@ func renderSessionState(dataJSON []byte) *FormattedEvent {
 
 // renderMessages renders /messages output.
 func renderMessages(dataJSON []byte) *FormattedEvent {
+	// Try new MessagesResult format first (has total/showing/preview fields)
+	var result rpc.MessagesResult
+	if err := json.Unmarshal(dataJSON, &result); err == nil && result.Total > 0 {
+		return renderFormattedMessages(result)
+	}
+
+	// Legacy format: {messages: [{role, content}]}
 	var payload struct {
 		Messages []struct {
 			Role    string `json:"role"`
@@ -882,31 +889,57 @@ func renderMessages(dataJSON []byte) *FormattedEvent {
 		return &FormattedEvent{Kind: KindMeta, Text: "no messages"}
 	}
 
-	const maxMessages = 10
-	total := len(payload.Messages)
-	display := payload.Messages
-	baseIndex := 0
-	if total > maxMessages {
-		baseIndex = total - maxMessages
-		display = payload.Messages[baseIndex:]
+	// Convert legacy format to MessagesResult
+	legacyResult := rpc.MessagesResult{
+		Total:    len(payload.Messages),
+		Showing:  len(payload.Messages),
+		Messages: make([]rpc.FormattedMessage, len(payload.Messages)),
+	}
+	for i, msg := range payload.Messages {
+		legacyResult.Messages[i] = rpc.FormattedMessage{
+			Index:   i,
+			Role:    msg.Role,
+			Preview: msg.Content,
+		}
+	}
+	return renderFormattedMessages(legacyResult)
+}
+
+// renderFormattedMessages renders a MessagesResult into a human-readable display.
+func renderFormattedMessages(result rpc.MessagesResult) *FormattedEvent {
+	if len(result.Messages) == 0 {
+		return &FormattedEvent{Kind: KindMeta, Text: "no messages"}
 	}
 
 	var b strings.Builder
-	if total > maxMessages {
-		b.WriteString(fmt.Sprintf("Messages (last %d of %d):\n", maxMessages, total))
+	if result.Showing < result.Total {
+		b.WriteString(fmt.Sprintf("Messages (last %d of %d):\n", result.Showing, result.Total))
 	} else {
-		b.WriteString("Messages:\n")
+		b.WriteString(fmt.Sprintf("Messages (%d):\n", result.Total))
 	}
 
-	for i, msg := range display {
-		text := strings.TrimSpace(msg.Content)
+	for _, msg := range result.Messages {
+		text := strings.TrimSpace(msg.Preview)
 		if text == "" {
 			text = "(no text)"
 		}
 		if len(text) > 120 {
 			text = text[:120] + "..."
 		}
-		b.WriteString(fmt.Sprintf("  [%d] %s: %s\n", baseIndex+i, msg.Role, text))
+
+		role := msg.Role
+		if msg.ToolName != "" {
+			role = fmt.Sprintf("%s: %s", msg.Role, msg.ToolName)
+		}
+
+		line := fmt.Sprintf("  [%d] %s: %s", msg.Index, role, text)
+
+		// Append tool call names if present
+		if len(msg.ToolCalls) > 0 {
+			line += fmt.Sprintf(" (tools: %s)", strings.Join(msg.ToolCalls, ", "))
+		}
+
+		b.WriteString(line + "\n")
 	}
 
 	return &FormattedEvent{Kind: KindMeta, Text: strings.TrimRight(b.String(), "\n")}

--- a/pkg/run/conv_test.go
+++ b/pkg/run/conv_test.go
@@ -644,3 +644,94 @@ func TestParseEvent_MessageUpdate_ThinkingDelta(t *testing.T) {
 		t.Fatalf("expected text 'Valid thinking', got %q", evt.Text)
 	}
 }
+
+func TestRenderMessages_NewFormat(t *testing.T) {
+	data := `{"total":5,"showing":3,"messages":[{"index":2,"role":"user","preview":"Hello world"},{"index":3,"role":"assistant","preview":"Let me check","toolCalls":["bash","read"]},{"index":4,"role":"toolResult","toolName":"bash","preview":"file1.txt\nfile2.txt"}]}`
+	evt := renderMessages([]byte(data))
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if evt.Kind != KindMeta {
+		t.Fatalf("expected KindMeta, got %s", evt.Kind)
+	}
+	// Should show "last 3 of 5"
+	if !contains(evt.Text, "last 3 of 5") {
+		t.Fatalf("expected 'last 3 of 5' in output, got: %s", evt.Text)
+	}
+	// Should show preview text
+	if !contains(evt.Text, "Hello world") {
+		t.Fatalf("expected 'Hello world' in output, got: %s", evt.Text)
+	}
+	// Should show tool calls
+	if !contains(evt.Text, "tools: bash, read") {
+		t.Fatalf("expected 'tools: bash, read' in output, got: %s", evt.Text)
+	}
+	// Should show tool name for toolResult
+	if !contains(evt.Text, "toolResult: bash") {
+		t.Fatalf("expected 'toolResult: bash' in output, got: %s", evt.Text)
+	}
+}
+
+func TestRenderMessages_NewFormatAllShown(t *testing.T) {
+	data := `{"total":3,"showing":3,"messages":[{"index":0,"role":"user","preview":"Hi"},{"index":1,"role":"assistant","preview":"Hello"},{"index":2,"role":"user","preview":"Bye"}]}`
+	evt := renderMessages([]byte(data))
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	// Should show "Messages (3):" not "last N of N"
+	if contains(evt.Text, "last") {
+		t.Fatalf("should not contain 'last' when all shown, got: %s", evt.Text)
+	}
+	if !contains(evt.Text, "Messages (3):") {
+		t.Fatalf("expected 'Messages (3):' in output, got: %s", evt.Text)
+	}
+}
+
+func TestRenderMessages_NewFormatEmptyPreview(t *testing.T) {
+	data := `{"total":1,"showing":1,"messages":[{"index":0,"role":"assistant","preview":""}]}`
+	evt := renderMessages([]byte(data))
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if !contains(evt.Text, "(no text)") {
+		t.Fatalf("expected '(no text)' for empty preview, got: %s", evt.Text)
+	}
+}
+
+func TestRenderMessages_LegacyFormat(t *testing.T) {
+	data := `{"messages":[{"role":"user","content":"Hello"},{"role":"assistant","content":"World"}]}`
+	evt := renderMessages([]byte(data))
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if !contains(evt.Text, "Hello") {
+		t.Fatalf("expected 'Hello' in output, got: %s", evt.Text)
+	}
+	if !contains(evt.Text, "World") {
+		t.Fatalf("expected 'World' in output, got: %s", evt.Text)
+	}
+}
+
+func TestRenderMessages_Empty(t *testing.T) {
+	data := `{"total":0,"showing":0,"messages":[]}`
+	evt := renderMessages([]byte(data))
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if !contains(evt.Text, "no messages") {
+		t.Fatalf("expected 'no messages' in output, got: %s", evt.Text)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || containsSubstr(s, sub))
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes the `/messages` slash command to return structured, human-readable message summaries instead of raw JSON dumps.

## Changes

- **`pkg/rpc/types.go`**: Added `FormattedMessage` and `MessagesResult` types for structured output
- **`cmd/ai/rpc_handlers.go`**: Rewrote `/messages` handler to use formatted display with:
  - Default last 20 messages, customizable via `/messages N`
  - Content preview truncated to 200 characters
  - Tool call names extracted for assistant messages
  - Tool name shown for tool result messages
  - Total/showing count metadata
- **`cmd/ai/messages_handler_test.go`**: 10 unit tests covering all message types and edge cases

## Acceptance Criteria

- [x] `/messages` returns structured message summary list, not raw JSON dump
- [x] Default shows last 20 messages, `/messages N` custom count
- [x] Each message includes role, content preview (truncated ~200 chars), tool call name summary
- [x] Returns `total` and `showing` counts
- [x] Does not break existing message structure — pure display layer
- [x] Has corresponding test coverage (10 tests, all passing)

## Test Results

```
=== RUN   TestFormatMessagesForDisplay_BasicUserMessage      --- PASS
=== RUN   TestFormatMessagesForDisplay_Truncation            --- PASS
=== RUN   TestFormatMessagesForDisplay_CountLimit            --- PASS
=== RUN   TestFormatMessagesForDisplay_CountExceedsTotal     --- PASS
=== RUN   TestFormatMessagesForDisplay_EmptyMessages         --- PASS
=== RUN   TestFormatMessagesForDisplay_ToolCalls             --- PASS
=== RUN   TestFormatMessagesForDisplay_ToolResult            --- PASS
=== RUN   TestFormatMessagesForDisplay_ToolResultError       --- PASS
=== RUN   TestFormatMessagesForDisplay_ThinkingFallback      --- PASS
=== RUN   TestFormatMessagesForDisplay_MixedMessages         --- PASS
PASS
``