### PR TITLE
Fix: [IMPROVEMENT] find_skill query parameter description optimization

### DIFF
--- a/pkg/tools/find_skill.go
+++ b/pkg/tools/find_skill.go
@@ -84,7 +84,7 @@ func (t *FindSkillTool) Parameters() map[string]any {
 		"properties": map[string]any{
 			"query": map[string]any{
 				"type":        "string",
-				"description": "Keyword to search — matches against skill name, description, aliases, use-when triggers, and categories (case-insensitive substring)",
+				"description": "Extract concise keywords from user input first, then search. Matches each keyword against skill name, description, aliases, use-when triggers, and categories (case-insensitive substring). Prefer short terms (e.g. use 'grill' not 'grill me about my design'). Multiple short queries are better than one long query.",
 			},
 			"load": map[string]any{
 				"type":        "boolean",


### PR DESCRIPTION
## Workpad

```
geniusdeMBP:/Users/genius/.symphony/workspaces/9fd51eae-93ff-467a-a6c2-432b9dca4023@0885f06
```

### Plan

- [x] 1. Locate find_skill tool query parameter description
  - [x] 1.1 Found in `pkg/tools/find_skill.go` line 87
- [x] 2. Update query parameter description to guide keyword extraction
- [ ] 3. Validate change (run tests)
- [ ] 4. Commit and push
- [ ] 5. Create PR with symphony label
- [ ] 6. Self-review and move to Done

### Acceptance Criteria

- [x] query parameter description updated from generic "Keyword to search..." to keyword-extraction guidance
- [ ] Existing tests still pass (pre-existing failure in TestFindSkill_CaseInsensitiveSearch unrelated to this change)
- [ ] PR created with symphony label

### Validation

- [x] targeted tests: `go test ./pkg/tools/ -run FindSkill -v` — only pre-existing failure (CaseInsensitiveSearch reads real ~/.ai/skill-index.json)

### Notes

- 2025-05-13: Confirmed TestFindSkill_CaseInsensitiveSearch fails on baseline too (reads real skill-index.json from ~/.ai/) — not caused by this change.