### PR TITLE
Fix: detect PID reuse causing zombie agents via start-time verification

### DIFF
--- a/cmd/ai/ls.go
+++ b/cmd/ai/ls.go
@@ -49,6 +49,14 @@ func lsSubcommand() {
 			continue
 		}
 
+		// Reconcile stale runs: if run.json says "running" but PID is
+		// dead or recycled, update to "failed" so callers see the real state.
+		if meta.Status == run.StatusRunning && !run.IsRunning(meta) {
+			meta.Status = run.StatusFailed
+			meta.FinishedAt = time.Now().Unix()
+			_ = run.SaveRunMeta(meta, metaPath)
+		}
+
 		// For non --all mode, check if the run is actually alive.
 		if !*allFlag {
 			if !run.IsRunning(meta) {

--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -90,12 +90,13 @@ func runSubcommand(binPath string) {
 
 	// Write initial run.json.
 	meta := &run.RunMeta{
-		ID:        id,
-		PID:       cmd.Process.Pid,
-		CWD:       cwd,
-		Status:    run.StatusRunning,
-		StartedAt: time.Now().Unix(),
-		Name:      *nameFlag,
+		ID:           id,
+		PID:          cmd.Process.Pid,
+		CWD:          cwd,
+		Status:       run.StatusRunning,
+		StartedAt:    time.Now().Unix(),
+		Name:         *nameFlag,
+		PidStartTime: run.GetProcessStartTime(cmd.Process.Pid),
 	}
 	metaPath := run.RunMetaPath(baseDir, id)
 	if err := run.SaveRunMeta(meta, metaPath); err != nil {
@@ -237,12 +238,13 @@ func serveSubcommand(binPath string) {
 
 	// Write initial run.json.
 	meta := &run.RunMeta{
-		ID:        id,
-		PID:       cmd.Process.Pid,
-		CWD:       cwd,
-		Status:    run.StatusRunning,
-		StartedAt: time.Now().Unix(),
-		Name:      *nameFlag,
+		ID:           id,
+		PID:          cmd.Process.Pid,
+		CWD:          cwd,
+		Status:       run.StatusRunning,
+		StartedAt:    time.Now().Unix(),
+		Name:         *nameFlag,
+		PidStartTime: run.GetProcessStartTime(cmd.Process.Pid),
 	}
 	metaPath := run.RunMetaPath(baseDir, id)
 	if err := run.SaveRunMeta(meta, metaPath); err != nil {

--- a/pkg/run/meta.go
+++ b/pkg/run/meta.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -22,14 +25,15 @@ const (
 
 // RunMeta holds metadata for a single run (an ai rpc subprocess invocation).
 type RunMeta struct {
-	ID         string `json:"id"`          // 6-char hex ID
-	PID        int    `json:"pid"`         // process ID of the ai rpc subprocess
-	CWD        string `json:"cwd"`         // working directory where ai run was invoked
-	Status     string `json:"status"`      // running, done, failed, killed
-	StartedAt  int64  `json:"started_at"`  // unix timestamp
-	FinishedAt int64  `json:"finished_at"` // unix timestamp, 0 if still running
-	Name       string `json:"name"`        // optional human-readable name
-	ParentRun  string `json:"parent_run"`  // optional parent run ID for subagents
+	ID           string `json:"id"`            // 6-char hex ID
+	PID          int    `json:"pid"`           // process ID of the ai rpc subprocess
+	CWD          string `json:"cwd"`           // working directory where ai run was invoked
+	Status       string `json:"status"`        // running, done, failed, killed
+	StartedAt    int64  `json:"started_at"`    // unix timestamp
+	FinishedAt   int64  `json:"finished_at"`   // unix timestamp, 0 if still running
+	Name         string `json:"name"`          // optional human-readable name
+	ParentRun    string `json:"parent_run"`    // optional parent run ID for subagents
+	PidStartTime int64  `json:"pid_start_time"` // epoch seconds of process start (for PID reuse detection)
 }
 
 // GenerateID returns a 6-character lowercase hex string using crypto/rand (3 bytes).
@@ -122,7 +126,8 @@ func SaveRunMeta(meta *RunMeta, path string) error {
 }
 
 // IsRunning checks if the run's process is still alive by sending signal 0
-// to the PID. Returns true only if status is "running" and the process exists.
+// to the PID, then verifying PID identity via start time to detect PID reuse.
+// Returns true only if status is "running" and the process exists and matches.
 func IsRunning(meta *RunMeta) bool {
 	if meta.Status != StatusRunning {
 		return false
@@ -131,8 +136,79 @@ func IsRunning(meta *RunMeta) bool {
 	if err != nil {
 		return false
 	}
-	err = proc.Signal(syscall.Signal(0))
-	return err == nil
+	if proc.Signal(syscall.Signal(0)) != nil {
+		return false
+	}
+	// Verify PID still belongs to the original process.
+	// If PidStartTime was recorded, the current start time must match.
+	if meta.PidStartTime > 0 {
+		currentStart := GetProcessStartTime(meta.PID)
+		if currentStart == 0 || currentStart != meta.PidStartTime {
+			return false
+		}
+	}
+	return true
+}
+
+// GetProcessStartTime returns the epoch-second start time of the given PID.
+// Returns 0 if the start time cannot be determined (process gone, unsupported OS).
+//
+// On Linux, it reads /proc/<pid>/stat field 22 (starttime in clock ticks).
+// On macOS/other, it uses `ps -o lstart= -p <pid>` and parses the date.
+var GetProcessStartTime = getProcessStartTime
+
+func getProcessStartTime(pid int) int64 {
+	if pid <= 0 {
+		return 0
+	}
+
+	if runtime.GOOS == "linux" {
+		return getProcessStartTimeLinux(pid)
+	}
+	return getProcessStartTimePS(pid)
+}
+
+// getProcessStartTimeLinux reads /proc/<pid>/stat field 22 (starttime).
+// Field 22 is the number of clock ticks since system boot.
+// NOTE: This implementation is only used on Linux. On non-Linux platforms,
+// getProcessStartTime falls through to getProcessStartTimePS.
+func getProcessStartTimeLinux(pid int) int64 {
+	// Non-Linux: fall back to ps-based approach.
+	return getProcessStartTimePS(pid)
+}
+
+// getClockTicks returns the sysconf(_SC_CLK_TCK) value.
+func getClockTicks() int64 {
+	return 100
+}
+
+// getProcessStartTimePS uses `ps -o lstart= -p <pid>` to get the start time.
+// Works on macOS and other Unix systems.
+// Forces LC_TIME=C to ensure consistent date format regardless of locale.
+func getProcessStartTimePS(pid int) int64 {
+	if pid <= 0 {
+		return 0
+	}
+	cmd := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(pid))
+	cmd.Env = append(os.Environ(), "LC_TIME=C")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return 0
+	}
+	// ps lstart format (C locale): "Wed Jan  2 15:04:05 2006"
+	t, err := time.Parse("Mon Jan  2 15:04:05 2006", line)
+	if err != nil {
+		// Try alternative format (single-digit day without extra space)
+		t, err = time.Parse("Mon Jan 2 15:04:05 2006", line)
+		if err != nil {
+			return 0
+		}
+	}
+	return t.Unix()
 }
 
 // --- internal helpers ---
@@ -196,11 +272,12 @@ func newTestMeta(id string) *RunMeta {
 func CreateRun(baseDir, cwd string, pid int) (*RunMeta, error) {
 	id := GenerateID()
 	meta := &RunMeta{
-		ID:        id,
-		PID:       pid,
-		CWD:       cwd,
-		Status:    StatusRunning,
-		StartedAt: now(),
+		ID:           id,
+		PID:          pid,
+		CWD:          cwd,
+		Status:       StatusRunning,
+		StartedAt:    now(),
+		PidStartTime: GetProcessStartTime(pid),
 	}
 	path := RunMetaPath(baseDir, id)
 	if err := SaveRunMeta(meta, path); err != nil {

--- a/pkg/run/meta_linux.go
+++ b/pkg/run/meta_linux.go
@@ -1,0 +1,58 @@
+//go:build linux
+
+package run
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func init() {
+	// Override the Linux implementation at init time.
+	GetProcessStartTime = getProcessStartTimeLinuxImpl
+}
+
+func getProcessStartTimeLinuxImpl(pid int) int64 {
+	if pid <= 0 {
+		return 0
+	}
+
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0
+	}
+
+	// Fields are space-separated, but field 2 (comm) may contain spaces
+	// enclosed in parentheses. Skip past the closing ')' to parse correctly.
+	s := string(data)
+	closeParen := strings.LastIndex(s, ")")
+	if closeParen < 0 || closeParen+2 >= len(s) {
+		return 0
+	}
+	fields := strings.Fields(s[closeParen+2:])
+	// After skipping fields 1 (pid) and 2 (comm), field indices shift:
+	// Fields: 3=state, 4=ppid, 5=pgrp, ..., 22=starttime
+	// So starttime is at index 22-3 = 19.
+	const starttimeField = 19
+	if len(fields) <= starttimeField {
+		return 0
+	}
+
+	ticks, err := strconv.ParseInt(fields[starttimeField], 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	// Convert ticks to epoch seconds: ticks / CLK_TCK + boot_time.
+	var si syscall.Sysinfo_t
+	if syscall.Sysinfo(&si) != nil {
+		return 0
+	}
+	clkTck := getClockTicks()
+	bootTime := time.Now().Unix() - int64(si.Uptime)
+	return bootTime + ticks/clkTck
+}

--- a/pkg/run/meta_test.go
+++ b/pkg/run/meta_test.go
@@ -275,3 +275,66 @@ func TestSyscallSignalZero(t *testing.T) {
 	err = proc.Signal(syscall.Signal(0))
 	assert.NoError(t, err, "signal 0 on own process should succeed")
 }
+
+func TestGetProcessStartTime_CurrentProcess(t *testing.T) {
+	// Should return a non-zero start time for the current process.
+	startTime := GetProcessStartTime(os.Getpid())
+	assert.Greater(t, startTime, int64(0), "start time should be > 0 for current process")
+}
+
+func TestGetProcessStartTime_NonexistentPID(t *testing.T) {
+	startTime := GetProcessStartTime(99999999)
+	assert.Equal(t, int64(0), startTime, "start time should be 0 for nonexistent PID")
+}
+
+func TestGetProcessStartTime_InvalidPID(t *testing.T) {
+	startTime := GetProcessStartTime(0)
+	assert.Equal(t, int64(0), startTime)
+	startTime = GetProcessStartTime(-1)
+	assert.Equal(t, int64(0), startTime)
+}
+
+func TestIsRunning_PIDReuseDetection(t *testing.T) {
+	// Simulate PID reuse: current process PID is alive, but with wrong start time.
+	realStartTime := GetProcessStartTime(os.Getpid())
+
+	// With correct start time → should be running.
+	meta := &RunMeta{
+		ID:           "reuse01",
+		PID:          os.Getpid(),
+		CWD:          "/tmp",
+		Status:       StatusRunning,
+		StartedAt:    1,
+		PidStartTime: realStartTime,
+	}
+	assert.True(t, IsRunning(meta), "should be running with correct start time")
+
+	// With wrong start time → should NOT be running (PID recycled).
+	meta.PidStartTime = realStartTime - 100000
+	assert.False(t, IsRunning(meta), "should NOT be running with wrong start time (PID reused)")
+
+	// With zero start time → should be running (backward compat, no check).
+	meta.PidStartTime = 0
+	assert.True(t, IsRunning(meta), "should be running with zero start time (backward compat)")
+}
+
+func TestIsRunning_PIDReuseWithDeadProcess(t *testing.T) {
+	// Dead process with wrong start time → should not be running.
+	meta := &RunMeta{
+		ID:           "reuse02",
+		PID:          99999999, // nonexistent
+		CWD:          "/tmp",
+		Status:       StatusRunning,
+		StartedAt:    1,
+		PidStartTime: 12345,
+	}
+	assert.False(t, IsRunning(meta), "dead process should not be running regardless of start time")
+}
+
+func TestCreateRun_RecordsPidStartTime(t *testing.T) {
+	tmpDir := t.TempDir()
+	meta, err := CreateRun(tmpDir, "/test", os.Getpid())
+	require.NoError(t, err)
+	assert.Equal(t, GetProcessStartTime(os.Getpid()), meta.PidStartTime,
+		"CreateRun should record process start time")
+}

--- a/skills/ag/cmd/agent_status.go
+++ b/skills/ag/cmd/agent_status.go
@@ -32,7 +32,7 @@ func GetAgentStatus(agentID string) (*agent.Activity, error) {
 
 	// For raw backends (codex, etc.), check process liveness and output.
 	if activity.Pid > 0 && activity.Status == "running" {
-		alive := agent.IsProcessAlive(activity.Pid)
+		alive := agent.IsProcessAlive(activity.Pid, activity.PidStartTime)
 		if !alive {
 			// Process exited. Scan output for terminal events.
 			agentDir := agent.AgentDir(agentID)
@@ -55,10 +55,11 @@ func getAgentStatusWithAI(agentID string) (*agent.Activity, error) {
 	}
 
 		activity := &agent.Activity{
-		Status:    convertAIStatus(runMeta.Status),
-		Pid:       runMeta.PID,
-		StartedAt: runMeta.StartedAt,
-		Backend:   "ai",
+		Status:       convertAIStatus(runMeta.Status),
+		Pid:          runMeta.PID,
+		StartedAt:    runMeta.StartedAt,
+		Backend:      "ai",
+		PidStartTime: runMeta.PidStartTime,
 	}
 
 	if runMeta.FinishedAt > 0 {
@@ -68,7 +69,7 @@ func getAgentStatusWithAI(agentID string) (*agent.Activity, error) {
 	// ai serve detached via Process.Release may not update run.json on exit.
 	// If run.json says running but PID is dead, mark as done.
 	if activity.Status == "running" && activity.Pid > 0 {
-		if !agent.IsProcessAlive(activity.Pid) {
+		if !agent.IsProcessAlive(activity.Pid, activity.PidStartTime) {
 			activity.Status = "done"
 			if activity.FinishedAt == 0 {
 				activity.FinishedAt = time.Now().Unix()

--- a/skills/ag/cmd/ai_adapter.go
+++ b/skills/ag/cmd/ai_adapter.go
@@ -101,14 +101,18 @@ func (a *AIAdapter) SpawnWithAIServe(id, system, input, cwd string) error {
 	// Save PID (Release zeroes the Pid field)
 	pid := cmd.Process.Pid
 
+	// Record process start time for PID reuse detection.
+	pidStartTime := getProcessStartTime(pid)
+
 	// Detach ai serve process from parent so spawn doesn't block
 	if err := cmd.Process.Release(); err != nil {
 		// Non-fatal, process is already started
 		fmt.Fprintf(os.Stderr, "warning: could not release ai serve process: %v\n", err)
 	}
 
-	// Save PID to activity
+	// Save PID and start time to activity
 	activity["pid"] = pid
+	activity["pidStartTime"] = pidStartTime
 	if err := storage.AtomicWriteJSON(filepath.Join(agentDir, "activity.json"), activity); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to update activity.json with PID: %v\n", err)
 	}
@@ -309,3 +313,29 @@ func (a *AIAdapter) getRunIDForAgent(agentID string) (string, error) {
 
 // Global adapter instance
 var aiAdapter = NewAIAdapter()
+
+// getProcessStartTime returns the epoch-second start time of the given PID.
+// Uses `ps -o lstart= -p <pid>`. Returns 0 on error.
+func getProcessStartTime(pid int) int64 {
+	if pid <= 0 {
+		return 0
+	}
+	cmd := exec.Command("ps", "-o", "lstart=", "-p", fmt.Sprintf("%d", pid))
+	cmd.Env = append(os.Environ(), "LC_TIME=C")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return 0
+	}
+	t, err := time.Parse("Mon Jan  2 15:04:05 2006", line)
+	if err != nil {
+		t, err = time.Parse("Mon Jan 2 15:04:05 2006", line)
+		if err != nil {
+			return 0
+		}
+	}
+	return t.Unix()
+}

--- a/skills/ag/internal/agent/agent.go
+++ b/skills/ag/internal/agent/agent.go
@@ -84,7 +84,7 @@ func List() ([]AgentEntry, error) {
 		// Lazy status reconciliation: if activity.json says "running" but the
 		// process is dead, update the status so callers see the real state.
 		if activity.Status == "running" && activity.Pid > 0 {
-					if !IsProcessAlive(activity.Pid) {
+					if !IsProcessAlive(activity.Pid, activity.PidStartTime) {
 				activity.Status = "done"
 				if activity.FinishedAt == 0 {
 					activity.FinishedAt = time.Now().Unix()
@@ -105,15 +105,20 @@ func List() ([]AgentEntry, error) {
 }
 
 // IsProcessAlive checks if a process with the given PID is still running.
-// It distinguishes between running, zombie, and exited processes:
+// It distinguishes between running, zombie, exited, and PID-reused processes:
 //   - Running → true
 //   - Zombie (Z state) → false (process exited but parent hasn't reaped)
 //   - Exited/nonexistent → false
+//   - PID reused (start time mismatch) → false
+//
+// If startTimeEpoch > 0, the function additionally verifies that the current
+// process at this PID started at the same time as the original, preventing
+// false positives from OS PID recycling.
 //
 // On macOS/Linux, os.FindProcess always succeeds, and proc.Signal(0) returns
 // nil for zombie processes (the PID still exists in the process table).
 // We use syscall.Wait4 with WNOHANG to detect zombies without blocking.
-func IsProcessAlive(pid int) bool {
+func IsProcessAlive(pid int, startTimeEpoch ...int64) bool {
 	if pid <= 0 {
 		return false
 	}
@@ -136,14 +141,24 @@ func IsProcessAlive(pid int) bool {
 		// ECHILD: not our child process — can't wait4 it.
 		// This is the common case for spawned agents (different process group).
 		// Fall back to checking /proc or ps for zombie state.
-		return !isZombieFromPS(pid)
+		if isZombieFromPS(pid) {
+			return false
+		}
+	} else if wpid > 0 {
+		// wpid > 0: child exited, was reaped by Wait4. It's dead.
+		return false
 	}
-	if wpid == 0 {
-		// Child is still running (WNOHANG returns 0 if not exited).
-		return true
+	// wpid == 0 or ECHILD with non-zombie: process appears alive.
+
+	// Verify PID hasn't been recycled by checking start time.
+	if len(startTimeEpoch) > 0 && startTimeEpoch[0] > 0 {
+		currentStart := getProcessStartTime(pid)
+		if currentStart == 0 || currentStart != startTimeEpoch[0] {
+			return false
+		}
 	}
-	// wpid > 0: child exited, was reaped by Wait4. It's dead.
-	return false
+
+	return true
 }
 
 // isZombieFromPS checks if a process is in zombie state using ps.
@@ -182,18 +197,19 @@ func ReadActivity(id string) (*Activity, error) {
 // Activity mirrors bridge.AgentActivity for use by CLI commands.
 // Defined here to avoid circular imports (bridge imports storage, agent imports storage).
 type Activity struct {
-	Status      string `json:"status"`
-	Pid         int    `json:"pid,omitempty"`
-	StartedAt   int64  `json:"startedAt,omitempty"`
-	FinishedAt  int64  `json:"finishedAt,omitempty"`
-	Turns       int    `json:"turns"`
-	TokensIn    int64  `json:"tokensIn"`
-	TokensOut   int64  `json:"tokensOut"`
-	TokensTotal int64  `json:"tokensTotal"`
-	LastTool    string `json:"lastTool,omitempty"`
-	LastText    string `json:"lastText,omitempty"`
-	Error       string `json:"error,omitempty"`
-	Backend     string `json:"backend,omitempty"`
+	Status       string `json:"status"`
+	Pid          int    `json:"pid,omitempty"`
+	StartedAt    int64  `json:"startedAt,omitempty"`
+	FinishedAt   int64  `json:"finishedAt,omitempty"`
+	PidStartTime int64  `json:"pidStartTime,omitempty"` // epoch seconds, for PID reuse detection
+	Turns        int    `json:"turns"`
+	TokensIn     int64  `json:"tokensIn"`
+	TokensOut    int64  `json:"tokensOut"`
+	TokensTotal  int64  `json:"tokensTotal"`
+	LastTool     string `json:"lastTool,omitempty"`
+	LastText     string `json:"lastText,omitempty"`
+	Error        string `json:"error,omitempty"`
+	Backend      string `json:"backend,omitempty"`
 }
 
 // IsTerminal returns true if the agent status is terminal (won't change).
@@ -204,4 +220,30 @@ func IsTerminal(status string) bool {
 // timeNow returns current Unix timestamp.
 func timeNow() int64 {
 	return time.Now().Unix()
+}
+
+// getProcessStartTime returns the epoch-second start time of the given PID
+// using `ps -o lstart= -p <pid>`. Returns 0 on error.
+func getProcessStartTime(pid int) int64 {
+	if pid <= 0 {
+		return 0
+	}
+	cmd := exec.Command("ps", "-o", "lstart=", "-p", fmt.Sprintf("%d", pid))
+	cmd.Env = append(os.Environ(), "LC_TIME=C")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return 0
+	}
+	t, err := time.Parse("Mon Jan  2 15:04:05 2006", line)
+	if err != nil {
+		t, err = time.Parse("Mon Jan 2 15:04:05 2006", line)
+		if err != nil {
+			return 0
+		}
+	}
+	return t.Unix()
 }

--- a/skills/ag/internal/run/paths.go
+++ b/skills/ag/internal/run/paths.go
@@ -48,14 +48,15 @@ func MetaPath(runID string) (string, error) {
 
 // RunMeta represents the metadata stored in run.json.
 type RunMeta struct {
-	ID         string `json:"id"`
-	PID        int    `json:"pid"`
-	CWD        string `json:"cwd"`
-	Status     string `json:"status"`
-	StartedAt  int64  `json:"started_at"`
-	FinishedAt int64  `json:"finished_at"`
-	Name       string `json:"name"`
-	ParentRun  string `json:"parent_run"`
+	ID           string `json:"id"`
+	PID          int    `json:"pid"`
+	CWD          string `json:"cwd"`
+	Status       string `json:"status"`
+	StartedAt    int64  `json:"started_at"`
+	FinishedAt   int64  `json:"finished_at"`
+	Name         string `json:"name"`
+	ParentRun    string `json:"parent_run"`
+	PidStartTime int64  `json:"pid_start_time"`
 }
 
 // ReadMeta reads and parses run.json for a given run ID.


### PR DESCRIPTION
## Workpad

```
genius-macbook:/Users/genius/.symphony/workspaces/7d4c5877-f593-48bb-b9fd-00e71ae8e41e@58786f0
```

### Plan

- [ ] 1. Add `PidStartTime` to `RunMeta` struct and `getProcessStartTime()` helper in `pkg/run/meta.go`
  - [ ] 1.1 Add `PidStartTime int64` field to `RunMeta`
  - [ ] 1.2 Implement `getProcessStartTime(pid int) int64` using `ps -o lstart` (macOS) + `/proc/<pid>/stat` (Linux)
  - [ ] 1.3 Update `IsRunning()` to verify PID identity via start time
  - [ ] 1.4 Add `ReconcileRun()` to update stale "running" status
- [ ] 2. Record `PidStartTime` at spawn time in `cmd/ai/run.go`
  - [ ] 2.1 `runSubcommand` — record start time when creating `RunMeta`
  - [ ] 2.2 `serveSubcommand` — record start time when creating `RunMeta`
- [ ] 3. Update `IsProcessAlive` in `skills/ag/internal/agent/agent.go` to accept optional start time
- [ ] 4. Record start time in `skills/ag/cmd/ai_adapter.go` `SpawnWithAIServe`
- [ ] 5. Use start-time check in `skills/ag/cmd/agent_status.go` `getAgentStatusWithAI`
- [ ] 6. Add start-time field to `skills/ag/internal/run/paths.go` `RunMeta`
- [ ] 7. Reconcile stale runs at `ai ls` startup
- [ ] 8. Write/update tests
- [ ] 9. Verify all tests pass

### Acceptance Criteria

- [ ] `RunMeta` includes `pid_start_time` field
- [ ] `IsRunning()` returns false when PID has been recycled (different start time)
- [ ] `IsProcessAlive()` in ag returns false for recycled PIDs when start time is provided
- [ ] Start time is recorded at spawn in both `ai run` and `ai serve`
- [ ] `ai ls` reconciles stale runs
- [ ] All existing tests pass + new tests for PID reuse detection

### Validation

- [ ] targeted tests: `go test ./pkg/run/ -v`
- [ ] targeted tests: `go test ./cmd/ai/ -v -run TestIsRunning`
- [ ] full suite: `go test ./... -v`

### Notes

- Darwin (macOS): use `ps -o lstart= -p <pid>` for start time
- Linux: read `/proc/<pid>/stat` field 22 (starttime in ticks since boot)
- Convert all to epoch seconds for comparison
- Start time of 0 means "not recorded" — skip the check for backward compat