### PR TITLE
Fix: keep worker agent alive across pair.sh rounds

### DIFF
--- a/skills/ag/SKILL.md
+++ b/skills/ag/SKILL.md
@@ -362,17 +362,21 @@ ag agent prompt <main-agent-id> "task:<task-name> status:failed error:<错误原
 
 一个 agent 产出，另一个 agent 审查，循环直到通过。
 
+**Worker 保持跨轮次存活**：worker 只 spawn 一次，后续轮次通过 `ag agent prompt` 发送 judge 反馈。这保留了 worker 的完整上下文，使其能在先前尝试的基础上迭代改进。Judge 每轮重新 spawn 以保持独立性。
+
 ```
 1. ag agent spawn worker --system worker-prompt --input "task description"
 2. ag agent wait worker --timeout 300
 3. ag agent output worker > /tmp/worker-output.txt
-4. ag agent rm worker
-5. ag agent spawn judge --system judge-prompt --input "$(cat /tmp/worker-output.txt)"
-6. ag agent wait judge --timeout 60
-7. ag agent output judge > /tmp/judge-output.txt
-8. ag agent rm judge
-9. if APPROVED → done
-   else → feed judge feedback back to worker, repeat from step 1
+   (do NOT rm worker — keep it alive for the loop)
+4. ag agent spawn judge --system judge-prompt --input "$(cat /tmp/worker-output.txt)"
+5. ag agent wait judge --timeout 60
+6. ag agent output judge > /tmp/judge-output.txt
+7. ag agent rm judge
+8. if APPROVED → ag agent rm worker, done
+   else → ag agent prompt worker "$(cat /tmp/judge-feedback.txt)"
+          ag agent wait worker --timeout 300
+          repeat from step 3
 ```
 
 封装在 `patterns/pair.sh` 中：

--- a/skills/ag/patterns/pair.sh
+++ b/skills/ag/patterns/pair.sh
@@ -6,6 +6,11 @@
 # Worker and judge prompt args are file paths. Their contents are read and
 # passed as --system to ag agent spawn.
 #
+# The worker agent is kept alive across rounds so it retains context from
+# previous iterations. Judge feedback is sent as a follow-up prompt via
+# `ag agent prompt`. The judge is freshly spawned each round to maintain
+# independence.
+#
 # Environment:
 #   AG_BINARY — path to ag binary (defaults to "ag")
 #
@@ -18,6 +23,18 @@ JUDGE_PROMPT_FILE="$2"
 INPUT_FILE="$3"
 MAX_ROUNDS="${4:-3}"
 
+WORKER_ID="pair-w-$$"
+WORKER_RUNNING=false
+
+cleanup() {
+  if [ "$WORKER_RUNNING" = true ]; then
+    echo "[pair] Cleaning up worker agent ($WORKER_ID)..."
+    $AG_BINARY agent rm "$WORKER_ID" 2>/dev/null || true
+    WORKER_RUNNING=false
+  fi
+}
+trap cleanup EXIT
+
 # --system @file reads the file content directly.
 # Prompt file args are paths prefixed with @.
 
@@ -25,31 +42,27 @@ echo "[pair] Starting worker-judge loop (max $MAX_ROUNDS rounds)"
 echo "[pair] Worker prompt: $WORKER_PROMPT_FILE ($(wc -l < "$WORKER_PROMPT_FILE" | tr -d ' ') lines)"
 echo "[pair] Judge prompt:  $JUDGE_PROMPT_FILE ($(wc -l < "$JUDGE_PROMPT_FILE" | tr -d ' ') lines)"
 
-FEEDBACK_FILE=""
-
 for round in $(seq 1 "$MAX_ROUNDS"); do
-  # Unique IDs per round to avoid "agent already exists"
-  WORKER_ID="pair-w-$$-r${round}"
   JUDGE_ID="pair-j-$$-r${round}"
 
   echo "[pair] === Round $round ==="
 
-  # --- Spawn worker ---
-  if [ "$round" -gt 1 ] && [ -n "$FEEDBACK_FILE" ]; then
-    CURRENT_INPUT=$(cat "$FEEDBACK_FILE")
-  else
-    CURRENT_INPUT=$(cat "$INPUT_FILE")
-  fi
-
+  if [ "$round" -eq 1 ]; then
+    # --- Spawn worker (once, at start of round 1) ---
     $AG_BINARY agent spawn "$WORKER_ID" \
-    --system "@$WORKER_PROMPT_FILE" \
-    --input "$CURRENT_INPUT"
+      --system "@$WORKER_PROMPT_FILE" \
+      --input "$(cat "$INPUT_FILE")"
+    WORKER_RUNNING=true
+  else
+    # --- Resume worker with judge feedback (not respawn) ---
+    echo "[pair] Sending judge feedback to existing worker ($WORKER_ID)..."
+    $AG_BINARY agent prompt "$WORKER_ID" "$(cat "$FEEDBACK_FILE")"
+  fi
 
   # --- Wait for worker ---
   echo "[pair] Waiting for worker ($WORKER_ID)..."
   if ! $AG_BINARY agent wait "$WORKER_ID" --timeout 120; then
     echo "[pair] Worker failed in round $round"
