### PR TITLE
refactor: loop guard returns ToolResult feedback to LLM instead of aborting

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -67,7 +67,7 @@ type LoopConfig struct {
 	// EnableCheckpoint enables automatic checkpoint creation (default true).
 	EnableCheckpoint bool
 	// MaxLoopGuardFeedback is the number of feedback rounds the loop guard gives
-	// the LLM before escalating to a hard abort (0=default=2, <0=always feedback/never hard-abort).
+	// the LLM before escalating to a hard abort (0=default=2).
 	MaxLoopGuardFeedback int
 }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -66,6 +66,9 @@ type LoopConfig struct {
 	LLMFirstResponseTimeout time.Duration
 	// EnableCheckpoint enables automatic checkpoint creation (default true).
 	EnableCheckpoint bool
+	// MaxLoopGuardFeedback is the number of feedback rounds the loop guard gives
+	// the LLM before escalating to a hard abort (0=default=2, <0=always feedback/never hard-abort).
+	MaxLoopGuardFeedback int
 }
 
 // getEffectiveModel returns the current model, using GetModel callback if available.

--- a/pkg/agent/loop_characterization_test.go
+++ b/pkg/agent/loop_characterization_test.go
@@ -248,15 +248,15 @@ func TestCharacterization_ToolLoopGuard(t *testing.T) {
 		t.Error("expected EventLoopGuardTriggered event")
 	}
 
-	// LLM should be called MaxConsecutiveToolCalls + 1 times
-	// (the guard triggers on the N+1th call when it observes the Nth tool result
-	// and sees the same pattern, but actually it observes the tool calls of the
-	// current response, so it triggers when consecutive count exceeds threshold)
+	// LLM should be called MaxConsecutiveToolCalls + 1 + defaultLoopGuardMaxFeedback times
+	// (3 identical calls allowed, then guard triggers → feedback #1 → LLM retries,
+	//  feedback #2 → LLM retries, then hard abort)
+	// Total: 3 normal + 2 feedback + 1 abort = 6
 	mu.Lock()
 	count := llmCallCount
 	mu.Unlock()
-	if count != 4 { // 3 identical calls allowed, 4th triggers guard
-		t.Errorf("expected 4 LLM calls (3 allowed + 1 guard trigger), got %d", count)
+	if count != 6 { // 3 allowed + 2 feedback + 1 hard abort trigger
+		t.Errorf("expected 6 LLM calls (3 allowed + 2 feedback + 1 hard abort), got %d", count)
 	}
 
 	// Must end with agent_end

--- a/pkg/agent/loop_recovery_test.go
+++ b/pkg/agent/loop_recovery_test.go
@@ -183,18 +183,25 @@ func TestRunInnerLoopStopsRepeatedToolCalls(t *testing.T) {
 		MaxToolCallsPerName:     100,
 	}, stream)
 
