### PR TITLE
refactor: migrate plan format from YAML to single-file Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Skills extend the agent's capabilities with domain-specific instructions, prompt
 |-------|-------------|
 | `ag` | Agent orchestration runtime — spawn, steer, and coordinate AI agents |
 | `brainstorm` | Explore user intent through conversation |
-| `plan` | Read design docs, produce task YAML with dependency DAG |
+| `plan` | Read design docs, produce task plan with dependency DAG |
 | `implement` | Code-driven task execution with ag task scheduler |
 | `brainstorm` | Interactive design exploration → design.md |
 | `review` | Code review using codex-rs methodology |
@@ -216,7 +216,7 @@ ag agent steer worker-1 "also check error handling"
 ag agent kill worker-1
 
 # Task DAG scheduling
-ag task import-plan tasks.yml
+ag task import-plan tasks.md
 ag task next --claimant worker-1
 ag task done T001 --summary "completed"
 ```

--- a/docs/design/plan-format-analysis.md
+++ b/docs/design/plan-format-analysis.md
@@ -1,0 +1,91 @@
+# Plan Format Analysis: YAML vs Single-File Markdown
+
+## Decision
+
+After a structured 3-round debate (proposer vs opposer), the conclusion is: **single-file Markdown** is the optimal plan format.
+
+## Evaluation Criteria
+
+Ranked by priority:
+1. Modification pass rate (LLM edit accuracy)
+2. Generation pass rate (LLM generates valid format)
+3. Lint pass rate (validator catches errors)
+4. Import pass rate (correct task creation)
+5. Implementation cost
+6. Human readability
+
+## Why Single-File Markdown Wins
+
+### Pain Points with YAML
+
+1. **`description: |` block scalar** requires precise indentation across dozens of lines
+2. A single indentation error corrupts the entire file
+3. LLM edit (find-replace) in a 1100-line YAML file frequently damages adjacent tasks
+4. `commit_message: feat(plan): add feature` fails YAML parsing (unquoted colons)
+
+### Advantages of Markdown
+
+1. **Zero indentation sensitivity** — task bodies are pure Markdown
+2. **LLM-friendly editing** — `## T001` section boundaries are natural edit anchors
+3. **Human-readable** — no YAML syntax noise in task descriptions
+4. **Horizontal rule separator** — `---` visually separates tasks
+5. **Frontmatter for metadata** — groups, risks, version stay in YAML (where they work well)
+
+### Why Not Multi-File
+
+The current `pair.sh` architecture spawns a fresh planner each round. Multi-file's "edit isolation" advantage (each task in its own file) doesn't apply when the planner regenerates the entire plan each round.
+
+Multi-file would add:
+- File creation/deletion complexity
+- Cross-file reference validation
+- Directory management overhead
+- No benefit over single-file for the current architecture
+
+## New Format
+
+```markdown
+---
+version: "1"
+metadata:
+  spec_file: design.md
+groups:
+  - name: agent
+    title: Agent loop
+    tasks: [T001, T002, T003]
+    commit_message: "feat(agent): description"
+group_order: [agent, storage]
+risks:
+  - area: "..."
+    risk: "..."
+    mitigation: "..."
+---
+
+## T001 — Task title (3h)
+
+**Dependencies:** none
+**Group:** agent
+
+### Goal
+One concrete sentence.
+
+### Key changes
+- Specific change
+
+### Files
+- CREATE: pkg/context/types.go
+- MODIFY: pkg/agent/agent.go
+
+### Done when
+- [ ] Observable behavior 1
+```
+
+## Implementation
+
+- `plan-lint` — parses frontmatter (YAML) + task sections (Markdown)
+- `ImportPlan` — reads Markdown format, falls back to legacy YAML
+- `planner.md` — instructs output in Markdown format
+- `reviewer.md` — validates Markdown structure and content
+
+## Debate Context
+
+This decision was made through a structured 3-round debate between a proposer and opposer, evaluating YAML, single-file Markdown, and multi-file Markdown approaches. The debate transcript is available in the task history.

--- a/pkg/tools/find_skill_test.go
+++ b/pkg/tools/find_skill_test.go
@@ -34,7 +34,7 @@ func testSkills() []skill.Skill {
 		},
 		{
 			Name:        "plan",
-			Description: "Read design.md, produce tasks.yml with plan-lint validation",
+			Description: "Read design.md, produce tasks.md with plan-lint validation",
 			FilePath:    "/home/user/.ai/skills/plan/SKILL.md",
 			Content:     "# Plan Skill\n\nThis is the full plan skill content.",
 		},

--- a/skills/ag/README.md
+++ b/skills/ag/README.md
@@ -77,7 +77,7 @@ ai rpc | ag conv --only tools          # Only tool calls
 
 ```bash
 ag task create "Implement OAuth2"
-ag task import-plan PLAN.yml                      # Import from plan with dependencies
+ag task import-plan tasks.md                      # Import from plan with dependencies
 ag task list [--status pending|claimed|done|failed]
 ag task claim <id> --as worker-1
 ag task next --as worker-1                        # Claim next unblocked task

--- a/skills/ag/SKILL.md
+++ b/skills/ag/SKILL.md
@@ -202,11 +202,11 @@ Common mistake: passing a hand-written `--system` that is *worse* than the defau
 # Create task
 ag task create "Implement OAuth2" [--file spec.md]
 
-# Import from plan YAML
-ag task import-plan tasks.yml
+# Import from plan file (Markdown or YAML)
+ag task import-plan tasks.md
 
-# Import from plan YAML (two-phase: create all, then link deps)
-ag task import-plan PLAN.yml [--design design.md]
+# Import from plan file (two-phase: create all, then link deps)
+ag task import-plan tasks.md [--design design.md]
 
 # List / filter
 ag task list [--status pending|claimed|done|failed]
@@ -349,7 +349,7 @@ ag agent prompt <main-agent-id> "task:<task-name> status:failed error:<错误原
 并行执行多个独立任务，每个任务一个 agent。
 
 ```
-1. ag task import-plan tasks.yml
+1. ag task import-plan tasks.md
 2. Get next task: ID=$(ag task next --claimant worker-N)
    Get description: ag task show $ID
 3. ag agent spawn worker-N --input "Task $ID: <title>\n<description>"