-    $AG_BINARY agent rm "$WORKER_ID" 2>/dev/null || true
     continue
   fi
 
@@ -58,12 +71,9 @@ for round in $(seq 1 "$MAX_ROUNDS"); do
   $AG_BINARY agent output "$WORKER_ID" > "$WORKER_OUTPUT"
   echo "[pair] Worker output: $(wc -l < "$WORKER_OUTPUT" | tr -d ' ') lines"
 
-  # Clean up worker agent
-  $AG_BINARY agent rm "$WORKER_ID" 2>/dev/null || true
-
-  # --- Spawn judge ---
+  # --- Spawn judge (fresh each round for independence) ---
   JUDGE_INPUT=$(cat "$WORKER_OUTPUT")
-    $AG_BINARY agent spawn "$JUDGE_ID" \
+  $AG_BINARY agent spawn "$JUDGE_ID" \
     --system "@$JUDGE_PROMPT_FILE" \
     --input "$JUDGE_INPUT"
 
@@ -90,22 +100,14 @@ for round in $(seq 1 "$MAX_ROUNDS"); do
     echo "[pair] ✅ Approved in round $round"
     cat "$WORKER_OUTPUT"
     rm -f "$WORKER_OUTPUT" "$JUDGE_OUTPUT"
-    [ -n "$FEEDBACK_FILE" ] && rm -f "$FEEDBACK_FILE"
+    [ -n "${FEEDBACK_FILE:-}" ] && rm -f "$FEEDBACK_FILE"
     exit 0
   fi
 
   # --- Prepare feedback for next round ---
   FEEDBACK_FILE=$(mktemp)
   {
-    echo "# Original task (from round 1)"
-    echo ""
-    cat "$INPUT_FILE"
-    echo ""
-    echo "# Previous attempt (round $round)"
-    echo ""
-    cat "$WORKER_OUTPUT"
-    echo ""
-    echo "# Judge feedback"
+    echo "# Judge feedback from round $round"
     echo ""
     cat "$JUDGE_OUTPUT"
     echo ""
@@ -118,5 +120,5 @@ for round in $(seq 1 "$MAX_ROUNDS"); do
 done
 
 echo "[pair] ❌ Max rounds ($MAX_ROUNDS) reached without approval"
-[ -n "$FEEDBACK_FILE" ] && rm -f "$FEEDBACK_FILE"
+[ -n "${FEEDBACK_FILE:-}" ] && rm -f "$FEEDBACK_FILE"
 exit 1


### PR DESCRIPTION
## Workpad

```text
symphony-workspace:~/.symphony/workspaces/8b4b8d93-4bb0-4260-9cf3-72d4b9dbe813@
```

### Plan

- [x] 1. Reproduce/investigate the bug
  - [x] 1.1 Read pair.sh and understand the current worker-judge loop
  - [x] 1.2 Verify `ag agent prompt` exists and how it works
  - [x] 1.3 Confirm `ai serve` stays alive after initial task (Process.Release)
- [ ] 2. Implement fix in `skills/ag/patterns/pair.sh`
  - [ ] 2.1 Move worker spawn before the loop
  - [ ] 2.2 Use `ag agent prompt` for round 2+ instead of respawn
  - [ ] 2.3 Keep judge as fresh spawn each round
  - [ ] 2.4 Only `ag agent rm worker` at end
- [ ] 3. Update `skills/ag/SKILL.md` worker-judge loop description
- [ ] 4. Validate: shellcheck and manual review
- [ ] 5. Commit, push, create PR
- [ ] 6. Self-review

### Acceptance Criteria

- [ ] Worker is spawned once before the loop (not per-round)
- [ ] Round 2+ uses `ag agent prompt` to send judge feedback to existing worker
- [ ] Judge is still freshly spawned each round (independence)
- [ ] Worker is only `ag agent rm`-ed after loop ends
- [ ] SKILL.md updated to reflect the new behavior
- [ ] Shellcheck passes on pair.sh

### Validation

- [ ] targeted tests: `shellcheck skills/ag/patterns/pair.sh`

### Notes

- Key constraint verified: `ai serve` stays alive after initial task via Process.Release(). The process enters idle state, ready for follow-up prompts.
- `ag agent prompt <id> <msg>` → calls `BridgeCommand(id, "prompt", msg)` → `bridgeCommandWithAI` → `aiAdapter.SendCommand` → `ai send --id <runID> <msg>`
- The output for round 2+ will still use `ag agent output` which reads from events.jsonl — this should accumulate the full conversation including the new prompt response.