### PR TITLE
Fix: prevent crashes during compaction and LLM streaming failures

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math/rand"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
@@ -117,7 +118,20 @@ func RunLoop(
 	)
 
 	go func() {
+		// Panic recovery must be registered after stream.End so it
+		// executes BEFORE stream.End (defers are LIFO). If we recover
+		// from a panic, we push error events before stream.End closes
+		// the stream.
 		defer stream.End(nil)
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("[Loop] Agent loop panic (recovered)",
+					"panic", r,
+					"turn", "unknown")
+				stream.Push(NewErrorEvent(fmt.Errorf("agent loop panic (recovered): %v", r)))
+				stream.Push(NewAgentEndEvent(agentCtx.RecentMessages))
+			}
+		}()
 
 		newMessages := append([]agentctx.AgentMessage{}, prompts...)
 		currentCtx := &agentctx.AgentContext{
@@ -163,6 +177,9 @@ func runInnerLoop(
 		state.advanceTurn()
 
 		// Pre-LLM compaction: check thresholds and compact if needed.
+		// Save checkpoint BEFORE compaction so progress is preserved if the
+		// compaction LLM call crashes the process.
+		state.savePreCompactionCheckpoint("pre_llm_threshold")
 		compacted, _ := state.performCompaction(ctx, "pre_llm_threshold", true, false)
 		if compacted != nil {
 			saveCheckpointAfterCompaction(state.checkpointMgr, agentCtx, compacted.LLMContextUpdated, state.turnCount, "pre_llm_threshold")

--- a/pkg/agent/loop_state.go
+++ b/pkg/agent/loop_state.go
@@ -77,6 +77,32 @@ func (s *loopState) advanceTurn() {
 	s.turnCount++
 }
 
+// savePreCompactionCheckpoint saves a checkpoint before compaction modifies
+// agent context. This ensures progress is preserved if the compaction LLM
+// call crashes the process. Only saves when at least one compactor indicates
+// it should compact, to avoid unnecessary I/O on every turn.
+func (s *loopState) savePreCompactionCheckpoint(trigger string) {
+	if s.checkpointMgr == nil || !s.checkpointMgr.ShouldCheckpoint() {
+		return
+	}
+	// Check if any compactor would trigger before saving checkpoint.
+	shouldCompact := false
+	for _, c := range s.config.Compactors {
+		if c.ShouldCompact(context.Background(), s.agentCtx) {
+			shouldCompact = true
+			break
+		}
+	}
+	if !shouldCompact {
+		return
+	}
+	if _, err := s.checkpointMgr.CreateSnapshot(s.agentCtx, s.agentCtx.LLMContext, s.turnCount); err != nil {
+		slog.Warn("[Loop] Failed to save pre-compaction checkpoint", "error", err, "trigger", trigger, "turn", s.turnCount)
+	} else {
+		slog.Info("[Loop] Pre-compaction checkpoint saved", "trigger", trigger, "turn", s.turnCount)
+	}
+}
+
 // performCompaction executes compaction using the configured compactors.
 // It iterates compactors in priority order, emits trace and stream events,
 // and updates agent context on success.

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"log/slog"
 
@@ -173,6 +174,8 @@ func (c *Compactor) GenerateSummary(messages []agentctx.AgentMessage) (string, e
 }
 
 // GenerateSummaryWithPrevious generates a structured summary, optionally updating a previous summary.
+// It includes retry logic for transient LLM errors and a total timeout to prevent
+// the compaction path from hanging indefinitely on network failures.
 func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage, previousSummary string) (string, error) {
 	if len(messages) == 0 {
 		return "", fmt.Errorf("no messages to summarize")
@@ -204,30 +207,61 @@ func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage
 		Messages:     llmMessages,
 	}
 
-	ctx := context.Background()
-	// Use 0 for chunk timeout to use defaults - compaction is less latency-sensitive
-	llmStream := llm.StreamLLM(ctx, c.model, llmCtx, c.apiKey, 0)
+	const maxRetries = 3
+	const totalTimeout = 5 * time.Minute
+	const chunkTimeout = 2 * time.Minute
+	var lastErr error
 
-	var summary strings.Builder
-	for event := range llmStream.Iterator(ctx) {
-		if event.Done {
-			break
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		// Use a bounded context with timeout instead of context.Background().
+		ctx, cancel := context.WithTimeout(context.Background(), totalTimeout)
+
+		llmStream := llm.StreamLLM(ctx, c.model, llmCtx, c.apiKey, chunkTimeout)
+
+		var summary strings.Builder
+		var streamErr error
+		for event := range llmStream.Iterator(ctx) {
+			if event.Done {
+				break
+			}
+
+			switch e := event.Value.(type) {
+			case llm.LLMTextDeltaEvent:
+				summary.WriteString(e.Delta)
+			case llm.LLMErrorEvent:
+				streamErr = e.Error
+			}
+		}
+		cancel()
+
+		if streamErr != nil {
+			lastErr = streamErr
+			if !llm.IsRetryableError(streamErr) {
+				slog.Error("[Compact] Summary generation failed (non-retryable)",
+					"attempt", attempt, "error", streamErr)
+				return "", fmt.Errorf("failed to generate summary: %w", streamErr)
+			}
+			if attempt < maxRetries {
+				backoff := time.Duration(attempt) * 2 * time.Second
+				slog.Warn("[Compact] Summary generation failed (retryable), retrying",
+					"attempt", attempt,
+					"max_retries", maxRetries,
+					"backoff", backoff,
+					"error", streamErr)
+				time.Sleep(backoff)
+			}
+			continue
 		}
 
-		switch e := event.Value.(type) {
-		case llm.LLMTextDeltaEvent:
-			summary.WriteString(e.Delta)
-		case llm.LLMErrorEvent:
-			return "", e.Error
+		result := summary.String()
+		if strings.TrimSpace(result) == "" {
+			return "", fmt.Errorf("empty summary generated")
 		}
+
+		return result, nil
 	}
 
-	result := summary.String()
-	if strings.TrimSpace(result) == "" {
-		return "", fmt.Errorf("empty summary generated")
-	}
-
-	return result, nil
+	return "", fmt.Errorf("failed to generate summary after %d retries: %w", maxRetries, lastErr)
 }
 
 // ContextWindow returns the configured model context window.

--- a/pkg/llm/anthropic.go
+++ b/pkg/llm/anthropic.go
@@ -40,6 +40,11 @@ func StreamAnthropic(
 
 	go func() {
 		defer stream.End(LLMMessage{})
+		defer func() {
+			if r := recover(); r != nil {
+				stream.Push(LLMErrorEvent{Error: fmt.Errorf("LLM stream panic (recovered): %v", r)})
+			}
+		}()
 
 		// Get API key from environment if not provided
 		if apiKey == "" {

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -43,6 +43,13 @@ func StreamLLM(
 
 	go func() {
 		defer stream.End(LLMMessage{})
+		defer func() {
+			if r := recover(); r != nil {
+				// Convert panic to error event so the stream consumer can handle it
+				// instead of crashing the entire process.
+				stream.Push(LLMErrorEvent{Error: fmt.Errorf("LLM stream panic (recovered): %v", r)})
+			}
+		}()
 
 		// Get API key from environment if not provided
 		if apiKey == "" {

--- a/pkg/llm/eventstream.go
+++ b/pkg/llm/eventstream.go
@@ -96,6 +96,17 @@ func (es *EventStream[T, R]) Iterator(ctx context.Context) <-chan IterResult[T] 
 
 	go func() {
 		defer close(ch)
+		defer func() {
+			if r := recover(); r != nil {
+				// Forward panic as a done signal so the consumer doesn't block.
+				// This should be extremely rare — the iterator goroutine only
+				// performs mutex operations and channel sends.
+				select {
+				case ch <- IterResult[T]{Done: true}:
+				default:
+				}
+			}
+		}()
 		for {
 			es.mu.Lock()
 


### PR DESCRIPTION
## Workpad

```text
macOS:/Users/genius/.symphony/workspaces/1717ec18-1400-46b8-9b9e-a7025ca0ef0d@fb1805b
```

### Plan

- [ ] 1. Fix Mode 1: Add retry logic and timeout to compaction LLM call (`GenerateSummaryWithPrevious`)
  - [ ] 1.1 Add context timeout to `GenerateSummaryWithPrevious` (currently uses `context.Background()` with no timeout)
  - [ ] 1.2 Add retry logic with exponential backoff for transient errors
  - [ ] 1.3 Add panic recovery in `StreamLLM` goroutine
- [ ] 2. Fix Mode 2: Add panic recovery to `StreamLLM` goroutine
  - [ ] 2.1 Wrap goroutine body with `defer recover()` to convert panics to `LLMErrorEvent`
  - [ ] 2.2 Add graceful handling for streaming connection drops (already partially handled)
- [ ] 3. Fix Mode 1b: Add checkpoint before compaction starts
  - [ ] 3.1 Save checkpoint before `performCompaction` modifies agent context
- [ ] 4. Handle EMPTY LLM CONTEXT gracefully
  - [ ] 4.1 In `performCompaction`, detect when LLM context is empty after compaction and log/return appropriately
- [ ] 5. Run tests and validate
  - [ ] 5.1 Run `go test ./pkg/compact/ -v`
  - [ ] 5.2 Run `go test ./pkg/agent/ -v -run TestCompact`
  - [ ] 5.3 Run `go test ./pkg/llm/ -v`
  - [ ] 5.4 Run full `go test ./...`

### Acceptance Criteria

- [ ] `GenerateSummaryWithPrevious` has a context timeout (not Background with no limit)
- [ ] `GenerateSummaryWithPrevious` retries transient LLM errors
- [ ] `StreamLLM` goroutine has panic recovery
- [ ] Checkpoint is saved before compaction modifies state
- [ ] All existing tests pass
- [ ] New tests cover the retry and timeout behavior

### Validation

- [ ] targeted tests: `go test ./pkg/compact/ -v && go test ./pkg/agent/ -v -run "TestCompact|TestLoop" && go test ./pkg/llm/ -v`

### Notes

- 2024-05-15: Initial investigation. Root cause: `GenerateSummaryWithPrevious` uses `context.Background()` with no timeout/retry. `StreamLLM` goroutine has no panic recovery. No checkpoint before compaction.

### Confusions

- The bug report mentions `context_management.go:320` EMPTY LLM CONTEXT error, but this is in the ContextManager path which already has retry logic. The real issue is the full Compactor path (`GenerateSummaryWithPrevious`) which has no retry.