-	if callCount != 3 {
-		t.Fatalf("expected loop guard to stop on third repeated call, got %d calls", callCount)
+	// With the feedback-to-LLM strategy:
+	//   call 1-2: normal execution
+	//   call 3: guard triggers → feedback #1 → LLM retries
+	//   call 4: guard triggers → feedback #2 → LLM retries
+	//   call 5: guard triggers → hard abort (feedback limit exhausted)
+	if callCount != 5 {
+		t.Fatalf("expected loop guard to hard-abort after 5 calls (2 normal + 2 feedback + 1 abort), got %d calls", callCount)
 	}
 
 	var sawGuardedTurn bool
 	var sawGuardEvent bool
+	var guardEventCount int
 	for item := range stream.Iterator(context.Background()) {
 		if item.Done {
 			break
 		}
 		if item.Value.Type == EventLoopGuardTriggered && item.Value.LoopGuard != nil && strings.TrimSpace(item.Value.LoopGuard.Reason) != "" {
 			sawGuardEvent = true
+			guardEventCount++
 		}
 		if item.Value.Type != EventTurnEnd || item.Value.Message == nil {
 			continue
@@ -210,6 +217,10 @@ func TestRunInnerLoopStopsRepeatedToolCalls(t *testing.T) {
 	}
 	if !sawGuardEvent {
 		t.Fatal("expected loop_guard_triggered event")
+	}
+	// Guard should trigger 3 times: 2 feedback + 1 hard abort
+	if guardEventCount != 3 {
+		t.Fatalf("expected 3 loop guard events (2 feedback + 1 hard abort), got %d", guardEventCount)
 	}
 }
 
@@ -244,8 +255,13 @@ func TestRunInnerLoopStopsRepeatedToolCallsByDefaultGuard(t *testing.T) {
 	runInnerLoop(context.Background(), agentCtx, nil, &LoopConfig{}, stream)
 
 	// defaultLoopMaxConsecutiveToolCalls = 6, so guard triggers on the 7th call.
-	if callCount != 7 {
-		t.Fatalf("expected default loop guard to stop on 7th repeated call, got %d calls", callCount)
+	// With feedback-to-LLM strategy (defaultLoopGuardMaxFeedback = 2):
+	//   call 1-6: normal execution
+	//   call 7: guard triggers → feedback #1 → LLM retries
+	//   call 8: guard triggers → feedback #2 → LLM retries
+	//   call 9: guard triggers → hard abort (feedback limit exhausted)
+	if callCount != 9 {
+		t.Fatalf("expected default loop guard to hard-abort after 9 calls (6 normal + 2 feedback + 1 abort), got %d calls", callCount)
 	}
 }
 
@@ -848,5 +864,195 @@ func TestRunInnerLoopLLMContextUpdateDoesNotTriggerLoopGuard(t *testing.T) {
 
 	if guardTriggeredForLLMContextUpdate {
 		t.Fatal("task_tracking should NOT trigger loop guard")
+	}
+}
+
+// TestLoopGuardFeedbackAllowsLLMSelfCorrection verifies that when the loop guard
+// detects repeated tool calls, it returns a ToolResult (feedback) to the LLM
+// instead of immediately aborting. The LLM can then self-correct by calling a
+// different tool and completing successfully.
+func TestLoopGuardFeedbackAllowsLLMSelfCorrection(t *testing.T) {
+	orig := streamAssistantResponseFn
+	defer func() { streamAssistantResponseFn = orig }()
+
+	callCount := 0
+	streamAssistantResponseFn = func(
+		_ context.Context,
+		_ *agentctx.AgentContext,
+		_ *LoopConfig,
+		_ *llm.EventStream[AgentEvent, []agentctx.AgentMessage],
+	) (*agentctx.AgentMessage, error) {
+		callCount++
+		msg := agentctx.NewAssistantMessage()
+
+		if callCount <= 3 {
+			// First 3 calls: repeat the same tool call (will trigger guard on call 3)
+			msg.Content = []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:        "call-repeat-" + fmt.Sprint(callCount),
+					Type:      "toolCall",
+					Name:      "read",
+					Arguments: map[string]any{"path": "/tmp/a.txt"},
+				},
+			}
+			msg.StopReason = "tool_calls"
+			return &msg, nil
+		}
+
+		// After receiving loop guard feedback, LLM self-corrects and returns text
+		msg.Content = []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "I see the file doesn't exist. Let me try something else."},
+		}
+		msg.StopReason = "stop"
+		return &msg, nil
+	}
+
+	agentCtx := agentctx.NewAgentContext("sys")
+	agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("start"))
+	stream := newTestAgentEventStream()
+	runInnerLoop(context.Background(), agentCtx, nil, &LoopConfig{
+		MaxConsecutiveToolCalls: 2,
+		MaxToolCallsPerName:     100,
+	}, stream)
+
+	// call 1-2: normal execution
+	// call 3: guard triggers → feedback → LLM sees result, tries again
+	// call 4: LLM self-corrects and returns text (stop)
+	if callCount != 4 {
+		t.Fatalf("expected 4 calls (2 normal + 1 guard feedback + 1 self-correction), got %d", callCount)
+	}
+
+	// Verify loop guard event was emitted (soft feedback, not hard abort)
+	var sawFeedbackEvent bool
+	var sawHardAbort bool
+	var sawFeedbackInTurnEnd bool
+	for item := range stream.Iterator(context.Background()) {
+		if item.Done {
+			break
+		}
+		if item.Value.Type == EventLoopGuardTriggered && item.Value.LoopGuard != nil {
+			sawFeedbackEvent = true
+		}
+		if item.Value.Type == EventTurnEnd {
+			if item.Value.Message != nil && item.Value.Message.StopReason == "aborted" {
+				sawHardAbort = true
+			}
+			// Check if the tool results in the turn end contain loop guard feedback
+			for _, tr := range item.Value.ToolResults {
+				if tr.IsError && strings.Contains(tr.ExtractText(), "[Loop guard]") {
+					sawFeedbackInTurnEnd = true
+				}
+			}
+		}
+	}
+
+	if !sawFeedbackEvent {
+		t.Fatal("expected loop_guard_triggered event for soft feedback")
+	}
+	if sawHardAbort {
+		t.Fatal("expected no hard abort — LLM should self-correct after feedback")
+	}
+	if !sawFeedbackInTurnEnd {
+		t.Fatal("expected tool result with loop guard feedback in turn_end event")
+	}
+}
+
+// TestLoopGuardFeedbackResetsOnSignatureChange verifies that the feedback counter
+// resets when the LLM changes its tool call signature after receiving feedback.
+func TestLoopGuardFeedbackResetsOnSignatureChange(t *testing.T) {
+	orig := streamAssistantResponseFn
+	defer func() { streamAssistantResponseFn = orig }()
+
+	callCount := 0
+	streamAssistantResponseFn = func(
+		_ context.Context,
+		_ *agentctx.AgentContext,
+		_ *LoopConfig,
+		_ *llm.EventStream[AgentEvent, []agentctx.AgentMessage],
+	) (*agentctx.AgentMessage, error) {
+		callCount++
+		msg := agentctx.NewAssistantMessage()
+
+		if callCount <= 3 {
+			// First 3 calls: repeat read /tmp/a.txt (guard triggers on call 3)
+			msg.Content = []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:        "call-read-a-" + fmt.Sprint(callCount),
+					Type:      "toolCall",
+					Name:      "read",
+					Arguments: map[string]any{"path": "/tmp/a.txt"},
+				},
+			}
+			msg.StopReason = "tool_calls"
+			return &msg, nil
+		}
+
+		if callCount == 4 {
+			// After guard feedback, LLM switches to a different file (signature changes)
+			msg.Content = []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:        "call-read-b-4",
+					Type:      "toolCall",
+					Name:      "read",
+					Arguments: map[string]any{"path": "/tmp/b.txt"},
+				},
+			}
+			msg.StopReason = "tool_calls"
+			return &msg, nil
+		}
+
+		if callCount <= 6 {
+			// Repeat /tmp/b.txt for calls 5 and 6
+			msg.Content = []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:        "call-read-b-" + fmt.Sprint(callCount),
+					Type:      "toolCall",
+					Name:      "read",
+					Arguments: map[string]any{"path": "/tmp/b.txt"},
+				},
+			}
+			msg.StopReason = "tool_calls"
+			return &msg, nil
+		}
+
+		// Self-correct after second guard feedback
+		msg.Content = []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "done"},
+		}
+		msg.StopReason = "stop"
+		return &msg, nil
+	}
+
+	agentCtx := agentctx.NewAgentContext("sys")
+	agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("start"))
+	stream := newTestAgentEventStream()
+	runInnerLoop(context.Background(), agentCtx, nil, &LoopConfig{
+		MaxConsecutiveToolCalls: 2,
+		MaxToolCallsPerName:     100,
+	}, stream)
+
+	// call 1: read a.txt (consecutive=1) — executed
+	// call 2: read a.txt (consecutive=2) — executed
+	// call 3: read a.txt (consecutive=3) → guard triggers feedback #1
+	// call 4: read b.txt (signature reset, consecutive=1) — executed
+	// call 5: read b.txt (consecutive=2) — executed
+	// call 6: read b.txt (consecutive=3) → guard triggers feedback #1 (fresh counter)
+	// call 7: LLM self-corrects → done
+	if callCount != 7 {
+		t.Fatalf("expected 7 calls with signature reset, got %d", callCount)
+	}
+
+	var guardEventCount int
+	for item := range stream.Iterator(context.Background()) {
+		if item.Done {
+			break
+		}
+		if item.Value.Type == EventLoopGuardTriggered {
+			guardEventCount++
+		}
+	}
+	// Two guard events: one for /tmp/a.txt loop, one for /tmp/b.txt loop
+	if guardEventCount != 2 {
+		t.Fatalf("expected 2 guard events (one per signature), got %d", guardEventCount)
 	}
 }

