### PR TITLE
perf: improve review perf based on trace analysis

### DIFF
--- a/pkg/compact/context_management.go
+++ b/pkg/compact/context_management.go
@@ -17,7 +17,7 @@ import (
 
 // Trigger thresholds for context management.
 const (
-	MgmtTokenLow    = 0.35 // 35%: start periodic checks
+	MgmtTokenLow    = 0.20 // 20%: start periodic checks
 	MgmtTokenMedium = 0.33 // 30%: more aggressive checks
 	MgmtTokenHigh   = 0.50 // 50%: frequent checks
 
@@ -261,6 +261,13 @@ func (c *ContextManager) CompactWithCtx(parent context.Context, agentCtx *agentc
 
 		if err != nil {
 			llmSpan.AddField("error", err.Error())
+			llmSpan.AddField("retryable", llm.IsRetryableError(err))
+			traceevent.Log(parent, traceevent.CategoryLLM, "llm_call_error",
+				traceevent.Field{Key: "caller", Value: "context_management"},
+				traceevent.Field{Key: "attempt", Value: attempt},
+				traceevent.Field{Key: "error", Value: err.Error()},
+				traceevent.Field{Key: "retryable", Value: llm.IsRetryableError(err)},
+			)
 		}
 		llmSpan.End()
 

--- a/pkg/compact/context_management.go
+++ b/pkg/compact/context_management.go
@@ -17,11 +17,11 @@ import (
 
 // Trigger thresholds for context management.
 const (
-	MgmtTokenLow    = 0.20 // 20%: start periodic checks
+	MgmtTokenLow    = 0.35 // 35%: start periodic checks
 	MgmtTokenMedium = 0.33 // 30%: more aggressive checks
 	MgmtTokenHigh   = 0.50 // 50%: frequent checks
 
-			MgmtIntervalLow    = 15 // At 20%: every 15 tool calls
+	MgmtIntervalLow    = 15 // At 20%: every 15 tool calls
 	MgmtIntervalMedium = 10 // At 40%: every 10 tool calls
 	MgmtIntervalHigh   = 7  // At 60%: every 7 tool calls
 
@@ -218,6 +218,15 @@ func (c *ContextManager) CompactWithCtx(parent context.Context, agentCtx *agentc
 			return nil, fmt.Errorf("context management LLM call failed: %w", err)
 		}
 
+		llmSpan := traceevent.StartSpan(parent, "llm_call", traceevent.CategoryLLM,
+			traceevent.Field{Key: "model", Value: c.model.ID},
+			traceevent.Field{Key: "provider", Value: c.model.Provider},
+			traceevent.Field{Key: "api", Value: c.model.API},
+			traceevent.Field{Key: "attempt", Value: attempt},
+			traceevent.Field{Key: "caller", Value: "context_management"},
+		)
+		llmCallStart := time.Now()
+
 		stream := llm.StreamLLM(
 			parent,
 			c.model,
@@ -231,7 +240,30 @@ func (c *ContextManager) CompactWithCtx(parent context.Context, agentCtx *agentc
 
 		// 4. Extract tool calls from stream
 		var err error
-		toolCalls, err = c.extractToolCalls(parent, stream)
+		var usage llm.Usage
+		var firstTokenLatency time.Duration
+		toolCalls, usage, firstTokenLatency, err = c.extractToolCalls(parent, stream)
+
+		// Add token usage metrics to span
+		if usage.InputTokens > 0 || usage.OutputTokens > 0 {
+			llmSpan.AddField("input_tokens", usage.InputTokens)
+			llmSpan.AddField("output_tokens", usage.OutputTokens)
+			llmSpan.AddField("total_tokens", usage.TotalTokens)
+			duration := time.Since(llmCallStart)
+			if duration.Seconds() > 0 {
+				llmSpan.AddField("input_tokens_per_sec", float64(usage.InputTokens)/duration.Seconds())
+				llmSpan.AddField("output_tokens_per_sec", float64(usage.OutputTokens)/duration.Seconds())
+			}
+		}
+		if firstTokenLatency > 0 {
+			llmSpan.AddField("first_token_ms", firstTokenLatency.Milliseconds())
+		}
+
+		if err != nil {
+			llmSpan.AddField("error", err.Error())
+		}
+		llmSpan.End()
+
 		if err == nil {
 			lastErr = nil
 			break
@@ -498,7 +530,7 @@ func (c *ContextManager) buildContextMgmtMessages(agentCtx *agentctx.AgentContex
 	tokenPercent := c.estimateTokenPercent(agentCtx)
 	recommendedTruncate := estimatedSavingsTokens >= mgmtForceTruncateSavingsTokens
 	llmContextEmpty := agentCtx.LLMContext == ""
-	
+
 	stateMsg := fmt.Sprintf(`<current_state>
 Truncatable tool outputs (selectable): %d (protected region: last %d messages)
 Estimated savings if truncating selectable outputs: ~%d tokens
@@ -603,8 +635,13 @@ func (c *ContextManager) convertToolsToLLM(tools []context_mgmt.Tool) []llm.LLMT
 }
 
 // extractToolCalls reads tool calls from the LLM stream.
-func (c *ContextManager) extractToolCalls(ctx context.Context, stream *llm.EventStream[llm.LLMEvent, llm.LLMMessage]) ([]llm.ToolCall, error) {
+func (c *ContextManager) extractToolCalls(ctx context.Context, stream *llm.EventStream[llm.LLMEvent, llm.LLMMessage]) ([]llm.ToolCall, llm.Usage, time.Duration, error) {
 	var toolCalls []llm.ToolCall
+	var usage llm.Usage
+	var firstTokenLatency time.Duration
+	llmStart := time.Now()
+	firstToken := true
+
 	for event := range stream.Iterator(ctx) {
 		if event.Done {
 			break
@@ -614,11 +651,22 @@ func (c *ContextManager) extractToolCalls(ctx context.Context, stream *llm.Event
 			if e.Message != nil {
 				toolCalls = append(toolCalls, e.Message.ToolCalls...)
 			}
+			usage = e.Usage
+		case llm.LLMTextDeltaEvent:
+			if firstToken {
+				firstTokenLatency = time.Since(llmStart)
+				firstToken = false
+			}
+		case llm.LLMThinkingDeltaEvent:
+			if firstToken {
+				firstTokenLatency = time.Since(llmStart)
+				firstToken = false
+			}
 		case llm.LLMErrorEvent:
-			return nil, e.Error
+			return nil, usage, firstTokenLatency, e.Error
 		}
 	}
-	return toolCalls, nil
+	return toolCalls, usage, firstTokenLatency, nil
 }
 
 // executeToolCalls runs each tool call and logs the result.

--- a/pkg/tools/read.go
+++ b/pkg/tools/read.go
@@ -12,11 +12,35 @@ import (
 )
 
 const (
-	// defaultReadMaxBytes is the default maximum file size to read (50KB).
-	defaultReadMaxBytes = 50 * 1024
+	// defaultReadMaxBytes is the default maximum file size to read.
+	// Can be overridden via AI_READ_MAX_BYTES environment variable.
+	defaultReadMaxBytes = 100 * 1024 // 100KB
 	// defaultReadLimit is the default maximum number of lines to return.
-	defaultReadLimit = 2000
+	// Can be overridden via AI_READ_MAX_LINES environment variable.
+	defaultReadLimit = 4000
 )
+
+// getReadMaxBytes returns the effective max bytes for read operations.
+// Checks AI_READ_MAX_BYTES env var first, then falls back to default.
+func getReadMaxBytes() int {
+	if v := os.Getenv("AI_READ_MAX_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultReadMaxBytes
+}
+
+// getReadLimit returns the effective line limit for read operations.
+// Checks AI_READ_MAX_LINES env var first, then falls back to default.
+func getReadLimit() int {
+	if v := os.Getenv("AI_READ_MAX_LINES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultReadLimit
+}
 
 // ReadTool reads file contents with dynamic workspace support.
 type ReadTool struct {
@@ -41,7 +65,7 @@ func (t *ReadTool) Name() string {
 
 // Description returns the tool description.
 func (t *ReadTool) Description() string {
-		return "Read the contents of a file. Supports text files. Use offset and limit to read specific line ranges. For large or unfamiliar files, prefer grep to locate relevant sections first, then read targeted ranges with offset/limit rather than reading the entire file sequentially."
+	return "Read the contents of a file. Supports text files. Use offset and limit to read specific line ranges. For large or unfamiliar files, prefer grep to locate relevant sections first, then read targeted ranges with offset/limit rather than reading the entire file sequentially."
 }
 
 // Parameters returns the JSON Schema for the tool parameters.
@@ -59,7 +83,7 @@ func (t *ReadTool) Parameters() map[string]any {
 			},
 			"limit": map[string]any{
 				"type":        "number",
-				"description": "Maximum number of lines to read. Defaults to 2000.",
+				"description": "Maximum number of lines to read. Defaults to 4000.",
 			},
 		},
 		"required": []string{"path"},
@@ -104,7 +128,7 @@ func (t *ReadTool) Execute(ctx context.Context, args map[string]any) ([]agentctx
 		return nil, err
 	}
 
-	limit, err := parsePositiveIntArg(args, "limit", defaultReadLimit)
+	limit, err := parsePositiveIntArg(args, "limit", getReadLimit())
 	if err != nil {
 		return nil, err
 	}
@@ -140,9 +164,10 @@ func (t *ReadTool) Execute(ctx context.Context, args map[string]any) ([]agentctx
 
 	// Check size of selected content (not entire file).
 	// This allows reading sections of large files via offset/limit.
-	if len(output) > defaultReadMaxBytes {
+	maxBytes := getReadMaxBytes()
+	if len(output) > maxBytes {
 		return nil, fmt.Errorf("selected range is too large (%d lines, %d bytes). Use a smaller limit value, e.g. limit=%d",
-			len(selectedLines), len(output), defaultReadMaxBytes/80) // rough line-width estimate
+			len(selectedLines), len(output), maxBytes/80) // rough line-width estimate
 	}
 
 	// Add continuation hints when content is truncated
@@ -151,7 +176,7 @@ func (t *ReadTool) Execute(ctx context.Context, args map[string]any) ([]agentctx
 		header = fmt.Sprintf("[%d lines above omitted. Use offset=1, limit=%d to read from start.]\n\n",
 			offset-1, offset-1)
 	}
-		if end < totalLines {
+	if end < totalLines {
 		remaining := totalLines - end
 		footer = fmt.Sprintf("\n\n[%d more lines below. Use grep to find specific patterns, or offset=%d to continue reading.]",
 			remaining, end+1)

--- a/pkg/tools/read_test.go
+++ b/pkg/tools/read_test.go
@@ -102,7 +102,7 @@ func TestReadTool_OffsetOnly(t *testing.T) {
 	ws, _ := NewWorkspace(dir)
 	tool := NewReadTool(ws)
 
-	// Read from line 90 (offset=90, default limit=2000)
+	// Read from line 90 (offset=90, default limit=4000)
 	result, err := tool.Execute(context.Background(), map[string]any{
 		"path":   filePath,
 		"offset": float64(90),
@@ -154,9 +154,9 @@ func TestReadTool_SelectedRangeTooLarge(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "large.txt")
 
-	// Create a file larger than 50KB with many lines
+	// Create a file larger than 100KB with many lines
 	var content string
-	for len(content) < 60*1024 {
+	for len(content) < 120*1024 {
 		content += strings.Repeat("a", 100) + "\n"
 	}
 	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
@@ -166,7 +166,7 @@ func TestReadTool_SelectedRangeTooLarge(t *testing.T) {
 	ws, _ := NewWorkspace(dir)
 	tool := NewReadTool(ws)
 
-	// Reading without offset/limit selects all lines, which exceeds 50KB
+	// Reading without offset/limit selects all lines, which exceeds 100KB
 	_, err := tool.Execute(context.Background(), map[string]any{
 		"path": filePath,
 	})
@@ -185,7 +185,7 @@ func TestReadTool_LargeFileWithOffsetLimit(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "large.txt")
 
-	// Create a file larger than 50KB with many lines
+	// Create a file larger than 100KB with many lines
 	var content string
 	lineWidth := 100
 	for len(content) < 60*1024 {
@@ -198,7 +198,7 @@ func TestReadTool_LargeFileWithOffsetLimit(t *testing.T) {
 	ws, _ := NewWorkspace(dir)
 	tool := NewReadTool(ws)
 
-	// Reading with limit=5 should succeed even though file is > 50KB
+	// Reading with limit=5 should succeed even though file is > 100KB
 	result, err := tool.Execute(context.Background(), map[string]any{
 		"path":  filePath,
 		"limit": float64(5),


### PR DESCRIPTION
## 背景

通过分析一次 331s 的 code review perfetto trace，发现以下性能瓶颈：

- **Read limit (2000行/50KB)** 导致 3852 行 diff 被拒绝 → 27 轮 grep/read → context 膨胀 → 触发 compaction
- **Review skill 预生成 diff 文件** 是不必要的，agent 自己可以 git diff
- **Compaction LLM 调用** 缺少 `llm_call` B/E trace event，无法在 trace 中观测
- **Compaction threshold (20%)** 太低，第一次 compaction 花 50s 只省 743 tokens

## 改动

### P0: Read tool limit 提高并配置化
- 默认 limit 2000→4000 行，max bytes 50KB→100KB
- 新增 `AI_READ_MAX_BYTES` 和 `AI_READ_MAX_LINES` 环境变量支持运行时配置
- 更新相关测试

### P0: Review skill 优化
- 移除 diff 文件生成流程，改为传入项目目录
- Agent 自己执行 `git diff` 和读取源文件，避免大文件问题

### P1: Compaction trace 可观测性
- 在 compaction LLM 调用周围添加 `llm_call` B/E span event
- 捕获 `input_tokens`, `output_tokens`, `first_token_ms`, `duration_ms`, `*_per_sec`
- 添加 `caller=context_management` 字段区分正常 LLM 调用

### P1: Compaction threshold 调整
- `MgmtTokenLow` 从 20% → 35%，避免过早触发 compaction

## 测试

```
go build ./...          # ✅
go test ./pkg/tools/    # ✅ (TestRead 全通过)
go test ./pkg/compact/  # ✅ (全部通过)
```