### PR TITLE
refactor: consolidate duplicate TopN constants into SSOT

### DIFF
--- a/pkg/skill/formatter.go
+++ b/pkg/skill/formatter.go
@@ -7,7 +7,6 @@ import (
 
 const (
 	maxSkillDescriptionRunes = 220
-	defaultPromptTopN        = 10
 )
 
 // FormatForPrompt formats skills for inclusion in a system prompt.
@@ -19,7 +18,7 @@ const (
 //
 // If stats is non-nil and has entries, only the top-N ranked skills from
 // stats are shown. Otherwise (cold start / nil stats), all visible skills
-// are shown capped at defaultPromptTopN.
+// are shown capped at DefaultTopN.
 func FormatForPrompt(skills []Skill, stats *SkillStatsFile) string {
 	// Filter out skills that shouldn't be auto-included
 	visibleSkills := make([]Skill, 0, len(skills))
@@ -33,7 +32,7 @@ func FormatForPrompt(skills []Skill, stats *SkillStatsFile) string {
 		return ""
 	}
 
-	topN := defaultPromptTopN
+	topN := DefaultTopN
 	if stats != nil && stats.TopN > 0 {
 		topN = stats.TopN
 	}

--- a/pkg/skill/stats.go
+++ b/pkg/skill/stats.go
@@ -30,7 +30,7 @@ type SkillStatsFile struct {
 
 const (
 	statsVersion       = 1
-		defaultTopN        = 10
+	DefaultTopN        = 10
 	decayHalfLifeHours = 168.0 // 1 week
 )
 
@@ -40,7 +40,7 @@ const (
 func LoadStats(path string) *SkillStatsFile {
 	s := &SkillStatsFile{
 		Version:  statsVersion,
-		TopN:     defaultTopN,
+		TopN:     DefaultTopN,
 		Entries:  make(map[string]*SkillUsageEntry),
 		FilePath: path,
 	}

--- a/pkg/skill/stats_test.go
+++ b/pkg/skill/stats_test.go
@@ -95,7 +95,7 @@ func TestStatsLoadMalformedJSON(t *testing.T) {
 func TestStatsRecordUsageCreatesEntry(t *testing.T) {
 	s := &SkillStatsFile{
 		Version:  statsVersion,
-		TopN:     defaultTopN,
+		TopN:     DefaultTopN,
 		Entries:  make(map[string]*SkillUsageEntry),
 		FilePath: filepath.Join(t.TempDir(), "stats.json"),
 	}
@@ -117,7 +117,7 @@ func TestStatsRecordUsageCreatesEntry(t *testing.T) {
 func TestStatsRecordUsageIncrementsCount(t *testing.T) {
 	s := &SkillStatsFile{
 		Version:  statsVersion,
-		TopN:     defaultTopN,
+		TopN:     DefaultTopN,
 		Entries:  make(map[string]*SkillUsageEntry),
 		FilePath: filepath.Join(t.TempDir(), "stats.json"),
 	}
@@ -138,7 +138,7 @@ func TestStatsRecordUsageIncrementsCount(t *testing.T) {
 func TestStatsTimeDecayOldEntryLowerScore(t *testing.T) {
 	s := &SkillStatsFile{
 		Version:  statsVersion,
-		TopN:     defaultTopN,
+		TopN:     DefaultTopN,
 		Entries:  make(map[string]*SkillUsageEntry),
 		FilePath: filepath.Join(t.TempDir(), "stats.json"),
 	}
@@ -186,7 +186,7 @@ func TestStatsTimeDecayOldEntryLowerScore(t *testing.T) {
 func TestStatsTopSkillsOrderingAndLimit(t *testing.T) {
 	s := &SkillStatsFile{
 		Version:  statsVersion,
-		TopN:     defaultTopN,
+		TopN:     DefaultTopN,
 		Entries:  make(map[string]*SkillUsageEntry),
 		FilePath: filepath.Join(t.TempDir(), "stats.json"),
 	}
@@ -240,7 +240,7 @@ func TestStatsSaveLoadRoundtrip(t *testing.T) {
 
 	s := &SkillStatsFile{
 		Version:  statsVersion,
-		TopN:     defaultTopN,
+		TopN:     DefaultTopN,
 		Entries:  make(map[string]*SkillUsageEntry),
 		FilePath: path,
 	}


### PR DESCRIPTION
## Summary

Consolidates two duplicate constants defining the default skill display limit into a single source of truth.

## Problem

Two constants defined the same semantic value (default skill display limit):
- `pkg/skill/stats.go:33` → `defaultTopN = 10`
- `pkg/skill/formatter.go:10` → `defaultPromptTopN = 10`

From git history (commit 2e70a42), only one was updated when changing 7→10, proving the risk of divergence.

## Changes

| File | Change |
|------|--------|
| `pkg/skill/stats.go` | Rename `defaultTopN` → `DefaultTopN` (exported) |
| `pkg/skill/formatter.go` | Remove `defaultPromptTopN` const, use `DefaultTopN` |
| `pkg/skill/stats_test.go` | Update 5 references `defaultTopN` → `DefaultTopN` |

## Validation

- `go test ./pkg/skill/ -v -count=1` — ALL PASS
- `go build ./...` — SUCCESS