### PR TITLE
feat(ag): scheduler fault tolerance - process cap, LLM health check, circuit breaker granularity

### DIFF
--- a/skills/ag/cmd/root.go
+++ b/skills/ag/cmd/root.go
@@ -90,6 +90,7 @@ var taskRunCmd = &cobra.Command{
 		cfg.DesignFile = design
 		cfg.SkipReview = skipReview
 		cfg.Callback = callback
+		cfg.MaxProcesses, _ = cmd.Flags().GetInt("max-processes")
 
 		cwd, _ := os.Getwd()
 		cfg.WorkDir = cwd
@@ -151,7 +152,7 @@ func runDetached(originalArgs []string) {
 	pidPath := filepath.Join(storage.BaseDir, "scheduler.pid")
 
 	// Open log file
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to open log file: %v\n", err)
 		os.Exit(1)
@@ -198,6 +199,16 @@ var taskRetryCmd = &cobra.Command{
 	Short: "Retry a failed task",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		force, _ := cmd.Flags().GetBool("force")
+		if force {
+			t, err := task.RetryForce(args[0])
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			fmt.Printf("force retried %s (attempt %d)\n", t.ID, t.RetryCount)
+			return
+		}
 		maxRetries, _ := cmd.Flags().GetInt("max-retries")
 		t, err := task.Retry(args[0], maxRetries)
 		if err != nil {
@@ -205,6 +216,20 @@ var taskRetryCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		fmt.Printf("retried %s (attempt %d)\n", t.ID, t.RetryCount)
+	},
+}
+
+var taskResetCmd = &cobra.Command{
+	Use:   "reset <id>",
+	Short: "Fully reset a task to pending (clear claimant, retryCount, error)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		t, err := task.Reset(args[0])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Printf("reset %s to pending\n", t.ID)
 	},
 }
 
@@ -732,7 +757,17 @@ var taskListCmd = &cobra.Command{
 				desc = desc[:50] + "..."
 			}
 			elapsed := ""
-			if t.ClaimedAt > 0 {
+			if t.Status == task.StatusRunning || t.Status == task.StatusClaimed {
+				// Use worker-meta.json startedAt for accurate elapsed display
+				startedAt := task.GetWorkerStartedAt(t.ID)
+				if startedAt > 0 {
+					dur := time.Since(time.Unix(startedAt, 0)).Round(time.Second)
+					elapsed = dur.String()
+				} else if t.ClaimedAt > 0 {
+					dur := time.Since(time.Unix(t.ClaimedAt, 0)).Round(time.Second)
+					elapsed = dur.String()
+				}
+			} else if t.ClaimedAt > 0 {
 				dur := time.Since(time.Unix(t.ClaimedAt, 0)).Round(time.Second)
 				elapsed = dur.String()
 			}
@@ -985,7 +1020,38 @@ var taskShowCmd = &cobra.Command{
 		}
 		if t.FinishedAt > 0 {
 			fmt.Printf("Finished: %s\n", formatTime(t.FinishedAt))
-			fmt.Printf("Duration: %s\n", formatDuration(t.FinishedAt-t.ClaimedAt))
+			// Use worker-meta.json startedAt for accurate duration
+			startedAt := task.GetWorkerStartedAt(t.ID)
+			if startedAt > 0 {
+				fmt.Printf("Duration: %s\n", formatDuration(t.FinishedAt-startedAt))
+			} else if t.ClaimedAt > 0 {
+				fmt.Printf("Duration: %s\n", formatDuration(t.FinishedAt-t.ClaimedAt))
+			}
+		}
+
+		if t.RetryCount > 0 {
+			fmt.Printf("Retry Count: %d\n", t.RetryCount)
+		}
+		if len(t.PreviousRuns) > 0 {
+			fmt.Printf("Previous Runs:\n")
+			for i, run := range t.PreviousRuns {
+				runID := run.RunID
+				if runID == "" {
+					runID = "(unknown)"
+				}
+				fmt.Printf("  #%d: run %s, started %s", i+1, runID, formatTime(run.StartedAt))
+				if run.FailedAt > 0 {
+					fmt.Printf(", failed %s", formatTime(run.FailedAt))
+				}
+				if run.Error != "" {
+					errStr := run.Error
+					if len(errStr) > 80 {
+						errStr = errStr[:80] + "..."
+					}
+					fmt.Printf(" — %s", errStr)
+				}
+				fmt.Println()
+			}
 		}
 
 		// Aggregate turns/tokens from claimant agent's activity.json (FR-023)
@@ -1109,8 +1175,10 @@ func init() {
 	taskRunCmd.Flags().Bool("skip-review", false, "Skip review phase")
 	taskRunCmd.Flags().Bool("detach", false, "Run scheduler in background (log to .ag/scheduler.log)")
 	taskRunCmd.Flags().String("callback", "", "Shell command to execute when all tasks complete (e.g. 'ag agent prompt main \"done\"')")
+	taskRunCmd.Flags().Int("max-processes", 0, "Global process cap (workers+reviewers). 0 = max-concurrent+1")
 	taskLogCmd.Flags().Int("tail", 0, "Show last N lines (default: follow mode)")
 	taskRetryCmd.Flags().Int("max-retries", 3, "Max retries allowed")
+	taskRetryCmd.Flags().Bool("force", false, "Force retry even if max retries exceeded")
 
 	// Send/recv flags
 	sendCmd.Flags().String("file", "", "Send file contents from path")
@@ -1130,7 +1198,7 @@ func init() {
 
 		// Task subcommands
 	taskDepCmd.AddCommand(taskDepAddCmd, taskDepRmCmd, taskDepLsCmd)
-				taskCmd.AddCommand(taskCreateCmd, taskImportPlanCmd, taskListCmd, taskClaimCmd, taskNextCmd, taskDoneCmd, taskFailCmd, taskShowCmd, taskDepCmd, taskRunCmd, taskTransitionCmd, taskRetryCmd, taskCleanupCmd, taskLogCmd, taskStopCmd)
+				taskCmd.AddCommand(taskCreateCmd, taskImportPlanCmd, taskListCmd, taskClaimCmd, taskNextCmd, taskDoneCmd, taskFailCmd, taskShowCmd, taskDepCmd, taskRunCmd, taskTransitionCmd, taskRetryCmd, taskResetCmd, taskCleanupCmd, taskLogCmd, taskStopCmd)
 
 		// Root subcommands
 	rootCmd.AddCommand(agentCmd, bridgeCmd, sendCmd, recvCmd, channelCmd, taskCmd, convCmd, doctorCmd)

--- a/skills/ag/internal/task/scheduler.go
+++ b/skills/ag/internal/task/scheduler.go
@@ -82,9 +82,9 @@ type schedulerState struct {
 	// maxProcesses is the cap for activeProcessCount.
 	maxProcesses int64
 
-	// perTaskFailures tracks consecutive failures per task ID for per-task
-	// circuit breaking instead of a global circuit breaker.
-	perTaskFailures sync.Map // map[string]int
+// perTaskFailures tracks consecutive failures per task ID for per-task
+// circuit breaking instead of a global circuit breaker.
+perTaskFailures sync.Map // map[string]*atomic.Int64
 }
 
 // tryAcquireSlot attempts to reserve a process slot. Returns true on success.
@@ -109,15 +109,14 @@ func (s *schedulerState) activeSlots() int64 {
 
 // recordTaskFailure increments the per-task failure counter and returns the new count.
 func (s *schedulerState) recordTaskFailure(taskID string) int {
-	val, _ := s.perTaskFailures.LoadOrStore(taskID, new(int))
-	counter := val.(*int)
-	*counter++
-	return *counter
+	val, _ := s.perTaskFailures.LoadOrStore(taskID, new(atomic.Int64))
+	counter := val.(*atomic.Int64)
+	return int(counter.Add(1))
 }
 
 // resetTaskFailures clears the per-task failure counter (e.g. on success).
 func (s *schedulerState) resetTaskFailures(taskID string) {
-	s.perTaskFailures.Store(taskID, new(int))
+	s.perTaskFailures.Store(taskID, new(atomic.Int64))
 }
 
 // getTaskFailures returns the current failure count for a task.
@@ -126,7 +125,7 @@ func (s *schedulerState) getTaskFailures(taskID string) int {
 	if !ok {
 		return 0
 	}
-	return *val.(*int)
+	return int(val.(*atomic.Int64).Load())
 }
 
 // RunScheduler executes the scheduler loop until all tasks are terminal

--- a/skills/ag/internal/task/scheduler.go
+++ b/skills/ag/internal/task/scheduler.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -30,6 +32,7 @@ type SchedulerConfig struct {
 	SkipReview      bool
 	MaxReviewRounds int
 	Callback        string // Shell command to execute after all tasks complete
+	MaxProcesses    int    // Global cap on concurrent ai serve processes (workers + reviewers). 0 = MaxConcurrent+1
 }
 
 // DefaultSchedulerConfig returns sensible defaults.
@@ -53,7 +56,78 @@ const (
 	// timeoutExtendPerActivity adds this much to the deadline each time
 	// we detect the worker is still actively writing events.
 	timeoutExtendPerActivity = 5 * time.Minute
+
+	// firstResponseTimeout is how long we wait for the LLM to produce
+	// its first assistant message before failing fast. If events.jsonl
+	// has zero assistant messages after this duration, the worker is
+	// considered dead (LLM never responded).
+	firstResponseTimeout = 5 * time.Minute
+
+	// retryBackoffDurations defines exponential backoff delays between retries.
+	// Index 0 = first retry (30s), index 1 = second retry (2min), index 2+ = 5min.
+	retryBackoffDurations = 3
+
+	// maxConsecutiveFailures is the per-task circuit breaker threshold.
+	// After this many consecutive failures, a task is marked non-retryable.
+	maxConsecutiveFailures = 3
 )
+
+// schedulerState holds mutable state shared across the scheduler loop.
+type schedulerState struct {
+	// activeProcessCount tracks the number of currently running ai serve
+	// processes (workers + reviewers). This is a global cap that prevents
+	// resource exhaustion when multiple reviewers spawn simultaneously.
+	activeProcessCount atomic.Int64
+
+	// maxProcesses is the cap for activeProcessCount.
+	maxProcesses int64
+
+	// perTaskFailures tracks consecutive failures per task ID for per-task
+	// circuit breaking instead of a global circuit breaker.
+	perTaskFailures sync.Map // map[string]int
+}
+
+// tryAcquireSlot attempts to reserve a process slot. Returns true on success.
+// Call releaseSlot() when the process finishes.
+func (s *schedulerState) tryAcquireSlot() bool {
+	current := s.activeProcessCount.Load()
+	if current >= s.maxProcesses {
+		return false
+	}
+	return s.activeProcessCount.CompareAndSwap(current, current+1)
+}
+
+// releaseSlot releases a process slot after a worker/reviewer finishes.
+func (s *schedulerState) releaseSlot() {
+	s.activeProcessCount.Add(-1)
+}
+
+// activeSlots returns the number of currently active process slots.
+func (s *schedulerState) activeSlots() int64 {
+	return s.activeProcessCount.Load()
+}
+
+// recordTaskFailure increments the per-task failure counter and returns the new count.
+func (s *schedulerState) recordTaskFailure(taskID string) int {
+	val, _ := s.perTaskFailures.LoadOrStore(taskID, new(int))
+	counter := val.(*int)
+	*counter++
+	return *counter
+}
+
+// resetTaskFailures clears the per-task failure counter (e.g. on success).
+func (s *schedulerState) resetTaskFailures(taskID string) {
+	s.perTaskFailures.Store(taskID, new(int))
+}
+
+// getTaskFailures returns the current failure count for a task.
+func (s *schedulerState) getTaskFailures(taskID string) int {
+	val, ok := s.perTaskFailures.Load(taskID)
+	if !ok {
+		return 0
+	}
+	return *val.(*int)
+}
 
 // RunScheduler executes the scheduler loop until all tasks are terminal
 // or the context is cancelled.
@@ -79,6 +153,15 @@ func RunScheduler(ctx context.Context, cfg SchedulerConfig) error {
 	fmt.Printf("Scheduler started: %d tasks, max concurrent=%d, review=%v\n",
 		len(tasks), cfg.MaxConcurrent, !cfg.SkipReview)
 
+	// Initialize global process cap state
+	state := &schedulerState{}
+	if cfg.MaxProcesses > 0 {
+		state.maxProcesses = int64(cfg.MaxProcesses)
+	} else {
+		state.maxProcesses = int64(cfg.MaxConcurrent) + 1 // +1 for reviewer
+	}
+	fmt.Printf("  Global process cap: %d (workers + reviewers)\n", state.maxProcesses)
+
 	// Heartbeat: write timestamp every poll interval so `ag task stop`
 	// can detect stale scheduler vs. dead scheduler.
 	heartbeatPath := filepath.Join(storage.BaseDir, "scheduler.heartbeat")
@@ -94,9 +177,7 @@ func RunScheduler(ctx context.Context, cfg SchedulerConfig) error {
 		}
 	}()
 
-	// Circuit breaker: stop after N consecutive failures
-	consecutiveFailures := 0
-	const maxConsecutiveFailures = 3
+	// Circuit breaker: per-task tracking (maxConsecutiveFailures per task)
 
 	// Print blocking status for each pending task
 	pendingTasks, _ := List(StatusPending)
@@ -138,17 +219,29 @@ func RunScheduler(ctx context.Context, cfg SchedulerConfig) error {
 		default:
 		}
 
-				progress, err := tick(ctx, cfg)
+				progress, err := tick(ctx, cfg, state)
 		if err != nil {
 			return fmt.Errorf("scheduler tick: %w", err)
 		}
 
-						// Circuit breaker: count consecutive failures or truly stuck reviews
-		// "Truly stuck" means: reviews in a fully-ready group (all tasks in review)
-		// with no reviewer process alive — indicating reviewer crashed.
+						// Per-task circuit breaker: check if any single task has exceeded max failures.
+		// Unlike the previous global breaker, this only marks the failing task as
+		// permanently failed (non-retryable) so AllDone() can proceed without
+		// stopping the entire scheduler.
 		failed, _ := List(StatusFailed)
+		for _, ft := range failed {
+			failures := state.getTaskFailures(ft.ID)
+			if failures >= maxConsecutiveFailures && ft.Retryable {
+				// Permanently fail this task so the scheduler can move on.
+				log.Printf("[scheduler] %s: exceeded %d consecutive failures, marking non-retryable", ft.ID, maxConsecutiveFailures)
+				// Set Retryable=false so retryFailed skips it and AllDone treats it as terminal.
+				MarkNonRetryable(ft.ID)
+			}
+		}
+
+		// Check for truly stuck reviews (reviewer crashed without updating tasks)
 		trulyStuck := false
-		if len(failed) == 0 {
+		{
 			// Check if any review group is fully in review but has no reviewer alive
 			reviewTasks, _ := List(StatusReview)
 			if len(reviewTasks) > 0 {
@@ -182,20 +275,8 @@ func RunScheduler(ctx context.Context, cfg SchedulerConfig) error {
 				}
 			}
 		}
-		if (len(failed) > 0 || trulyStuck) && !progress {
-			consecutiveFailures++
-			if consecutiveFailures >= maxConsecutiveFailures {
-				fmt.Printf("\n⛔ Circuit breaker: %d consecutive ticks without progress\n", consecutiveFailures)
-				if trulyStuck {
-					fmt.Println("  Reason: review group fully in review but no reviewer alive")
-				}
-				fmt.Println("Stopping scheduler to prevent wasting resources.")
-				printSummary()
-				return fmt.Errorf("circuit breaker triggered: %d consecutive failures", consecutiveFailures)
-			}
-			log.Printf("[scheduler] circuit breaker: %d/%d (failed=%d, trulyStuck=%v)", consecutiveFailures, maxConsecutiveFailures, len(failed), trulyStuck)
-		} else if progress {
-			consecutiveFailures = 0
+		if trulyStuck && !progress {
+			log.Printf("[scheduler] truly stuck review detected but continuing (per-task circuit breaker handles individual tasks)")
 		}
 
 		// Check if all done
@@ -226,25 +307,25 @@ func RunScheduler(ctx context.Context, cfg SchedulerConfig) error {
 }
 
 // tick executes one scheduler cycle. Returns true if any progress was made.
-func tick(ctx context.Context, cfg SchedulerConfig) (bool, error) {
+func tick(ctx context.Context, cfg SchedulerConfig, state *schedulerState) (bool, error) {
 	progress := false
 
 	// 1. Retry failed tasks
-	if p, err := retryFailed(cfg); err != nil {
+	if p, err := retryFailed(cfg, state); err != nil {
 		return false, err
 	} else if p {
 		progress = true
 	}
 
 	// 2. Spawn workers for runnable tasks
-	if p, err := spawnWorkers(ctx, cfg); err != nil {
+	if p, err := spawnWorkers(ctx, cfg, state); err != nil {
 		return false, err
 	} else if p {
 		progress = true
 	}
 
 	// 3. Check running tasks for completion
-	if p, err := checkRunning(cfg); err != nil {
+	if p, err := checkRunning(cfg, state); err != nil {
 		return false, err
 	} else if p {
 		progress = true
@@ -252,7 +333,7 @@ func tick(ctx context.Context, cfg SchedulerConfig) (bool, error) {
 
 	// 4. Group review
 	if !cfg.SkipReview {
-		if p, err := checkGroupReview(ctx, cfg); err != nil {
+		if p, err := checkGroupReview(ctx, cfg, state); err != nil {
 			return false, err
 		} else if p {
 			progress = true
@@ -265,7 +346,8 @@ func tick(ctx context.Context, cfg SchedulerConfig) (bool, error) {
 // retryFailed retries failed tasks that haven't exceeded max retries.
 // Before retrying, kills any leftover worker processes from the failed attempt
 // and waits for them to actually die before resetting the task to pending.
-func retryFailed(cfg SchedulerConfig) (bool, error) {
+// Applies exponential backoff between retries: 30s, 2min, 5min.
+func retryFailed(cfg SchedulerConfig, state *schedulerState) (bool, error) {
 	failed, err := List(StatusFailed)
 	if err != nil {
 		return false, err
@@ -274,6 +356,13 @@ func retryFailed(cfg SchedulerConfig) (bool, error) {
 	for _, t := range failed {
 		if !t.Retryable {
 			log.Printf("[scheduler] skip retry %s: not retryable (error: %s)", t.ID, t.Error)
+			continue
+		}
+
+		// Per-task circuit breaker: if this task has failed too many times in a row,
+		// don't retry it. The main loop's circuit breaker check will mark it non-retryable.
+		if state.getTaskFailures(t.ID) >= maxConsecutiveFailures {
+			log.Printf("[scheduler] skip retry %s: per-task circuit breaker (%d failures)", t.ID, state.getTaskFailures(t.ID))
 			continue
 		}
 
@@ -290,10 +379,35 @@ func retryFailed(cfg SchedulerConfig) (bool, error) {
 			log.Printf("[scheduler] skip retry %s: %v", t.ID, err)
 			continue // max retries exceeded, skip
 		}
+
+		// Exponential backoff: wait before spawning next attempt.
+		// Schedule: 30s for 1st retry, 2min for 2nd, 5min for 3rd+.
+		backoff := retryBackoff(t.RetryCount)
+		if backoff > 0 {
+			log.Printf("[scheduler] %s: backing off %v before retry attempt %d", t.ID, backoff, t.RetryCount+1)
+			time.Sleep(backoff)
+		}
+
 		fmt.Printf("  🔄 Retried %s (attempt %d)\n", t.ID, t.RetryCount+1)
 		progress = true
 	}
 	return progress, nil
+}
+
+// retryBackoff returns the delay duration for a given retry attempt (1-indexed).
+// Schedule: attempt 1 = 30s, attempt 2 = 2min, attempt 3+ = 5min.
+func retryBackoff(retryCount int) time.Duration {
+	switch retryCount {
+	case 1:
+		return 30 * time.Second
+	case 2:
+		return 2 * time.Minute
+	default:
+		if retryCount >= retryBackoffDurations {
+			return 5 * time.Minute
+		}
+		return 30 * time.Second
+	}
 }
 
 // waitForWorkerDeath polls until the worker process is confirmed dead
@@ -325,17 +439,9 @@ func waitForWorkerDeath(claimant string, timeout time.Duration) {
 }
 
 // spawnWorkers picks pending tasks with met dependencies and spawns worker agents.
-func spawnWorkers(ctx context.Context, cfg SchedulerConfig) (bool, error) {
-	// Count currently running tasks
-	running, err := List(StatusRunning)
-	if err != nil {
-		return false, err
-	}
-	slots := cfg.MaxConcurrent - len(running)
-	if slots <= 0 {
-		return false, nil
-	}
-
+// Uses the global process cap (state.activeProcessCount) to limit total concurrent
+// ai serve processes (workers + reviewers).
+func spawnWorkers(ctx context.Context, cfg SchedulerConfig, state *schedulerState) (bool, error) {
 	// Find pending tasks with met dependencies
 	pending, err := List(StatusPending)
 	if err != nil {
@@ -344,15 +450,20 @@ func spawnWorkers(ctx context.Context, cfg SchedulerConfig) (bool, error) {
 
 	progress := false
 	for _, t := range pending {
-		if slots <= 0 {
+		// Check global process cap before spawning
+		if !state.tryAcquireSlot() {
+			log.Printf("[scheduler] skip spawn: global process cap reached (%d/%d)", state.activeSlots(), state.maxProcesses)
 			break
 		}
+
 		unmet, err := UnmetDependencies(t.ID)
 		if err != nil {
+			state.releaseSlot() // won't spawn, release slot
 			log.Printf("[scheduler] skip %s: dependency check error: %v", t.ID, err)
 			continue
 		}
 		if len(unmet) > 0 {
+			state.releaseSlot() // won't spawn, release slot
 			log.Printf("[scheduler] skip %s: blocked by %v", t.ID, unmet)
 			continue
 		}
@@ -360,25 +471,28 @@ func spawnWorkers(ctx context.Context, cfg SchedulerConfig) (bool, error) {
 		// Claim and transition to running
 		claimed, err := Claim(t.ID, fmt.Sprintf("worker-%s", t.ID))
 		if err != nil {
+			state.releaseSlot() // won't spawn, release slot
 			log.Printf("[scheduler] skip %s: claim failed: %v", t.ID, err)
 			continue
 		}
 		_, err = Transition(t.ID, StatusRunning)
 		if err != nil {
+			state.releaseSlot() // won't spawn, release slot
 			log.Printf("[scheduler] skip %s: transition to running failed: %v", t.ID, err)
 			continue
 		}
 
-		// Spawn worker agent
-		go spawnWorker(t.ID, claimed.Claimant, cfg)
-		slots--
+		// Spawn worker agent — slot is released in spawnWorker on completion
+		go spawnWorker(t.ID, claimed.Claimant, cfg, state)
 		progress = true
 	}
 	return progress, nil
 }
 
 // spawnWorker runs a worker agent for a single task.
-func spawnWorker(taskID, agentID string, cfg SchedulerConfig) {
+// Releases the global process slot when the worker finishes (success or failure).
+func spawnWorker(taskID, agentID string, cfg SchedulerConfig, state *schedulerState) {
+	defer state.releaseSlot()
 	t, err := Load(taskID)
 	if err != nil {
 		Fail(taskID, fmt.Sprintf("load task: %v", err), false)
@@ -479,7 +593,8 @@ func spawnWorker(taskID, agentID string, cfg SchedulerConfig) {
 // checkRunning checks if any running tasks have completed (stale detection).
 // For ai-serve workers, checks the run.json status via runID.
 // For legacy workers, checks if PID is still alive.
-func checkRunning(cfg SchedulerConfig) (bool, error) {
+// Also detects LLM silence (zero assistant messages) and fails fast.
+func checkRunning(cfg SchedulerConfig, state *schedulerState) (bool, error) {
 	running, err := List(StatusRunning)
 	if err != nil {
 		return false, err
@@ -592,10 +707,34 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 								// Kill the worker BEFORE marking as failed, so retryFailed
 				// won't spawn a new worker while the old one is still alive.
 				killWorker(t.ID, t.Claimant)
-				Fail(t.ID, fmt.Sprintf("task timed out after %v", elapsed.Round(time.Minute)), true)
+				state.recordTaskFailure(t.ID)
+				errMsg := fmt.Sprintf("task timed out after %v", elapsed.Round(time.Minute))
+				Fail(t.ID, errMsg, true)
+				if runID != "" {
+					RecordFailedRun(t.ID, runID, startedAt, errMsg)
+				}
 				fmt.Printf("  ⏰ Detected timeout %s (ran for %v)\n", t.ID, elapsed.Round(time.Minute))
 				progress = true
 				continue
+			}
+		}
+
+		// LLM silence detection: if the worker has been running for a while but
+		// events.jsonl has zero assistant messages, the LLM backend is not responding.
+		// Fail fast instead of waiting for the full timeout.
+		if startedAt > 0 && runID != "" {
+			elapsed := time.Since(time.Unix(startedAt, 0))
+			if elapsed > firstResponseTimeout {
+				if !hasAssistantMessages(runID) {
+					killWorker(t.ID, t.Claimant)
+					state.recordTaskFailure(t.ID)
+					silenceErr := fmt.Sprintf("LLM silence: no assistant messages after %v", elapsed.Round(time.Minute))
+					Fail(t.ID, silenceErr, true)
+					RecordFailedRun(t.ID, runID, startedAt, silenceErr)
+					fmt.Printf("  🔇 LLM silence detected %s (no response after %v)\n", t.ID, elapsed.Round(time.Minute))
+					progress = true
+					continue
+				}
 			}
 		}
 
@@ -617,7 +756,11 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 				if lastOutput != "" {
 					errMsg += "\nLast output:\n" + lastOutput
 				}
+				state.recordTaskFailure(t.ID)
 				Fail(t.ID, errMsg, true)
+				if runID != "" {
+					RecordFailedRun(t.ID, runID, startedAt, errMsg)
+				}
 				fmt.Printf("  ❌ Detected failure %s (ai-serve process died)\n", t.ID)
 				progress = true
 				continue
@@ -638,6 +781,7 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 					if lastOutput != "" {
 						errMsg += "\nLast output:\n" + lastOutput
 					}
+					state.recordTaskFailure(t.ID)
 					Fail(t.ID, errMsg, true)
 					fmt.Printf("  ❌ Detected failure %s (process died)\n", t.ID)
 					progress = true
@@ -647,6 +791,9 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 		}
 
 				if completed {
+			// Task completed successfully — reset per-task failure counter
+			state.resetTaskFailures(t.ID)
+
 			// Cross-task file modification detection (Problem 4):
 			// Check if the worker modified files outside its declared scope.
 			if warning := checkCrossTaskModifications(cfg.WorkDir, t); warning != "" {
@@ -673,6 +820,23 @@ func checkRunning(cfg SchedulerConfig) (bool, error) {
 		}
 	}
 	return progress, nil
+}
+
+// hasAssistantMessages checks if events.jsonl for a run contains any assistant messages.
+// Returns false if no assistant messages are found, indicating LLM silence.
+func hasAssistantMessages(runID string) bool {
+	eventsPath, err := run.EventsPath(runID)
+	if err != nil {
+		return false
+	}
+	data, err := os.ReadFile(eventsPath)
+	if err != nil {
+		return false // no events file yet = no messages
+	}
+	// Check for "assistant" role in events — a simple string scan is sufficient
+	// and avoids needing to parse the full JSONL.
+	return strings.Contains(string(data), `"role":"assistant"`) ||
+		strings.Contains(string(data), `"role": "assistant"`)
 }
 
 // checkAIServeRun checks events.jsonl for a specific run to see if the agent has finished.
@@ -729,7 +893,8 @@ func checkAIServeRun(runID, taskID string) (bool, string) {
 }
 
 // checkGroupReview checks if any group has all tasks in review and needs reviewer.
-func checkGroupReview(ctx context.Context, cfg SchedulerConfig) (bool, error) {
+// Acquires a global process slot before spawning the reviewer.
+func checkGroupReview(ctx context.Context, cfg SchedulerConfig, state *schedulerState) (bool, error) {
 	groups, err := Groups()
 	if err != nil {
 		return false, err
@@ -770,8 +935,13 @@ func checkGroupReview(ctx context.Context, cfg SchedulerConfig) (bool, error) {
 			}
 		}
 	}
+	// Check global process cap before spawning reviewer
+	if !state.tryAcquireSlot() {
+		log.Printf("[scheduler] skip reviewer for group %s: global process cap reached (%d/%d)", group, state.activeSlots(), state.maxProcesses)
+		continue
+	}
 	fmt.Printf("  🔍 Reviewing group %s\n", group)
-	go spawnReviewer(group, tasks, cfg)
+	go spawnReviewer(group, tasks, cfg, state)
 	progress = true
 	}
 	return progress, nil
@@ -781,7 +951,9 @@ func checkGroupReview(ctx context.Context, cfg SchedulerConfig) (bool, error) {
 // It writes the prompt to a temp file (--input-file) to avoid OS argument
 // length limits, and writes activity.json so agent commands can find it.
 // The reviewer runs synchronously within this goroutine (blocks until cmd.Wait).
-func spawnReviewer(group string, tasks []*Task, cfg SchedulerConfig) {
+// Releases the global process slot when finished.
+func spawnReviewer(group string, tasks []*Task, cfg SchedulerConfig, state *schedulerState) {
+	defer state.releaseSlot()
 	// Get diff of changes
 	diff := getDiff(cfg.WorkDir)
 

--- a/skills/ag/internal/task/task.go
+++ b/skills/ag/internal/task/task.go
@@ -89,6 +89,15 @@ type Task struct {
 	Summary          string   `json:"summary,omitempty"`
 	Retryable        bool     `json:"retryable,omitempty"`
 	RetryCount       int      `json:"retryCount,omitempty"`
+	PreviousRuns     []RunRecord `json:"previousRuns,omitempty"` // History of failed run attempts
+}
+
+// RunRecord stores metadata about a single task run attempt.
+type RunRecord struct {
+	RunID     string `json:"runId,omitempty"`
+	StartedAt int64  `json:"startedAt,omitempty"`
+	FailedAt  int64  `json:"failedAt,omitempty"`
+	Error     string `json:"error,omitempty"`
 }
 
 var (
@@ -311,6 +320,17 @@ func Fail(taskID string, errMsg string, retryable bool) (*Task, error) {
 // Retry resets a failed task back to pending for re-execution.
 // Increments RetryCount. Returns error if task is not failed or max retries exceeded.
 func Retry(taskID string, maxRetries int) (*Task, error) {
+	return retryInternal(taskID, maxRetries, false)
+}
+
+// RetryForce resets a failed task back to pending, bypassing the max retries check.
+// Use for manual recovery of stuck tasks.
+func RetryForce(taskID string) (*Task, error) {
+	return retryInternal(taskID, 0, true)
+}
+
+// retryInternal is the shared implementation for Retry and RetryForce.
+func retryInternal(taskID string, maxRetries int, force bool) (*Task, error) {
 	taskMu.Lock()
 	defer taskMu.Unlock()
 
@@ -323,7 +343,7 @@ func Retry(taskID string, maxRetries int) (*Task, error) {
 		return nil, fmt.Errorf("task %s is %s (not failed, cannot retry)", taskID, task.Status)
 	}
 
-	if task.RetryCount >= maxRetries {
+	if !force && task.RetryCount >= maxRetries {
 		return nil, fmt.Errorf("task %s exceeded max retries (%d)", taskID, maxRetries)
 	}
 
@@ -342,6 +362,91 @@ func Retry(taskID string, maxRetries int) (*Task, error) {
 		return nil, err
 	}
 	return task, nil
+}
+
+// Reset fully resets a task to pending state, clearing all runtime fields.
+// Unlike Retry, this clears RetryCount and makes the task appear as new.
+// Useful for manual recovery of stuck or permanently-failed tasks.
+func Reset(taskID string) (*Task, error) {
+	taskMu.Lock()
+	defer taskMu.Unlock()
+
+	task, err := loadTask(taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reset all runtime fields
+	task.Status = StatusPending
+	task.Claimant = ""
+	task.ClaimedAt = 0
+	task.FinishedAt = 0
+	task.Error = ""
+	task.Summary = ""
+	task.Retryable = false
+	task.RetryCount = 0
+
+	// Remove claim lock so Claim can succeed
+	os.Remove(filepath.Join(storage.TaskDir(taskID), ".claim-lock"))
+
+	if err := storage.AtomicWriteJSON(filepath.Join(storage.TaskDir(taskID), "task.json"), task); err != nil {
+		return nil, err
+	}
+	return task, nil
+}
+
+// MarkNonRetryable sets Retryable=false on a task so the scheduler
+// will stop retrying it and AllDone() can treat it as terminal.
+func MarkNonRetryable(taskID string) error {
+	taskMu.Lock()
+	defer taskMu.Unlock()
+
+	task, err := loadTask(taskID)
+	if err != nil {
+		return err
+	}
+	task.Retryable = false
+	return storage.AtomicWriteJSON(filepath.Join(storage.TaskDir(taskID), "task.json"), task)
+}
+
+// RecordFailedRun appends a run record to the task's PreviousRuns history.
+// This preserves failed run IDs for debugging and retry history display.
+func RecordFailedRun(taskID, runID string, startedAt int64, errMsg string) error {
+	taskMu.Lock()
+	defer taskMu.Unlock()
+
+	task, err := loadTask(taskID)
+	if err != nil {
+		return err
+	}
+	task.PreviousRuns = append(task.PreviousRuns, RunRecord{
+		RunID:     runID,
+		StartedAt: startedAt,
+		FailedAt:  time.Now().Unix(),
+		Error:     errMsg,
+	})
+	return storage.AtomicWriteJSON(filepath.Join(storage.TaskDir(taskID), "task.json"), task)
+}
+
+// GetWorkerStartedAt returns the startedAt timestamp from worker-meta.json
+// for a task's claimant agent, or 0 if not available.
+func GetWorkerStartedAt(taskID string) int64 {
+	t, err := loadTask(taskID)
+	if err != nil || t.Claimant == "" {
+		return 0
+	}
+	agentDir := storage.AgentDir(t.Claimant)
+	metaPath := filepath.Join(agentDir, "worker-meta.json")
+	if !storage.Exists(metaPath) {
+		return 0
+	}
+	var meta struct {
+		StartedAt int64 `json:"startedAt"`
+	}
+	if err := storage.ReadJSON(metaPath, &meta); err != nil {
+		return 0
+	}
+	return meta.StartedAt
 }
 
 // Groups returns all unique group names across all tasks.

--- a/skills/ag/internal/task/task_test.go
+++ b/skills/ag/internal/task/task_test.go
@@ -1,9 +1,11 @@
 package task
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func setupTest(t *testing.T) {
@@ -772,5 +774,265 @@ tasks:
 	t2, _ := Load("T002")
 	if t2.Group != "frontend" {
 		t.Fatalf("expected frontend group, got %s", t2.Group)
+	}
+}
+
+func TestRetryForce(t *testing.T) {
+	setupTest(t)
+
+	Create("Task", "")
+	claimAndRun(t, "t001", "worker-1")
+
+	// Fail and retry 3 times to exceed max
+	for i := 0; i < 3; i++ {
+		Fail("t001", "error", true)
+		Retry("t001", 3)
+		claimAndRun(t, "t001", fmt.Sprintf("worker-%d", i))
+	}
+	Fail("t001", "final error", true)
+
+	// Normal retry should fail (max exceeded)
+	_, err := Retry("t001", 3)
+	if err == nil {
+		t.Fatal("expected error: max retries exceeded")
+	}
+
+	// Force retry should succeed
+	task, err := RetryForce("t001")
+	if err != nil {
+		t.Fatalf("RetryForce: %v", err)
+	}
+	if task.Status != StatusPending {
+		t.Fatalf("expected pending, got %s", task.Status)
+	}
+	if task.RetryCount != 4 {
+		t.Fatalf("expected retry count 4, got %d", task.RetryCount)
+	}
+}
+
+func TestReset(t *testing.T) {
+	setupTest(t)
+
+	Create("Task", "")
+	claimAndRun(t, "t001", "worker-1")
+	Fail("t001", "some error", true)
+	Retry("t001", 3)
+	claimAndRun(t, "t001", "worker-2")
+	Fail("t001", "another error", true)
+
+	// Reset should clear everything
+	task, err := Reset("t001")
+	if err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if task.Status != StatusPending {
+		t.Fatalf("expected pending, got %s", task.Status)
+	}
+	if task.Claimant != "" {
+		t.Fatalf("claimant should be empty, got %s", task.Claimant)
+	}
+	if task.Error != "" {
+		t.Fatalf("error should be empty, got %s", task.Error)
+	}
+	if task.RetryCount != 0 {
+		t.Fatalf("retry count should be 0, got %d", task.RetryCount)
+	}
+	if task.ClaimedAt != 0 {
+		t.Fatalf("claimedAt should be 0, got %d", task.ClaimedAt)
+	}
+
+	// Should be claimable again
+	_, err = Claim("t001", "fresh-worker")
+	if err != nil {
+		t.Fatalf("should be claimable after reset: %v", err)
+	}
+}
+
+func TestMarkNonRetryable(t *testing.T) {
+	setupTest(t)
+
+	Create("Task", "")
+	claimAndRun(t, "t001", "worker-1")
+	Fail("t001", "error", true)
+
+	task, _ := Load("t001")
+	if !task.Retryable {
+		t.Fatal("should be retryable initially")
+	}
+
+	MarkNonRetryable("t001")
+
+	task, _ = Load("t001")
+	if task.Retryable {
+		t.Fatal("should be non-retryable after MarkNonRetryable")
+	}
+}
+
+func TestRecordFailedRun(t *testing.T) {
+	setupTest(t)
+
+	Create("Task", "")
+	claimAndRun(t, "t001", "worker-1")
+	Fail("t001", "timeout", true)
+
+	// Record a failed run
+	err := RecordFailedRun("t001", "run-abc123", 1000000, "task timed out")
+	if err != nil {
+		t.Fatalf("RecordFailedRun: %v", err)
+	}
+
+	task, _ := Load("t001")
+	if len(task.PreviousRuns) != 1 {
+		t.Fatalf("expected 1 previous run, got %d", len(task.PreviousRuns))
+	}
+	if task.PreviousRuns[0].RunID != "run-abc123" {
+		t.Fatalf("wrong run ID: %s", task.PreviousRuns[0].RunID)
+	}
+	if task.PreviousRuns[0].Error != "task timed out" {
+		t.Fatalf("wrong error: %s", task.PreviousRuns[0].Error)
+	}
+
+	// Record another failed run
+	RecordFailedRun("t001", "run-def456", 2000000, "LLM silence")
+	task, _ = Load("t001")
+	if len(task.PreviousRuns) != 2 {
+		t.Fatalf("expected 2 previous runs, got %d", len(task.PreviousRuns))
+	}
+}
+
+func TestGetWorkerStartedAt(t *testing.T) {
+	setupTest(t)
+
+	Create("Task", "")
+
+	// No claimant — should return 0
+	ts := GetWorkerStartedAt("t001")
+	if ts != 0 {
+		t.Fatalf("expected 0 with no claimant, got %d", ts)
+	}
+
+	// With claimant but no worker-meta.json — should return 0
+	Claim("t001", "worker-t001")
+	ts = GetWorkerStartedAt("t001")
+	if ts != 0 {
+		t.Fatalf("expected 0 with no meta file, got %d", ts)
+	}
+}
+
+func TestRetryBackoff(t *testing.T) {
+	tests := []struct {
+		retryCount int
+		expected   time.Duration
+	}{
+		{0, 30 * time.Second},
+		{1, 30 * time.Second},
+		{2, 2 * time.Minute},
+		{3, 5 * time.Minute},
+		{5, 5 * time.Minute},
+	}
+	for _, tt := range tests {
+		got := retryBackoff(tt.retryCount)
+		if got != tt.expected {
+			t.Errorf("retryBackoff(%d) = %v, want %v", tt.retryCount, got, tt.expected)
+		}
+	}
+}
+
+func TestSchedulerStateProcessSlots(t *testing.T) {
+	state := &schedulerState{maxProcesses: 3}
+
+	if state.activeSlots() != 0 {
+		t.Fatalf("expected 0 active slots, got %d", state.activeSlots())
+	}
+
+	// Acquire slots up to max
+	if !state.tryAcquireSlot() {
+		t.Fatal("should acquire slot 1")
+	}
+	if !state.tryAcquireSlot() {
+		t.Fatal("should acquire slot 2")
+	}
+	if !state.tryAcquireSlot() {
+		t.Fatal("should acquire slot 3")
+	}
+	if state.tryAcquireSlot() {
+		t.Fatal("should NOT acquire slot 4 (at cap)")
+	}
+
+	// Release one and acquire again
+	state.releaseSlot()
+	if state.activeSlots() != 2 {
+		t.Fatalf("expected 2 active slots, got %d", state.activeSlots())
+	}
+	if !state.tryAcquireSlot() {
+		t.Fatal("should acquire slot after release")
+	}
+}
+
+func TestSchedulerStatePerTaskFailures(t *testing.T) {
+	state := &schedulerState{}
+
+	if state.getTaskFailures("t001") != 0 {
+		t.Fatal("initial failures should be 0")
+	}
+
+	count := state.recordTaskFailure("t001")
+	if count != 1 {
+		t.Fatalf("expected 1, got %d", count)
+	}
+	count = state.recordTaskFailure("t001")
+	if count != 2 {
+		t.Fatalf("expected 2, got %d", count)
+	}
+
+	state.resetTaskFailures("t001")
+	if state.getTaskFailures("t001") != 0 {
+		t.Fatal("failures should be 0 after reset")
+	}
+
+	// Different task should be independent
+	state.recordTaskFailure("t002")
+	if state.getTaskFailures("t001") != 0 {
+		t.Fatal("t001 failures should be independent of t002")
+	}
+	if state.getTaskFailures("t002") != 1 {
+		t.Fatal("t002 should have 1 failure")
+	}
+}
+
+func TestHasAssistantMessages(t *testing.T) {
+	// Create a fake run directory with events
+	tmpDir := t.TempDir()
+
+	// Test with no run directory
+	if hasAssistantMessages("nonexistent-run") {
+		t.Fatal("should return false for nonexistent run")
+	}
+
+	// Create a run directory with events containing assistant messages
+	runDir := filepath.Join(tmpDir, ".ai", "runs", "test-run")
+	os.MkdirAll(runDir, 0755)
+	eventsContent := `{"role":"user","content":"hello"}
+{"role":"assistant","content":"hi there"}
+`
+	os.WriteFile(filepath.Join(runDir, "events.jsonl"), []byte(eventsContent), 0644)
+
+	// Override home dir for the test
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	if !hasAssistantMessages("test-run") {
+		t.Fatal("should find assistant messages")
+	}
+
+	// Test with no assistant messages
+	runDir2 := filepath.Join(tmpDir, ".ai", "runs", "test-run2")
+	os.MkdirAll(runDir2, 0755)
+	os.WriteFile(filepath.Join(runDir2, "events.jsonl"), []byte(`{"role":"user","content":"hello"}
+`), 0644)
+
+	if hasAssistantMessages("test-run2") {
+		t.Fatal("should NOT find assistant messages in run2")
 	}
 }


### PR DESCRIPTION
## Workpad

```text
genius:/Users/genius/.symphony/workspaces/1b99a94e-6e99-4cd9-b9bf-3f53d1bc07ad@17a8ff6
```

### Plan

- [ ] 1. P0: Global ai serve process cap (workers + reviewers counted together)
  - [ ] 1.1 Add global process counter (semaphore) in scheduler.go
  - [ ] 1.2 Refactor spawnWorkers to count against global cap, not just StatusRunning
  - [ ] 1.3 Refactor spawnReviewer to acquire global slot
  - [ ] 1.4 Add MaxProcesses config field (default: MaxConcurrent + 1)
- [ ] 2. P0: LLM silence detection (fail fast on no assistant messages)
  - [ ] 2.1 Add checkActiveWorker() — scan events.jsonl for assistant messages
  - [ ] 2.2 If no assistant messages after firstResponseTimeout (5min), fail fast
- [ ] 3. P0: Per-retry exponential backoff
  - [ ] 3.1 Add backoff delay in retryFailed() based on RetryCount
  - [ ] 3.2 Backoff schedule: 30s, 2min, 5min
- [ ] 4. P1: Per-task circuit breaker (stop individual task, not entire scheduler)
  - [ ] 4.1 Replace global consecutiveFailures with per-task tracking
  - [ ] 4.2 Mark permanently failed tasks as non-retryable, AllDone() can proceed
- [ ] 5. P1: `ag task retry --force` flag
  - [ ] 5.1 Add --force flag to taskRetryCmd in root.go
  - [ ] 5.2 Add forceRetry to task.Retry() that bypasses max retries check
- [ ] 6. P1: `ag task reset <id>` command
  - [ ] 6.1 Add Reset() function in task.go
  - [ ] 6.2 Add taskResetCmd in root.go
- [ ] 7. P1: Elapsed time fix (use worker-meta.json.startedAt)
  - [ ] 7.1 Fix task list elapsed display to prefer worker-meta.json startedAt
- [ ] 8. P1: Preserve failed run history
  - [ ] 8.1 Add PreviousRuns field to Task struct
  - [ ] 8.2 Record run IDs on failure/retry in task.go
- [ ] 9. P2: Append-mode scheduler log
  - [ ] 9.1 Change runDetached to use O_APPEND instead of O_TRUNC
- [ ] 10. Tests
  - [ ] 10.1 Unit tests for new functions
  - [ ] 10.2 Run existing tests to verify no regressions

### Acceptance Criteria

- [ ] Global process cap counts workers + reviewers together
- [ ] LLM silence detection fails fast when no assistant messages after 5 minutes
- [ ] Per-retry exponential backoff: 30s, 2min, 5min
- [ ] Per-task circuit breaker — one task failure doesn't stop others
- [ ] `ag task retry --force` overrides max retries
- [ ] `ag task reset <id>` fully resets task to pending
- [ ] Elapsed time uses worker-meta.json.startedAt
- [ ] Failed run history preserved in PreviousRuns
- [ ] Scheduler log uses append mode
- [ ] All existing tests pass

### Validation

- [ ] targeted tests: `cd skills/ag && go test ./internal/task/ -v -run "Test"`

### Notes

- Initial exploration complete, all key files read and understood
- Key files: scheduler.go (1176 lines), task.go (task_test.go has 776 lines of tests), root.go (1282 lines)
- scheduler.go tick() function: retryFailed → spawnWorkers → checkRunning → checkGroupReview
- Current circuit breaker is global (consecutiveFailures across ALL tasks)
- spawnWorkers counts only StatusRunning against MaxConcurrent slots
- spawnReviewer runs as independent goroutine with no global cap
- Elapsed display uses task.ClaimedAt, not worker-meta.json.startedAt

### Confusions

- None so far — codebase is well-structured and clear