--- a/pkg/agent/loop_state.go
+++ b/pkg/agent/loop_state.go
@@ -203,19 +203,35 @@ func (s *loopState) processToolCalls(
 
 	// Check loop guard for consecutive identical tool call patterns.
 	if hasMore && s.loopGuard != nil {
-		if blocked, reason := s.loopGuard.Observe(toolCalls); blocked {
-			slog.Warn("[Loop] tool call loop guard triggered", "reason", reason)
-			s.stream.Push(NewLoopGuardTriggeredEvent(LoopGuardInfo{Reason: reason}))
+		result := s.loopGuard.Observe(toolCalls)
+		if result.Blocked {
+			slog.Warn("[Loop] tool call loop guard triggered", "reason", result.Reason, "hardAbort", result.HardAbort, "feedbackAttempt", result.FeedbackAttempt)
+			s.stream.Push(NewLoopGuardTriggeredEvent(LoopGuardInfo{Reason: result.Reason}))
 			traceevent.Log(ctx, traceevent.CategoryEvent, "tool_loop_guard_triggered",
-				traceevent.Field{Key: "reason", Value: reason},
+				traceevent.Field{Key: "reason", Value: result.Reason},
 				traceevent.Field{Key: "call_count", Value: len(toolCalls)},
+				traceevent.Field{Key: "hard_abort", Value: result.HardAbort},
+				traceevent.Field{Key: "feedback_attempt", Value: result.FeedbackAttempt},
 			)
-			sanitizeMessageForToolLoopGuard(msg, reason)
-			// Update the message in both arrays to reflect sanitization.
-			s.agentCtx.RecentMessages[len(s.agentCtx.RecentMessages)-1] = *msg
-			s.newMessages = replaceLast(s.newMessages, *msg)
-			hasMore = false
-			return hasMore, nil
+
+			if result.HardAbort {
+				// Escalation limit reached: sanitize the message and abort.
+				sanitizeMessageForToolLoopGuard(msg, result.Reason)
+				s.agentCtx.RecentMessages[len(s.agentCtx.RecentMessages)-1] = *msg
+				s.newMessages = replaceLast(s.newMessages, *msg)
+				hasMore = false
+				return hasMore, nil
+			}
+
+			// Soft feedback: construct ToolResult messages for each blocked tool call
+			// and return them to the LLM so it can self-correct.
+			toolResults := buildLoopGuardToolResults(toolCalls, result, s.loopGuard.maxFeedbackAttempts)
+			for _, tr := range toolResults {
+				s.agentCtx.RecentMessages = append(s.agentCtx.RecentMessages, tr)
+				s.newMessages = append(s.newMessages, tr)
+			}
+			// hasMore stays true — the LLM will see the feedback results and get another turn.
+			return hasMore, toolResults
 		}
 	}
 

--- a/pkg/agent/tool_guard.go
+++ b/pkg/agent/tool_guard.go
@@ -14,12 +14,25 @@ import (
 // toolLoopGuard detects and prevents infinite tool call loops.
 // It only counts consecutive calls with the same signature (name + arguments hash).
 // When the tool or arguments change, the counter resets to 1.
+//
+// Strategy: instead of aborting immediately, the guard returns a ToolResult
+// with actionable feedback so the LLM can self-correct. After maxFeedbackAttempts
+// the guard escalates to a hard abort.
 type toolLoopGuard struct {
 	maxConsecutive int
 
 	lastSignature  string
 	consecutiveRun int
+
+	// feedbackCount tracks how many times the guard has returned feedback
+	// to the LLM for the same repeated signature.
+	feedbackCount int
+	// maxFeedbackAttempts is the number of feedback rounds before hard abort.
+	// 0 means use the default (defaultLoopGuardMaxFeedback).
+	maxFeedbackAttempts int
 }
+
+const defaultLoopGuardMaxFeedback = 2
 
 func newToolLoopGuard(config *LoopConfig) *toolLoopGuard {
 	if config == nil {
@@ -29,8 +42,13 @@ func newToolLoopGuard(config *LoopConfig) *toolLoopGuard {
 	if maxConsecutive == 0 {
 		return nil
 	}
+	maxFeedback := defaultLoopGuardMaxFeedback
+	if config.MaxLoopGuardFeedback > 0 {
+		maxFeedback = config.MaxLoopGuardFeedback
+	}
 	return &toolLoopGuard{
-		maxConsecutive: maxConsecutive,
+		maxConsecutive:     maxConsecutive,
+		maxFeedbackAttempts: maxFeedback,
 	}
 }
 
@@ -44,10 +62,26 @@ func resolveLoopGuardLimit(value, defaultValue int) int {
 	return value
 }
 
+// ObserveResult holds the outcome of a loop guard check.
+type ObserveResult struct {
+	// Blocked is true when a loop is detected.
+	Blocked bool
+	// Reason describes why the loop was detected.
+	Reason string
+	// HardAbort is true when the guard has exhausted feedback attempts
+	// and the loop must be terminated.
+	HardAbort bool
+	// FeedbackAttempt is the 1-based feedback round number (0 if not feedback).
+	FeedbackAttempt int
+}
+
 // Observe checks tool calls for loop patterns.
 // It only counts consecutive calls with the same signature (name + arguments hash).
 // When the signature changes, the counter resets.
-func (g *toolLoopGuard) Observe(toolCalls []agentctx.ToolCallContent) (bool, string) {
+//
+// Returns an ObserveResult indicating whether a loop was detected and whether
+// the guard should return feedback to the LLM (soft) or abort (hard).
+func (g *toolLoopGuard) Observe(toolCalls []agentctx.ToolCallContent) ObserveResult {
 	for _, tc := range toolCalls {
 		name := strings.ToLower(strings.TrimSpace(tc.Name))
 		if name == "" {
@@ -60,13 +94,64 @@ func (g *toolLoopGuard) Observe(toolCalls []agentctx.ToolCallContent) (bool, str
 		} else {
 			g.lastSignature = signature
 			g.consecutiveRun = 1
+			g.feedbackCount = 0
 		}
 
 		if g.maxConsecutive > 0 && g.consecutiveRun > g.maxConsecutive {
-			return true, fmt.Sprintf("detected %d consecutive identical tool calls (%s)", g.consecutiveRun, name)
+			reason := fmt.Sprintf("detected %d consecutive identical tool calls (%s)", g.consecutiveRun, name)
+
+			// Check if we've exhausted feedback attempts.
+			if g.feedbackCount >= g.maxFeedbackAttempts {
+				return ObserveResult{
+					Blocked:   true,
+					Reason:    reason,
+					HardAbort: true,
+				}
+			}
+
+			g.feedbackCount++
+			return ObserveResult{
+				Blocked:         true,
+				Reason:          reason,
+				HardAbort:       false,
+				FeedbackAttempt: g.feedbackCount,
+			}
 		}
 	}
-	return false, ""
+	return ObserveResult{Blocked: false}
+}
+
+// buildLoopGuardToolResults creates ToolResult messages for each tool call that
+// was blocked by the loop guard. These results are returned to the LLM as
+// feedback so it can self-correct its approach.
+func buildLoopGuardToolResults(toolCalls []agentctx.ToolCallContent, result ObserveResult, maxFeedback int) []agentctx.AgentMessage {
+	results := make([]agentctx.AgentMessage, 0, len(toolCalls))
+	feedbackMsg := fmt.Sprintf(
+		"[Loop guard] Repeated identical tool call detected: %s\n\n"+
+			"You have made the same tool call with identical arguments multiple times in a row. "+
+			"This suggests the tool is not producing the expected result or you are stuck in a loop.\n\n"+
+			"Please try a different approach:\n"+
+			"- Use different arguments or parameters\n"+
+			"- Try a different tool entirely\n"+
+			"- If the tool keeps returning an error, investigate the root cause first\n"+
+			"- Consider whether you need this tool call at all\n\n"+
+			"Feedback attempt %d of %d. If you continue with the same call, the loop will be terminated.",
+		strings.TrimSpace(result.Reason),
+		result.FeedbackAttempt,
+		maxFeedback,
+	)
+
+	for _, tc := range toolCalls {
+		name := strings.ToLower(strings.TrimSpace(tc.Name))
+		if name == "" {
+			name = "unknown"
+		}
+		toolResult := agentctx.NewToolResultMessage(tc.ID, name, []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: feedbackMsg},
+		}, true)
+		results = append(results, toolResult)
+	}
+	return results
 }
 
 func sanitizeMessageForToolLoopGuard(msg *agentctx.AgentMessage, reason string) {


### PR DESCRIPTION
## Summary

Previously, the tool loop guard detected consecutive identical tool calls and immediately aborted the conversation. This prevented the LLM from self-correcting.

Now the guard implements a feedback-to-LLM strategy:
1. On loop detection: returns a ToolResult with actionable feedback suggesting the LLM try a different approach
2. After MaxLoopGuardFeedback rounds (default 2): escalates to hard abort (preserving safety ceiling)
3. Feedback counter resets when the tool call signature changes

## Test plan
- [x] Updated existing tests (TestRunInnerLoopStopsRepeatedToolCalls, TestRunInnerLoopStopsRepeatedToolCallsByDefaultGuard, TestCharacterization_ToolLoopGuard)
- [x] Added TestLoopGuardFeedbackAllowsLLMSelfCorrection — verifies LLM can self-correct after feedback
- [x] Added TestLoopGuardFeedbackResetsOnSignatureChange — verifies counter resets on tool change
- [x] All agent package tests pass: `go test ./pkg/agent/ -v`
- [x] Core packages pass: `go test ./pkg/agent/... ./pkg/context/... ./pkg/rpc/... ./pkg/session/...`