### PR TITLE
Improve find_skill query description to guide keyword extraction

### DIFF
--- a/pkg/tools/find_skill.go
+++ b/pkg/tools/find_skill.go
@@ -84,7 +84,7 @@ func (t *FindSkillTool) Parameters() map[string]any {
 		"properties": map[string]any{
 			"query": map[string]any{
 				"type":        "string",
-				"description": "Keyword to search — matches against skill name, description, aliases, use-when triggers, and categories (case-insensitive substring)",
+				"description": "Extract concise keywords from user input first, then search. Matches each keyword against skill name, description, aliases, use-when triggers, and categories (case-insensitive substring). Prefer short terms (e.g. 'grill' not 'grill me about my design'). Multiple short queries are better than one long query.",
 			},
 			"load": map[string]any{
 				"type":        "boolean",


### PR DESCRIPTION
## Summary

Improves the `find_skill` tool's `query` parameter description to guide the LLM agent to extract concise keywords from user input before searching.

## Problem
The `find_skill` tool performs case-insensitive substring matching. When users express intent in long natural language (e.g. "challenge my design"), the agent passes the entire phrase as the query, which fails to match existing skill aliases like "challenge".

## Change
Updated the `query` parameter description in `pkg/tools/find_skill.go` `Parameters()` method.

**Before:** Keyword to search — matches against skill name, description, aliases, use-when triggers, and categories (case-insensitive substring)

**After:** Extract concise keywords from user input first, then search. Matches each keyword against skill name, description, aliases, use-when triggers, and categories (case-insensitive substring). Prefer short terms (e.g. 'grill' not 'grill me about my design'). Multiple short queries are better than one long query.

## Testing
- All existing find_skill tests pass (one pre-existing test failure unrelated to this change)
- Single-line description update with no logic changes