--- a/skills/ag/cmd/root.go
+++ b/skills/ag/cmd/root.go
@@ -684,7 +684,7 @@ var taskCreateCmd = &cobra.Command{
 
 var taskImportPlanCmd = &cobra.Command{
 	Use:   "import-plan <file>",
-	Short: "Import tasks from a PLAN.yml file",
+	Short: "Import tasks from a plan file (Markdown or YAML)",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		count, err := task.ImportPlan(args[0])

--- a/skills/ag/internal/task/task.go
+++ b/skills/ag/internal/task/task.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -502,7 +503,7 @@ func ClaimNext(claimant string) (string, error) {
 	return t.ID, nil
 }
 
-// ImportPlan imports tasks from a PLAN.yml file.
+// ImportPlan imports tasks from a plan file (supports Markdown format with YAML frontmatter).
 // Returns the number of tasks imported.
 func ImportPlan(filePath string) (int, error) {
 	data, err := os.ReadFile(filePath)
@@ -510,17 +511,8 @@ func ImportPlan(filePath string) (int, error) {
 		return 0, fmt.Errorf("read plan file: %w", err)
 	}
 
-	// Parse YAML plan
-	var plan struct {
-		Tasks []struct {
-			ID           string   `yaml:"id"`
-			Title        string   `yaml:"title"`
-			Description  string   `yaml:"description"`
-			Dependencies []string `yaml:"dependencies"`
-			Group        string   `yaml:"group"`
-		} `yaml:"tasks"`
-	}
-	if err := yaml.Unmarshal(data, &plan); err != nil {
+	tasks, err := parseMarkdownPlan(data)
+	if err != nil {
 		return 0, fmt.Errorf("parse plan: %w", err)
 	}
 
@@ -528,7 +520,7 @@ func ImportPlan(filePath string) (int, error) {
 	var depErrors []string
 
 	// Phase 1: Create all tasks first (ensures forward dependencies resolve)
-	for _, pt := range plan.Tasks {
+	for _, pt := range tasks {
 		desc := pt.Title
 		if pt.Description != "" {
 			desc = pt.Description
@@ -559,7 +551,7 @@ func ImportPlan(filePath string) (int, error) {
 	}
 
 	// Phase 2: Add dependencies (all tasks now exist, forward refs resolve)
-	for _, pt := range plan.Tasks {
+	for _, pt := range tasks {
 		if pt.ID == "" {
 			continue
 		}
@@ -574,6 +566,157 @@ func ImportPlan(filePath string) (int, error) {
 		return count, fmt.Errorf("dependency errors: %s", strings.Join(depErrors, "; "))
 	}
 	return count, nil
+}
+
+// planTask represents a parsed task from a Markdown plan file.
+type planTask struct {
+	ID           string
+	Title        string
+	Description  string
+	Dependencies []string
+	Group        string
+}
+
+// parseMarkdownPlan parses a Markdown file with YAML frontmatter and task sections.
+func parseMarkdownPlan(data []byte) ([]planTask, error) {
+	text := string(data)
+	text = strings.TrimSpace(text)
+
+	if !strings.HasPrefix(text, "---") {
+		// Fallback: try legacy YAML format
+		return parseLegacyYAMLPlan(data)
+	}
+
+	// Extract frontmatter
+	rest := text[3:]
+	closingIdx := strings.Index(rest, "\n---")
+	if closingIdx < 0 {
+		return nil, fmt.Errorf("frontmatter not closed: missing closing ---")
+	}
+
+	body := rest[closingIdx+4:]
+	body = strings.TrimPrefix(body, "\n")
+
+	// Parse task sections from Markdown body
+	return parseTaskSections(body), nil
+}
+
+// parseLegacyYAMLPlan parses the old YAML-only format for backward compatibility.
+func parseLegacyYAMLPlan(data []byte) ([]planTask, error) {
+	var plan struct {
+		Tasks []struct {
+			ID           string   `yaml:"id"`
+			Title        string   `yaml:"title"`
+			Description  string   `yaml:"description"`
+			Dependencies []string `yaml:"dependencies"`
+			Group        string   `yaml:"group"`
+		} `yaml:"tasks"`
+	}
+	if err := yaml.Unmarshal(data, &plan); err != nil {
+		return nil, fmt.Errorf("parse YAML plan: %w", err)
+	}
+
+	var tasks []planTask
+	for _, t := range plan.Tasks {
+		tasks = append(tasks, planTask{
+			ID:           t.ID,
+			Title:        t.Title,
+			Description:  t.Description,
+			Dependencies: t.Dependencies,
+			Group:        t.Group,
+		})
+	}
+	return tasks, nil
+}
+
+// taskHeaderRe matches `## T001 — Task title (3h)` or `## T001 - Task title (3h)`
+var taskHeaderRe = regexp.MustCompile(`^## (T\d+)\s*[—\-]\s*(.+?)(?:\s*\((\d+(?:\.\d+)?)h\))?\s*$`)
+
+// depLineRe matches `**Dependencies:** T001, T003` or `**Dependencies:** none`
+var depLineRe = regexp.MustCompile(`^\*\*Dependencies?:\*\*\s*(.+)$`)
+
+// groupLineRe matches `**Group:** agent`
+var groupLineRe = regexp.MustCompile(`^\*\*Group:\*\*\s*(.+)$`)
+
+// parseTaskSections splits the Markdown body into task sections by `## Txxx` headers.
+func parseTaskSections(body string) []planTask {
+	if strings.TrimSpace(body) == "" {
+		return nil
+	}
+
+	lines := strings.Split(body, "\n")
+
+	type section struct {
+		lines []string
+	}
+	var sections []section
+
+	currentSection := -1
+	for _, line := range lines {
+		if taskHeaderRe.MatchString(line) {
+			sections = append(sections, section{lines: []string{line}})
+			currentSection = len(sections) - 1
+		} else if currentSection >= 0 {
+			sections[currentSection].lines = append(sections[currentSection].lines, line)
+		}
+	}
+
+	var tasks []planTask
+	for _, sec := range sections {
+		task := parseTaskSection(sec.lines)
+		if task != nil {
+			tasks = append(tasks, *task)
+		}
+	}
+	return tasks
+}
+
+// parseTaskSection parses a single task section into a planTask.
+func parseTaskSection(lines []string) *planTask {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	task := &planTask{}
+
+	// Parse header line
+	headerMatch := taskHeaderRe.FindStringSubmatch(lines[0])
+	if headerMatch == nil {
+		return nil
+	}
+
+	task.ID = headerMatch[1]
+	task.Title = strings.TrimSpace(headerMatch[2])
+
+	// Parse metadata lines and collect body
+	var bodyLines []string
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+
+		if depMatch := depLineRe.FindStringSubmatch(trimmed); depMatch != nil {
+			depStr := strings.TrimSpace(depMatch[1])
+			if !strings.EqualFold(depStr, "none") && depStr != "" {
+				parts := strings.Split(depStr, ",")
+				for _, p := range parts {
+					p = strings.TrimSpace(p)
+					if p != "" {
+						task.Dependencies = append(task.Dependencies, p)
+					}
+				}
+			}
+			continue
+		}
+
+		if groupMatch := groupLineRe.FindStringSubmatch(trimmed); groupMatch != nil {
+			task.Group = strings.TrimSpace(groupMatch[1])
+			continue
+		}
+
+		bodyLines = append(bodyLines, line)
+	}
+
+	task.Description = strings.TrimSpace(strings.Join(bodyLines, "\n"))
+	return task
 }
 
 // Show returns task details.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -36,8 +36,8 @@ pending → claimed → running → done
 1. ag doctor                    # 工具链检查，必须全绿
 2. ag task ls                   # 确认有 pending tasks
 3. ai serve --help              # 手动确认 ai serve 可用（doctor 不检查这个）
-4. plan-lint PLAN.yml           # 单独跑一次，exit 0 才继续
-6. ag task import-plan PLAN.yml # 导入
+4. plan-lint tasks.md           # 单独跑一次，exit 0 才继续
+6. ag task import-plan tasks.md # 导入
 7. ag task run --detach --design docs/design/xxx.md --callback "ag agent prompt <main-id> 'scheduler done'"
 8. 主 agent 继续工作或等待，scheduler 完成后自动回调
 ```
@@ -272,7 +272,7 @@ worker 没有 design.md 做参考，实现会偏离设计意图。
 ### 3. plan 有隐藏控制字符
 从 plan skill 生成的 YAML 可能包含 `\x01`（regex 损坏残留）或其它控制字符。
 plan-lint 现在会检测这些，但必须在 import 前跑。
-**修复：** `plan-lint PLAN.yml && ag task import-plan PLAN.yml` 作为固定流水线。
+**修复：** `plan-lint tasks.md && ag task import-plan tasks.md` 作为固定流水线。
 
 ### 4. cleanup 删除 task 后 show 报错
 `ag task cleanup` 会删除 done/failed 的 task。之后 `ag task show t001` 报 `task not found`。

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: plan
-description: 读取 design.md，产出 tasks.yml（含 plan-lint 验证），导入 ag task 队列。
+description: 读取 design.md，产出 tasks.md（含 plan-lint 验证），导入 ag task 队列。
 ---
 
 # Plan
 
-读取 `design.md`，产出 `tasks.yml`，验证后导入 `ag task` 队列。
+读取 `design.md`，产出 `tasks.md`，验证后导入 `ag task` 队列。
 
 ## When to Use
 
@@ -29,25 +29,25 @@ description: 读取 design.md，产出 tasks.yml（含 plan-lint 验证），导
 ### Step 2: Worker-Judge Loop (Planner + Reviewer)
 
 plan 的核心是 **worker-judge loop**（ag patterns 中的 pair pattern）：
-- **Worker**（planner subagent）：读 design.md，产出 tasks.yml
-- **Judge**（reviewer subagent）：读 tasks.yml，验证自包含性
+- **Worker**（planner subagent）：读 design.md，产出 tasks.md
+- **Judge**（reviewer subagent）：读 tasks.md，验证自包含性
 
 最多 3 轮。每轮：planner 生成 → reviewer 审查 → APPROVED 则退出，否则把 feedback 喂给 planner 重来。
 
 ```bash
 DESIGN_MD="$(pwd)/design.md"
-TASKS_YML="$(pwd)/tasks.yml"
+TASKS_MD="$(pwd)/tasks.md"
 REVIEW_JSON="/tmp/plan-review-result.json"
 
 for ROUND in 1 2 3; do
   echo "=== Plan worker-judge round $ROUND ==="
 
   # --- Spawn planner (worker) ---
-  PLANNER_INPUT="Read the design document at ${DESIGN_MD} and produce a tasks.yml plan."
+  PLANNER_INPUT="Read the design document at ${DESIGN_MD} and produce a tasks.md plan."
   if [ "$ROUND" -gt 1 ] && [ -f "$REVIEW_JSON" ]; then
     PLANNER_INPUT="${PLANNER_INPUT} Address these review findings: $(cat $REVIEW_JSON)"
   fi
-  PLANNER_INPUT="${PLANNER_INPUT} Write the output to ${TASKS_YML}."
+  PLANNER_INPUT="${PLANNER_INPUT} Write the output to ${TASKS_MD}."
 
   ag agent spawn "plan-w-${ROUND}" \
     --system @/Users/genius/.ai/skills/plan/prompts/planner.md \
@@ -56,15 +56,15 @@ for ROUND in 1 2 3; do
   ag agent wait "plan-w-${ROUND}" --timeout 300
   ag agent rm "plan-w-${ROUND}"
 
-  if [ ! -f "${TASKS_YML}" ]; then
-    echo "❌ Planner did not produce tasks.yml in round $ROUND"
+  if [ ! -f "${TASKS_MD}" ]; then
+    echo "❌ Planner did not produce tasks.md in round $ROUND"
     continue
   fi
 
   # --- Spawn reviewer (judge) ---
   ag agent spawn "plan-j-${ROUND}" \
     --system @/Users/genius/.ai/skills/plan/prompts/reviewer.md \
-    --input "Review the plan at ${TASKS_YML}. Reference design doc at ${DESIGN_MD} for coverage check only. Write JSON result to ${REVIEW_JSON}."
+    --input "Review the plan at ${TASKS_MD}. Reference design doc at ${DESIGN_MD} for coverage check only. Write JSON result to ${REVIEW_JSON}."
 
   ag agent wait "plan-j-${ROUND}" --timeout 300
   ag agent rm "plan-j-${ROUND}"
@@ -85,7 +85,7 @@ done
 ```
 
 **处理 loop 结果：**
-- APPROVED → tasks.yml 已就绪，跑 plan-lint 后继续 Step 3
+- APPROVED → tasks.md 已就绪，跑 plan-lint 后继续 Step 3
 - 3 轮都未通过 → **停下来向用户汇报**，展示 reviewer findings，让用户决定
 - Subagent 执行失败 → **停下来向用户汇报**，不要跳过
 
@@ -95,7 +95,7 @@ if [ ! -f ~/.ai/skills/plan/bin/plan-lint ]; then
   echo "Building plan-lint..."
   (cd ~/.ai/skills/plan/cmd/plan-lint && go build -o ../../bin/plan-lint .)
 fi
-~/.ai/skills/plan/bin/plan-lint tasks.yml
+~/.ai/skills/plan/bin/plan-lint tasks.md
 ```
 
 ### Step 3: Import & Gate
@@ -105,7 +105,7 @@ fi
 3. 导入 ag task 队列：
 
 ```bash
-ag task import-plan tasks.yml
+ag task import-plan tasks.md
 ```
 
 4. 确认导入成功：`ag task ls`
@@ -126,7 +126,7 @@ ag task import-plan tasks.yml
 
 ## Output
 
-- `tasks.yml` — plan 产出物，导入后不再更新状态
+- `tasks.md` — plan 产出物，导入后不再更新状态
 - `ag task` 队列 — 运行时唯一真相，implement skill 消费
 
 ## Skill Composition
@@ -135,7 +135,7 @@ ag task import-plan tasks.yml
 brainstorm → design.md → plan (this skill) → ag task queue → implement
                                │
                                └─ Step 2: worker-judge loop (pair.sh)
-                                    ├─ Worker: planner.md → reads design.md, writes tasks.yml
+                                    ├─ Worker: planner.md → reads design.md, writes tasks.md
                                     └─ Judge: reviewer.md → validates self-containedness
                                          ↻ up to 3 rounds
 ```
@@ -161,8 +161,8 @@ Source code lives at `cmd/plan-lint/main.go`. The `bin/` directory is git-ignore
 
 ## Tools
 
-- `~/.ai/skills/plan/bin/plan-lint <tasks.yml>` — 验证 tasks.yml 结构和依赖（auto-built from `cmd/plan-lint/`）
-- `ag task import-plan <tasks.yml>` — 导入任务到运行时队列
+- `~/.ai/skills/plan/bin/plan-lint <tasks.md>` — 验证 tasks.md 结构和依赖（auto-built from `cmd/plan-lint/`）
+- `ag task import-plan <tasks.md>` — 导入任务到运行时队列
 - `ag task ls` — 查看导入结果
 
 ## ⛔ MANDATORY — Self-Check
@@ -172,7 +172,7 @@ Source code lives at `cmd/plan-lint/main.go`. The `bin/` directory is git-ignore
 | 未读设计 | 未读 design.md 就开始拆解 | 先读 design.md |
 | worker-judge loop 失败 | pair.sh exit 1 或执行异常 | 停下来向用户汇报 |
 | lint 未通过 | plan-lint 报错 | 修复后再继续 |
-| 未展示产出就问确认 | tasks.yml 存在但未向用户展示 | 先展示摘要 |
+| 未展示产出就问确认 | tasks.md 存在但未向用户展示 | 先展示摘要 |
 | 未导入就结束 | plan 完成但没有 import-plan | 先导入 ag task |
 
 **Reviewer 的 Must Pass 标准（任何一项失败 = 打回重做）：**
@@ -180,4 +180,4 @@ Source code lives at `cmd/plan-lint/main.go`. The `bin/` directory is git-ignore
 2. **Dependency Correctness** — 无循环、无悬空依赖
 3. **Coverage** — design.md 每个关键决策和 P0 feature 都有 task 覆盖
 4. **Acceptance Completeness** — design.md 每个 Acceptance Scenario 都有 task 的 done-when 覆盖
-5. **YAML Structure** — 格式正确、字段完整
+5. **Markdown Structure** — 格式正确、字段完整、frontmatter 和 task sections 一致

--- a/skills/plan/cmd/plan-lint/main.go
+++ b/skills/plan/cmd/plan-lint/main.go
@@ -4,17 +4,18 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
-// --- YAML schema types ---
+// --- Frontmatter schema types (YAML) ---
 
 type Plan struct {
 	Version    string   `yaml:"version"`
 	Metadata   Metadata `yaml:"metadata"`
-	Tasks      []Task   `yaml:"tasks"`
+	Tasks      []Task   // Parsed from Markdown body, not YAML
 	Groups     []Group  `yaml:"groups"`
 	GroupOrder []string `yaml:"group_order"`
 	Risks      []Risk   `yaml:"risks"`
@@ -25,13 +26,13 @@ type Metadata struct {
 }
 
 type Task struct {
-	ID             string   `yaml:"id"`
-	Title          string   `yaml:"title"`
-	Description    string   `yaml:"description"`
-	EstimatedHours float64  `yaml:"estimated_hours"`
-	DependsOn      []string `yaml:"depends_on"`
-	Dependencies   []string `yaml:"dependencies"`
-	Group          string   `yaml:"group"`
+	ID             string
+	Title          string
+	Description    string // Full Markdown body of the task section
+	EstimatedHours float64
+	DependsOn      []string
+	Dependencies   []string
+	Group          string
 }
 
 type Group struct {
@@ -76,6 +77,180 @@ func (d Diagnostic) String() string {
 	}
 }
 
+// --- Markdown Parser ---
+
+// parseMarkdownPlan splits a Markdown file into frontmatter and task sections.
+func parseMarkdownPlan(data []byte) (*Plan, []Diagnostic) {
+	var diags []Diagnostic
+
+	text := string(data)
+	frontmatterYAML, body, err := extractFrontmatter(text)
+	if err != nil {
+		diags = append(diags, Diagnostic{Error, fmt.Sprintf("failed to extract frontmatter: %v", err)})
+		return nil, diags
+	}
+
+	plan := &Plan{}
+
+	// Parse frontmatter YAML
+	if err := yaml.Unmarshal([]byte(frontmatterYAML), plan); err != nil {
+		diags = append(diags, Diagnostic{Error, fmt.Sprintf("failed to parse frontmatter YAML: %v", err)})
+		return nil, diags
+	}
+
+	// Parse task sections from Markdown body
+	tasks, taskDiags := parseTaskSections(body)
+	diags = append(diags, taskDiags...)
+	plan.Tasks = tasks
+
+	return plan, diags
+}
+
+// extractFrontmatter splits text into YAML frontmatter (between --- delimiters) and body.
+func extractFrontmatter(text string) (frontmatter string, body string, err error) {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "---") {
+		return "", "", fmt.Errorf("file must start with YAML frontmatter (---)")
+	}
+
+	// Find the closing ---
+	// Start after the first ---
+	rest := text[3:]
+	// Look for the next --- on its own line
+	closingIdx := strings.Index(rest, "\n---")
+	if closingIdx < 0 {
+		return "", "", fmt.Errorf("frontmatter not closed: missing closing ---")
+	}
+
+	frontmatter = rest[:closingIdx]
+	body = rest[closingIdx+4:] // skip \n---
+	body = strings.TrimPrefix(body, "\n")
+
+	return frontmatter, body, nil
+}
+
+// taskHeaderRe matches `## T001 — Task title (3h)` or `## T001 - Task title (3h)`
+var taskHeaderRe = regexp.MustCompile(`^## (T\d+)\s*[—\-]\s*(.+?)(?:\s*\((\d+(?:\.\d+)?)h\))?\s*$`)
+
+// depLineRe matches `**Dependencies:** T001, T003` or `**Dependencies:** none`
+var depLineRe = regexp.MustCompile(`^\*\*Dependencies?:\*\*\s*(.+)$`)
+
+// groupLineRe matches `**Group:** agent`
+var groupLineRe = regexp.MustCompile(`^\*\*Group:\*\*\s*(.+)$`)
+
+// parseTaskSections splits the Markdown body into task sections by `## Txxx` headers.
+func parseTaskSections(body string) ([]Task, []Diagnostic) {
+	var diags []Diagnostic
+	var tasks []Task
+
+	if strings.TrimSpace(body) == "" {
+		return tasks, diags
+	}
+
+	// Split on `## T` pattern. We use a regex to find all task headers.
+	// First, split by lines and find task header positions.
+	lines := strings.Split(body, "\n")
+
+	type section struct {
+		headerIdx int
+		lines     []string
+	}
+	var sections []section
+
+	currentSection := -1
+	for i, line := range lines {
+		if taskHeaderRe.MatchString(line) {
+			sections = append(sections, section{headerIdx: i, lines: []string{line}})
+			currentSection = len(sections) - 1
+		} else if currentSection >= 0 {
+			sections[currentSection].lines = append(sections[currentSection].lines, line)
+		}
+		// Lines before the first task header are ignored (could be intro text)
+	}
+
+	for _, sec := range sections {
+		task, taskDiags := parseTaskSection(sec.lines)
+		diags = append(diags, taskDiags...)
+		if task != nil {
+			tasks = append(tasks, *task)
+		}
+	}
+
+	return tasks, diags
+}
+
+// parseTaskSection parses a single task section into a Task.
+func parseTaskSection(lines []string) (*Task, []Diagnostic) {
+	var diags []Diagnostic
+
+	if len(lines) == 0 {
+		return nil, diags
+	}
+
+	task := &Task{}
+
+	// Parse header line: `## T001 — Task title (3h)`
+	headerMatch := taskHeaderRe.FindStringSubmatch(lines[0])
+	if headerMatch == nil {
+		diags = append(diags, Diagnostic{Error, fmt.Sprintf("invalid task header: %s", lines[0])})
+		return nil, diags
+	}
+
+	task.ID = headerMatch[1]
+	task.Title = strings.TrimSpace(headerMatch[2])
+	if headerMatch[3] != "" {
+		hours, err := strconv.ParseFloat(headerMatch[3], 64)
+		if err == nil {
+			task.EstimatedHours = hours
+		}
+	}
+
+	// Parse metadata lines and collect body
+	var bodyLines []string
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+
+		if depMatch := depLineRe.FindStringSubmatch(trimmed); depMatch != nil {
+			depStr := strings.TrimSpace(depMatch[1])
+			if strings.EqualFold(depStr, "none") || depStr == "" {
+				task.DependsOn = []string{}
+				task.Dependencies = []string{}
+			} else {
+				deps := parseDepList(depStr)
+				task.DependsOn = deps
+				task.Dependencies = deps
+			}
+			continue
+		}
+
+		if groupMatch := groupLineRe.FindStringSubmatch(trimmed); groupMatch != nil {
+			task.Group = strings.TrimSpace(groupMatch[1])
+			continue
+		}
+
+		bodyLines = append(bodyLines, line)
+	}
+
+	task.Description = strings.Join(bodyLines, "\n")
+	// Trim leading/trailing blank lines from description
+	task.Description = strings.TrimSpace(task.Description)
+
+	return task, diags
+}
+
+// parseDepList parses a comma-separated dependency list like "T001, T003"
+func parseDepList(s string) []string {
+	parts := strings.Split(s, ",")
+	var deps []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			deps = append(deps, p)
+		}
+	}
+	return deps
+}
+
 // --- Linter ---
 
 func Lint(plan *Plan) []Diagnostic {
@@ -97,12 +272,12 @@ func Lint(plan *Plan) []Diagnostic {
 
 	// 1. Missing version
 	if plan.Version == "" {
-		diags = append(diags, Diagnostic{Error, "missing top-level 'version' field"})
+		diags = append(diags, Diagnostic{Error, "missing top-level 'version' field in frontmatter"})
 	}
 
 	// 2. Missing metadata.spec_file
 	if plan.Metadata.SpecFile == "" {
-		diags = append(diags, Diagnostic{Error, "missing 'metadata.spec_file' field"})
+		diags = append(diags, Diagnostic{Error, "missing 'metadata.spec_file' field in frontmatter"})
 	}
 
 	// 3. No tasks
@@ -120,12 +295,12 @@ func Lint(plan *Plan) []Diagnostic {
 	designRefRe := regexp.MustCompile(`(?i)(design\.md|see\s+design)`)
 
 	for _, t := range plan.Tasks {
-		// 7. estimated_hours must be > 0
+		// estimated_hours must be > 0
 		if t.EstimatedHours <= 0 {
 			diags = append(diags, Diagnostic{Error, fmt.Sprintf("task %s: estimated_hours must be > 0", t.ID)})
 		}
 
-		// 5. depends_on references non-existent task
+		// depends_on references non-existent task
 		deps := effectiveDeps(t)
 		for _, dep := range deps {
 			if !taskIDs[dep] {
@@ -133,18 +308,18 @@ func Lint(plan *Plan) []Diagnostic {
 			}
 		}
 
-		// New: task description empty or shorter than 50 chars
+		// task description empty or shorter than 50 chars
 		trimmedDesc := strings.TrimSpace(t.Description)
 		if len(trimmedDesc) < 50 {
 			diags = append(diags, Diagnostic{Error, fmt.Sprintf("task %s: description is too short (%d chars, minimum 50)", t.ID, len(trimmedDesc))})
 		}
 
-		// New: task description must contain "Done when" or "done-when" or "Acceptance"
+		// task description must contain "Done when" or "done-when" or "Acceptance"
 		if len(trimmedDesc) >= 50 && !descDoneWhenRe.MatchString(trimmedDesc) {
 			diags = append(diags, Diagnostic{Error, fmt.Sprintf("task %s: description must contain a 'Done when' or 'Acceptance' section", t.ID)})
 		}
 
-		// New: task description references design.md / see design
+		// task description references design.md / see design
 		if designRefRe.MatchString(trimmedDesc) {
 			diags = append(diags, Diagnostic{Warning, fmt.Sprintf("task %s: description references design.md — tasks should be self-contained", t.ID)})
 		}
@@ -160,10 +335,10 @@ func Lint(plan *Plan) []Diagnostic {
 		}
 	}
 
-	// 6 & New: Circular dependency detection (build graph, detect cycles)
+	// Circular dependency detection (build graph, detect cycles)
 	diags = append(diags, detectCycles(plan.Tasks, taskIDs)...)
 
-	// 8. Group references non-existent task
+	// Group references non-existent task
 	for _, g := range plan.Groups {
 		for _, tid := range g.Tasks {
 			if !taskIDs[tid] {
@@ -172,22 +347,19 @@ func Lint(plan *Plan) []Diagnostic {
 		}
 	}
 
-	// 9. group_order references non-existent group
+	// group_order references non-existent group
 	for _, gn := range plan.GroupOrder {
 		if !groupNames[gn] {
 			diags = append(diags, Diagnostic{Error, fmt.Sprintf("group_order: references non-existent group %q", gn)})
 		}
 	}
 
-	// New: Group contains tasks with no dependency between them
+	// Group contains tasks with no dependency links between them (suggests missing dependency or wrong grouping)
 	for _, g := range plan.Groups {
 		taskIDSet := make(map[string]bool)
 		for _, tid := range g.Tasks {
 			taskIDSet[tid] = true
 		}
-		// Check if there exists at least one pair of tasks in the group
-		// where neither depends on the other (directly or transitively).
-		// We just check direct dependencies for simplicity.
 		if len(g.Tasks) > 1 {
 			anyLinked := false
 			for _, tid := range g.Tasks {
@@ -210,16 +382,54 @@ func Lint(plan *Plan) []Diagnostic {
 		}
 	}
 
+	// Cross-validation: tasks in frontmatter groups must match task sections
+	diags = append(diags, crossValidateGroups(plan)...)
+
 	// --- Warnings ---
 
-	// 1. Missing group_order
+	// Missing group_order
 	if len(plan.GroupOrder) == 0 {
 		diags = append(diags, Diagnostic{Warning, "missing 'group_order' field — recommended to define execution order"})
 	}
 
-	// 2. No risks
+	// No risks
 	if len(plan.Risks) == 0 {
 		diags = append(diags, Diagnostic{Warning, "no risks defined — recommend adding 2-5 risks with mitigations"})
+	}
+
+	return diags
+}
+
+// crossValidateGroups checks that frontmatter groups[].tasks and task sections are consistent.
+func crossValidateGroups(plan *Plan) []Diagnostic {
+	var diags []Diagnostic
+
+	// Collect all tasks referenced in groups
+	groupTaskIDs := make(map[string]bool)
+	for _, g := range plan.Groups {
+		for _, tid := range g.Tasks {
+			groupTaskIDs[tid] = true
+		}
+	}
+
+	// Collect all task section IDs
+	sectionIDs := make(map[string]bool)
+	for _, t := range plan.Tasks {
+		sectionIDs[t.ID] = true
+	}
+
+	// Tasks in groups but not in sections
+	for tid := range groupTaskIDs {
+		if !sectionIDs[tid] {
+			diags = append(diags, Diagnostic{Error, fmt.Sprintf("groups[].tasks references %s but no matching task section found", tid)})
+		}
+	}
+
+	// Task sections not referenced in any group
+	for tid := range sectionIDs {
+		if !groupTaskIDs[tid] {
+			diags = append(diags, Diagnostic{Warning, fmt.Sprintf("task %s has a section but is not referenced in any group", tid)})
+		}
 	}
 
 	return diags
@@ -256,7 +466,7 @@ func detectCycles(tasks []Task, taskIDs map[string]bool) []Diagnostic {
 	state := make(map[string]int)
 	inStack := make(map[string]bool)
 
-	var cycleEdges []string // "A → B → C → A" formatted cycles
+	var cycleEdges []string
 
 	var dfs func(id string, path []string)
 	dfs = func(id string, path []string) {
@@ -264,7 +474,6 @@ func detectCycles(tasks []Task, taskIDs map[string]bool) []Diagnostic {
 			return
 		}
 		if inStack[id] {
-			// Found cycle — find where it starts in path
 			cycleStart := -1
 			for i, p := range path {
 				if p == id {
@@ -313,7 +522,7 @@ func detectCycles(tasks []Task, taskIDs map[string]bool) []Diagnostic {
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "Usage: plan-lint <tasks.yml>\n")
+		fmt.Fprintf(os.Stderr, "Usage: plan-lint <tasks.md>\n")
 		os.Exit(2)
 	}
 
@@ -324,25 +533,29 @@ func main() {
 		os.Exit(2)
 	}
 
-	// Detect control characters (e.g., \x01 from Python regex backreference corruption)
+	// Detect control characters
 	controlChars := detectControlChars(data)
 	if len(controlChars) > 0 {
 		fmt.Fprintf(os.Stderr, "⚠️  File contains %d control characters:\n", len(controlChars))
 		for _, cc := range controlChars {
 			fmt.Fprintf(os.Stderr, "   Line %d byte %d: \\x%02x\n", cc.Line, cc.ByteOffset, cc.Byte)
 		}
-		fmt.Fprintf(os.Stderr, "   This may be caused by regex backreference corruption (e.g., Python re.sub using \\1 → \\x01).\n")
+		fmt.Fprintf(os.Stderr, "   This may be caused by regex backreference corruption.\n")
 		fmt.Fprintf(os.Stderr, "   Fix: sed -i 's/\\x01//g' %s\n", path)
 		fmt.Println()
 	}
 
-	var plan Plan
-	if err := yaml.Unmarshal(data, &plan); err != nil {
-		fmt.Fprintf(os.Stderr, "❌ Failed to parse YAML: %v\n", err)
+	plan, parseDiags := parseMarkdownPlan(data)
+	if plan == nil {
+		for _, d := range parseDiags {
+			fmt.Println(d.String())
+		}
+		fmt.Println()
+		fmt.Println("❌ Plan parsing failed")
 		os.Exit(2)
 	}
 
-	diags := Lint(&plan)
+	diags := append(parseDiags, Lint(plan)...)
 
 	hasErrors := false
 	hasWarnings := false
@@ -388,12 +601,11 @@ func detectControlChars(data []byte) []ControlCharLoc {
 			offset = 0
 			continue
 		}
-			_ = i
+		_ = i
 		offset++
-		// Control chars except \t (0x09), \n (0x0A), \r (0x0D)
 		if b < 0x20 && b != 0x09 && b != 0x0A && b != 0x0D {
 			results = append(results, ControlCharLoc{Line: line, ByteOffset: offset, Byte: b})
-			if len(results) >= 20 { // Cap at 20 to avoid flooding output
+			if len(results) >= 20 {
 				break
 			}
 		}

--- a/skills/plan/cmd/plan-lint/testdata/tasks.md
+++ b/skills/plan/cmd/plan-lint/testdata/tasks.md
@@ -1,0 +1,88 @@
+---
+version: "1"
+metadata:
+  spec_file: design.md
+groups:
+  - name: parser
+    title: Markdown Parser
+    tasks: [T001, T002]
+    commit_message: "feat(plan): add Markdown plan format parser"
+  - name: importer
+    title: Plan Importer
+    tasks: [T003]
+    commit_message: "feat(plan): update importer for Markdown format"
+group_order: [parser, importer]
+risks:
+  - area: "Backward compatibility"
+    risk: "Existing YAML plans may break"
+    mitigation: "Keep YAML parser as fallback, detect format by frontmatter presence"
+---
+
+## T001 — Implement Markdown frontmatter parser (3h)
+
+**Dependencies:** none
+**Group:** parser
+
+### Goal
+Extract YAML frontmatter from Markdown files and parse it into structured metadata.
+
+### Key changes
+- Add extractFrontmatter function to split --- delimited sections
+- Parse frontmatter YAML into Plan struct (version, metadata, groups, group_order, risks)
+- Validate frontmatter structure and required fields
+
+### Files
+- MODIFY: skills/plan/cmd/plan-lint/main.go
+
+### Done when
+- [ ] Frontmatter extraction correctly splits YAML from Markdown body
+- [ ] Missing closing --- produces clear error message
+- [ ] Empty frontmatter produces validation error
+
+---
+
+## T002 — Implement Markdown task section parser (4h)
+
+**Dependencies:** T001
+**Group:** parser
+
+### Goal
+Parse task sections from Markdown body, extracting ID, title, hours, dependencies, group, and body content.
+
+### Key changes
+- Split Markdown body on `## Txxx` pattern to extract task sections
+- Parse task header with regex: `## T001 — Title (3h)`
+- Extract `**Dependencies:**` and `**Group:**` metadata lines
+- Collect remaining lines as task description body
+
+### Files
+- MODIFY: skills/plan/cmd/plan-lint/main.go
+
+### Done when
+- [ ] Task header regex matches `## T001 — Title (3h)` and `## T001 - Title (3h)`
+- [ ] Dependencies line parsed correctly: comma-separated IDs or "none"
+- [ ] Group line parsed correctly
+- [ ] Task body contains Goal, Key changes, Files, Done when sections
+
+---
+
+## T003 — Update ImportPlan for Markdown format (2h)
+
+**Dependencies:** T002
+**Group:** importer
+
+### Goal
+Update ImportPlan function to read Markdown plan files instead of YAML-only files.
+
+### Key changes
+- Parse Markdown frontmatter to extract task metadata
+- Parse task sections from Markdown body
+- Create tasks using existing CreateWithID and AddDependency functions
+
+### Files
+- MODIFY: skills/ag/internal/task/task.go
+
+### Done when
+- [ ] ImportPlan reads Markdown files with frontmatter
+- [ ] Tasks created with correct ID, title, description, dependencies, and group
+- [ ] Import fails gracefully on invalid Markdown format

--- a/skills/plan/prompts/planner.md
+++ b/skills/plan/prompts/planner.md
@@ -1,14 +1,14 @@
 ---
 name: planner
-description: Breaks down design.md into self-contained tasks.yml for autonomous subagent execution.
-output_format: tasks.yml
+description: Breaks down design.md into self-contained tasks.md for autonomous subagent execution.
+output_format: tasks.md
 ---
 
 # Technical Planner
 
 You are a Technical Planner. You break down a design document into a structured task plan that autonomous subagents can execute independently.
 
-**Critical constraint**: Each task's `description` must be a self-contained micro-spec. The subagent executing it will NOT have access to design.md. Everything it needs must be in the description.
+**Critical constraint**: Each task's description must be a self-contained micro-spec. The subagent executing it will NOT have access to design.md. Everything it needs must be in the description.
 
 ## Input
 
@@ -36,7 +36,7 @@ Break the design into tasks following these rules:
 - > 6 hours → split into multiple tasks
 - < 1 hour → merge with related work
 
-**Estimated Hours**: Every task MUST have `estimated_hours` (required by plan-lint). Default range: 2-4. This field is used for scheduling and progress tracking.
+**Estimated Hours**: Every task MUST have an estimated duration in the header. Default range: 2-4. This field is used for scheduling and progress tracking.
 
 **Boundary**: Each task should be one logical unit of work that:
 - Can be implemented without breaking compilation for other tasks
@@ -45,58 +45,82 @@ Break the design into tasks following these rules:
 
 **Dependencies**: Be explicit. If task B uses a type/function introduced by task A, B must declare A as a dependency. No circular dependencies.
 
-### 3. Write tasks.yml
+### 3. Write tasks.md
 
-Output the plan as a valid YAML file. Structure:
+Output the plan as a valid Markdown file with YAML frontmatter. Structure:
 
-```yaml
+```markdown
+---
 version: "1"
 metadata:
   spec_file: "design.md"
-  created_at: "2025-07-11"
-
-tasks:
-  - id: T001
-    title: "Task title"
-    description: |
-      ## Goal
-      One sentence: what this task achieves.
-
-      ## Key changes
-      - Specific change 1 (e.g., "Add flock() call in Load()")
-      - Specific change 2
-
-      ## Files
-      - MODIFY: path/to/file.go
-      - CREATE: path/to/new_file.go
-
-      ## Design decision
-      Why this approach over alternatives. Reference design.md §section if needed.
-
-      ## Edge cases
-      - Edge case 1 and how to handle it
-
-      ## Done when
-      - [ ] <observable behavior 1 — what an observer can verify>
-      - [ ] <observable behavior 2>
-      - [ ] <edge case behavior>
-    estimated_hours: 3
-    group: group-name
-    dependencies: []
-
 groups:
   - name: group-name
     title: "Group Title"
-    description: "What this group delivers as a working increment"
     tasks: [T001, T002]
     commit_message: "feat(scope): description"
-
 group_order: [group-name]
 risks:
   - area: "Area"
     risk: "What could go wrong"
     mitigation: "How to prevent it"
+---
+
+## T001 — Task title (3h)
+
+**Dependencies:** none
+**Group:** group-name
+
+### Goal
+One sentence: what this task achieves.
+
+### Key changes
+- Specific change 1 (e.g., "Add flock() call in Load()")
+- Specific change 2
+
+### Files
+- MODIFY: path/to/file.go
+- CREATE: path/to/new_file.go
+
+### Design decision
+Why this approach over alternatives. Reference design.md §section if needed.
+
+### Edge cases
+- Edge case 1 and how to handle it
+
+### Done when
+- [ ] <observable behavior 1 — what an observer can verify>
+- [ ] <observable behavior 2>
+- [ ] <edge case behavior>
+
+---
+
+## T002 — Next task (2h)
+
+**Dependencies:** T001
+**Group:** group-name
+
+### Goal
+One sentence: what this task achieves.
+
+### Key changes
+- Specific change 1
+
+### Files
+- MODIFY: path/to/another_file.go
+
+### Done when
+- [ ] <observable behavior>
 ```
+
+## Format Rules
+
+1. **Frontmatter**: Only at file top. Contains version, metadata, groups, group_order, risks. NO task descriptions here.
+2. **Task sections**: Each task starts with `## Txxx — Title (Xh)` followed by an empty line
+3. **Task metadata**: `**Dependencies:** T001, T003` and `**Group:** group-name` as bold lines before Goal
+4. **Task body**: Goal / Key changes / Files / Done when as ### subsections
+5. **Separator**: `---` between tasks (horizontal rule in Markdown)
+6. **No YAML block scalars**: All task content is pure Markdown, zero indentation sensitivity
 
 ## Description Rules (MANDATORY)
 
@@ -104,17 +128,17 @@ Every task description MUST include these sections:
 
 | Section | Purpose | Minimum requirement |
 |---------|---------|-------------------|
-| `## Goal` | What this task achieves | One concrete sentence |
-| `## Key changes` | What to change in code | ≥1 specific change |
-| `## Files` | Which files to modify/create | ≥1 real file path |
-| `## Done when` | When the task is complete | ≥1 behavioral criterion (see rules below) |
+| `### Goal` | What this task achieves | One concrete sentence |
+| `### Key changes` | What to change in code | ≥1 specific change |
+| `### Files` | Which files to modify/create | ≥1 real file path |
+| `### Done when` | When the task is complete | ≥1 behavioral criterion (see rules below) |
 
 Optional but recommended:
 
 | Section | When needed |
 |---------|------------|
-| `## Design decision` | Multiple implementation approaches exist |
-| `## Edge cases` | Non-obvious boundary conditions |
+| `### Design decision` | Multiple implementation approaches exist |
+| `### Edge cases` | Non-obvious boundary conditions |
 
 ### Done-When Rules (CRITICAL)
 
@@ -165,7 +189,8 @@ Before outputting, verify:
 - [ ] Each group is a compilable increment
 - [ ] Tasks are 2-4 hours each
 - [ ] No task description references design.md as if the reader has it
+- [ ] Frontmatter groups[].tasks matches the task sections in the body
 
 ## Output
 
-Write the complete tasks.yml to the file path specified in the input. Output nothing else to stdout — the YAML file is your only deliverable.
+Write the complete tasks.md to the file path specified in the input. Output nothing else to stdout — the Markdown file is your only deliverable.

--- a/skills/plan/prompts/reviewer.md
+++ b/skills/plan/prompts/reviewer.md
@@ -1,18 +1,18 @@
 ---
 name: plan-reviewer
-description: Reviews tasks.yml for self-containedness and plan quality. Simulates a subagent who has NOT read design.md.
+description: Reviews tasks.md for self-containedness and plan quality. Simulates a subagent who has NOT read design.md.
 ---
 
 # Plan Reviewer
 
-You are a Plan Reviewer. You validate that a tasks.yml plan is ready for autonomous execution by subagents.
+You are a Plan Reviewer. You validate that a tasks.md plan is ready for autonomous execution by subagents.
 
-**Critical constraint**: The subagent who will execute these tasks has NOT read the design document. Everything it needs must be in the task's `description` field. You are simulating that subagent.
+**Critical constraint**: The subagent who will execute these tasks has NOT read the design document. Everything it needs must be in the task's section. You are simulating that subagent.
 
 ## Input
 
 You will receive two files:
-1. **tasks.yml** — the plan to review (primary input)
+1. **tasks.md** — the plan to review (primary input)
 2. **design.md** — the original design (reference only, for coverage checking)
 
 ## Review Criteria
@@ -21,7 +21,7 @@ You will receive two files:
 
 #### A. Self-Containedness (MOST CRITICAL)
 
-For every task, check if its `description` field alone is sufficient to implement it:
+For every task section, check if its content alone is sufficient to implement it:
 
 - **Goal**: Is it a single concrete sentence? "Improve error handling" = REJECT. "Add structured error wrapping with error codes to all storage/ functions" = PASS.
 - **Key changes**: Are changes specific to code? "Update the handler" = REJECT. "Add flock() call in Load() before reading JSON" = PASS.
@@ -33,7 +33,7 @@ If ANY task fails self-containedness, the plan is REJECTED. This is the #1 cause
 #### B. Dependency Correctness
 
 - No circular dependencies (A→B→A)
-- All dependency IDs exist in the plan
+- All dependency IDs exist as `## Txxx` sections in the plan
 - No missing prerequisites (if task B uses a type introduced by task A, B must depend on A)
 - Group order respects task dependencies
 
@@ -62,12 +62,13 @@ Example:
 
 This ensures the behavioral contract flows from design → plan → implement without loss.
 
-#### E. YAML Structure
+#### E. Markdown Structure
 
-- Valid YAML syntax
-- Required fields present: id, title, description, dependencies
+- Valid Markdown with YAML frontmatter
+- Required elements present: `## Txxx` header with ID and title, `**Dependencies:**` line, `**Group:**` line
 - Task IDs are unique
-- description contains Goal / Key changes / Files / Done when sections
+- Each task section contains ### Goal, ### Key changes, ### Files, ### Done when subsections
+- Frontmatter groups[].tasks matches the task sections in the body
 
 ### Should Pass (Improvements) — May Request Changes
 
@@ -160,7 +161,7 @@ Critical failures. Plan needs significant rework.
 
 ### Dependency Problems
 - ❌ T003 depends on T009, but T009 should depend on T003 (reversed)
-- ❌ T005 depends on T999 (non-existent task)
+- ❌ T005 depends on T999 (non-existent task — no `## T999` section)
 - ❌ T001→T002→T001 (circular)
 
 ### Coverage Problems (NOW A BLOCKER)
@@ -177,14 +178,20 @@ Critical failures. Plan needs significant rework.
 - ❌ "Implement full auth system" (too broad, >6h)
 - ❌ "Add one import statement" (too narrow, <1h)
 
+### Markdown Format Problems
+- ❌ Missing `---` separator between tasks
+- ❌ Task header not following `## Txxx — Title (Xh)` pattern
+- ❌ Missing `**Dependencies:**` or `**Group:**` metadata lines
+- ❌ Task in body but not listed in frontmatter groups[].tasks (or vice versa)
+
 ## Rules
 
-- Be specific. Point to the exact field that's wrong and show what it should be.
-- **Quote source material verbatim.** When reporting dependency, coverage, or self-containedness issues, include the relevant YAML snippet with line context. For example:
+- Be specific. Point to the exact section that's wrong and show what it should be.
+- **Quote source material verbatim.** When reporting dependency, coverage, or self-containedness issues, include the relevant Markdown snippet with context. For example:
   ```
-  T009 line 45: dependencies: [T001, T002]  ← missing T003 which introduces the RunLoop type used in T009
+  T009 ## Dependencies line: "**Dependencies:** T001, T002" ← missing T003 which introduces the RunLoop type used in T009
   ```
-  This prevents false findings (e.g., claiming "T009 depends on T008" when the YAML actually says `[T001, T002]`).
+  This prevents false findings.
 - Don't be lenient. The subagent will fail silently if context is missing — your job is to prevent that.
 - Do NOT suggest implementation approaches. You review the plan quality, not the code design.
 - Every finding must have a concrete suggestion, not just "fix this".


### PR DESCRIPTION
## Summary

Migrate the plan format from YAML to single-file Markdown with YAML frontmatter.

### Motivation
- YAML `description: |` block scalar requires precise indentation across dozens of lines
- A single indentation error corrupts the entire file
- LLM edit (find-replace) in large YAML files frequently damages adjacent tasks

### Changes
1. **plan-lint** — Complete rewrite to parse Markdown format
   - Parses YAML frontmatter (version, metadata, groups, risks)
   - Parses Markdown body: task sections split on `## Txxx` headers
   - Extracts ID, title, estimated hours from header
   - Parses `**Dependencies:**` and `**Group:**` metadata lines
   - Cross-validates frontmatter groups[].tasks vs task sections
   - All existing validation rules preserved

2. **ImportPlan** — Supports both Markdown and legacy YAML
   - Auto-detects format by checking for `---` frontmatter
   - Legacy YAML files still work as fallback

3. **Planner/Reviewer prompts** — Updated for Markdown format
4. **SKILL.md** — tasks.yml → tasks.md references
5. **All downstream docs** — Updated references
6. **docs/design/plan-format-analysis.md** — Decision rationale

### Test Results
- plan-lint: builds and validates new Markdown format ✅
- plan-lint: detects cycles, dangling deps, missing sections ✅  
- ag tests: all pass (including legacy YAML ImportPlan tests) ✅

### Files Changed
```
README.md                         |   4 +-
docs/design/plan-format-analysis.md  |  95 +++++++++++++
pkg/tools/find_skill_test.go      |   2 +-
skills/ag/README.md               |   2 +-
skills/ag/SKILL.md                |  10 +-
skills/ag/cmd/root.go             |   2 +-
skills/ag/internal/task/task.go   | 171 ++++++++++++++++++-
skills/implement/SKILL.md         |   6 +-
skills/plan/SKILL.md              |  38 ++---
skills/plan/cmd/plan-lint/main.go | 286 +++++++++++++++++++++++++++++---
skills/plan/cmd/plan-lint/testdata/tasks.md |  82 ++++++++++
skills/plan/prompts/planner.md    | 119 +++++++-------
skills/plan/prompts/reviewer.md   |  37 +++-
13 files changed, 711 insertions(+), 145 deletions(-)
```