### PR TITLE
Fix: [BUG] Session death: context_limit_recovery dead code + compaction overflow

### DIFF
--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -107,6 +107,7 @@ type rpcApp struct {
 	showTools          bool
 	showPrefix         bool
 	busyMode           string
+	consecutiveCompactionFailures int
 
 	// --- Internal helper functions ---
 	// These are assigned in initHelpers and used by handler closures.
@@ -127,6 +128,45 @@ func (app *rpcApp) parseJSONArgs(args string, target any) bool {
 		return json.Unmarshal([]byte(args), target) == nil
 	}
 	return false
+}
+
+// nuclearTruncate force-truncates oldest messages without LLM summary.
+// This is the last-resort fallback when compaction repeatedly fails (e.g.,
+// the summarization model cannot handle the conversation size).
+func (app *rpcApp) nuclearTruncate() {
+	if app.ag == nil {
+		return
+	}
+	agentCtx := app.ag.GetContext()
+	if agentCtx == nil {
+		return
+	}
+	messages := agentCtx.RecentMessages
+	if len(messages) <= 10 {
+		return
+	}
+
+	// Keep only the last 20% of messages (minimum 10)
+	keepCount := max(10, int(float64(len(messages))*0.2))
+	truncatedCount := len(messages) - keepCount
+	agentCtx.RecentMessages = messages[len(messages)-keepCount:]
+
+	// Also sync to session
+	if app.sess != nil {
+		if err := app.sess.SaveMessages(agentCtx.RecentMessages); err != nil {
+			slog.Error("[Compact] Nuclear truncation failed to save session", "error", err)
+		}
+	}
+
+	// Reset failure counter after nuclear truncation
+	app.stateMu.Lock()
+	app.consecutiveCompactionFailures = 0
+	app.stateMu.Unlock()
+
+	slog.Warn("[Compact] Nuclear truncation completed",
+		"messages_before", len(messages),
+		"messages_after", keepCount,
+		"truncated_count", truncatedCount)
 }
 
 // initHelpers creates the closures that need access to app fields.
@@ -326,6 +366,26 @@ func (app *rpcApp) initHelpers() {
 			} else {
 				slog.Error("Pre-request compaction failed", "trigger", trigger, "error", err)
 			}
+
+			// Nuclear fallback: after consecutive compaction failures, force-truncate
+			// oldest messages without LLM summary. This prevents permanent session death
+			// when the summarization model itself cannot handle the conversation size.
+			const maxConsecutiveFailures = 3
+			app.stateMu.Lock()
+			app.consecutiveCompactionFailures++
+			failures := app.consecutiveCompactionFailures
+			app.stateMu.Unlock()
+
+			if failures >= maxConsecutiveFailures {
+				slog.Warn("[Compact] Nuclear fallback: force-truncating oldest messages after consecutive compaction failures",
+					"failures", failures,
+					"trigger", trigger)
+				app.nuclearTruncate()
+			}
+		} else {
+			app.stateMu.Lock()
+			app.consecutiveCompactionFailures = 0
+			app.stateMu.Unlock()
 		}
 		app.server.EmitEvent(agent.NewCompactionEndEvent(compactionInfo))
 	}

--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -184,6 +184,23 @@ func streamAssistantResponse(
 			if firstTokenLatency > 0 {
 				llmSpan.AddField("first_token_ms", firstTokenLatency.Milliseconds())
 			}
+
+			// Check if stopReason indicates context length exceeded.
+			// Some providers return this as a normal completion (ChunkDone) rather
+			// than an error (ChunkError). We must convert it to a Go error so the
+			// context_limit_recovery path in loop.go can trigger compaction.
+			if llm.IsContextLengthStopReason(e.StopReason) {
+				ctxErr := &llm.ContextLengthExceededError{
+					Message: fmt.Sprintf("LLM returned stopReason=%s indicating context window exceeded", e.StopReason),
+				}
+				llmSpan.AddField("context_limit_detected", true)
+				traceevent.Log(ctx, traceevent.CategoryLLM, "context_limit_from_stop_reason",
+					traceevent.Field{Key: "stop_reason", Value: e.StopReason},
+					traceevent.Field{Key: "input_tokens", Value: e.Usage.InputTokens},
+				)
+				return nil, WithErrorStack(ctxErr)
+			}
+
 			if partialMessage != nil {
 				stream.Push(NewMessageUpdateEvent(*partialMessage, AssistantMessageEvent{
 					Type:         "text_end",

--- a/pkg/agent/loop_recovery_test.go
+++ b/pkg/agent/loop_recovery_test.go
@@ -1056,3 +1056,78 @@ func TestLoopGuardFeedbackResetsOnSignatureChange(t *testing.T) {
 		t.Fatalf("expected 2 guard events (one per signature), got %d", guardEventCount)
 	}
 }
+
+func TestRunInnerLoopCompactionRecoveryOnContextLimitStopReason(t *testing.T) {
+	// Test that when LLM returns stopReason=model_context_window_exceeded
+	// in a ChunkDone event (NOT an error), the context_limit_recovery path
+	// still triggers compaction.
+	orig := streamAssistantResponseFn
+	defer func() { streamAssistantResponseFn = orig }()
+
+	compactor := &recoveryCompactor{}
+	callCount := 0
+	streamAssistantResponseFn = func(
+		_ context.Context,
+		_ *agentctx.AgentContext,
+		_ *LoopConfig,
+		_ *llm.EventStream[AgentEvent, []agentctx.AgentMessage],
+	) (*agentctx.AgentMessage, error) {
+		callCount++
+		if callCount == 1 {
+			// Simulate LLM returning context limit via stopReason (not error).
+			// In real code, streamAssistantResponse detects this in ChunkDone
+			// and converts it to a ContextLengthExceededError.
+			return nil, &llm.ContextLengthExceededError{
+				Message: "LLM returned stopReason=model_context_window_exceeded indicating context window exceeded",
+			}
+		}
+
+		msg := agentctx.NewAssistantMessage()
+		msg.Content = []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "recovered"},
+		}
+		msg.StopReason = "stop"
+		return &msg, nil
+	}
+
+	agentCtx := agentctx.NewAgentContext("sys")
+	agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("hello"))
+
+	config := &LoopConfig{
+		Compactors: []Compactor{compactor},
+	}
+
+	stream := newTestAgentEventStream()
+	runInnerLoop(context.Background(), agentCtx, nil, config, stream)
+
+	var gotStart, gotEnd bool
+	var finalMessages []agentctx.AgentMessage
+	for item := range stream.Iterator(context.Background()) {
+		if item.Done {
+			break
+		}
+		if item.Value.Type == EventCompactionStart {
+			gotStart = true
+		}
+		if item.Value.Type == EventCompactionEnd {
+			gotEnd = true
+		}
+		if item.Value.Type == EventAgentEnd {
+			finalMessages = item.Value.Messages
+		}
+	}
+
+	if compactor.calls != 1 {
+		t.Fatalf("expected compactor to be called once, got %d", compactor.calls)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected assistant streaming to be called twice (recovery), got %d", callCount)
+	}
+	if !gotStart || !gotEnd {
+		t.Fatalf("expected compaction start/end events, got start=%v end=%v", gotStart, gotEnd)
+	}
+	// Verify the agent recovered and returned the second response
+	if len(finalMessages) == 0 {
+		t.Fatal("expected final messages after recovery")
+	}
+}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -187,6 +187,30 @@ func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage
 	}
 
 	conversationText := serializeConversation(projected)
+
+	// Guard against sending a conversation that exceeds the model's context
+	// window. For large sessions the serialized text can be many megabytes,
+	// which the summarization model cannot process. Truncate oldest messages
+	// until the conversation fits within ~40% of the model's context window
+	// (leaving room for the prompt, system prompt, and response).
+	const maxContextFraction = 0.4
+	if c.contextWindow > 0 {
+		maxTokens := int(float64(c.contextWindow) * maxContextFraction)
+		// Each char is roughly 0.25 tokens, so maxBytes ≈ maxTokens * 4
+		maxChars := maxTokens * 4
+		if len(conversationText) > maxChars {
+			truncated := truncateConversationToCharBudget(projected, maxChars)
+			conversationText = serializeConversation(truncated)
+			slog.Info("[Compact] Truncated conversation for summarization",
+				"original_messages", len(projected),
+				"truncated_messages", len(truncated),
+				"original_chars", len(serializeConversation(projected)),
+				"truncated_chars", len(conversationText),
+				"context_window", c.contextWindow,
+				"max_chars", maxChars)
+		}
+	}
+
 	promptText := fmt.Sprintf("<conversation>\\n%s\\n</conversation>\\n\\n", conversationText)
 	basePrompt := summarizationPrompt
 	if previousSummary != "" {
@@ -473,6 +497,75 @@ func serializeConversation(messages []agentctx.AgentMessage) string {
 		}
 	}
 	return strings.Join(parts, "\n\n")
+}
+
+// truncateConversationToCharBudget keeps the most recent messages whose
+// serialized text fits within charBudget. It drops oldest messages first.
+func truncateConversationToCharBudget(messages []agentctx.AgentMessage, charBudget int) []agentctx.AgentMessage {
+	if len(messages) == 0 || charBudget <= 0 {
+		return messages
+	}
+
+	// Walk from the end backwards, accumulating size until we exceed the budget.
+	totalChars := 0
+	cutoff := len(messages)
+	for i := len(messages) - 1; i >= 0; i-- {
+		msgText := serializeSingleMessage(messages[i])
+		totalChars += len(msgText)
+		if totalChars > charBudget {
+			cutoff = i + 1
+			break
+		}
+	}
+
+	if cutoff >= len(messages) {
+		return messages
+	}
+	return messages[cutoff:]
+}
+
+// serializeSingleMessage returns the serialized text of a single message.
+func serializeSingleMessage(msg agentctx.AgentMessage) string {
+	switch msg.Role {
+	case "user":
+		if text := extractText(msg); text != "" {
+			return "[User]: " + text
+		}
+	case "assistant":
+		parts := make([]string, 0)
+		for _, block := range msg.Content {
+			switch b := block.(type) {
+			case agentctx.TextContent:
+				if b.Text != "" {
+					parts = append(parts, b.Text)
+				}
+			case agentctx.ToolCallContent:
+				args := ""
+				if b.Arguments != nil {
+					if raw, err := json.Marshal(b.Arguments); err == nil {
+						args = string(raw)
+					}
+				}
+				if args != "" {
+					parts = append(parts, fmt.Sprintf("%s(%s)", b.Name, args))
+				} else {
+					parts = append(parts, fmt.Sprintf("%s()", b.Name))
+				}
+			}
+		}
+		if len(parts) > 0 {
+			return "[Assistant]: " + strings.Join(parts, "\n")
+		}
+	case "toolResult":
+		if text := extractText(msg); text != "" {
+			toolName := strings.TrimSpace(msg.ToolName)
+			if toolName == "" {
+				return "[Tool result]: " + text
+			}
+			return "[Tool result " + toolName + "]: " + text
+		}
+	}
+	return ""
 }
 
 func projectMessagesForSummary(messages []agentctx.AgentMessage) []agentctx.AgentMessage {
@@ -824,10 +917,27 @@ func (c *Compactor) Compact(ctx *agentctx.AgentContext) (*agentctx.CompactionRes
 	if keepRecentTokens > 0 {
 		oldMessages, recentMessages = splitMessagesByTokenBudget(ctx.RecentMessages, keepRecentTokens)
 		if len(oldMessages) == 0 {
-			return &agentctx.CompactionResult{
-				TokensBefore: tokensBefore,
-				TokensAfter:  tokensBefore,
-			}, nil
+			// Token estimation says all messages fit within budget, but if we have
+			// many messages the estimation is likely inaccurate (rough char/4
+			// heuristic). Force a split when message count is high.
+			const forceSplitMinMessages = 50
+			if len(ctx.RecentMessages) > forceSplitMinMessages {
+				// Keep the last 30% of messages (minimum 10)
+				keepCount := max(10, int(float64(len(ctx.RecentMessages))*0.3))
+				splitIndex := len(ctx.RecentMessages) - keepCount
+				oldMessages = ctx.RecentMessages[:splitIndex]
+				recentMessages = ctx.RecentMessages[splitIndex:]
+				slog.Info("[Compact] Forced split: token budget covered all messages but count exceeds threshold",
+					"count", len(ctx.RecentMessages),
+					"keepCount", keepCount,
+					"keepTokens", keepRecentTokens,
+					"forceSplitMin", forceSplitMinMessages)
+			} else {
+				return &agentctx.CompactionResult{
+					TokensBefore: tokensBefore,
+					TokensAfter:  tokensBefore,
+				}, nil
+			}
 		}
 		slog.Info("[Compact] Compressing messages",
 			"count", len(ctx.RecentMessages),

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -2,6 +2,7 @@ package compact
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -142,5 +143,92 @@ func TestSplitMessagesByTokenBudget(t *testing.T) {
 	}
 	if recentMessages[0].ExtractText() != "dddd" || recentMessages[1].ExtractText() != "eeee" {
 		t.Errorf("Unexpected recent messages order")
+	}
+}
+func TestTruncateConversationToCharBudget(t *testing.T) {
+	// Create messages with known text sizes
+	messages := []agentctx.AgentMessage{
+		agentctx.NewUserMessage(strings.Repeat("a", 1000)), // 1000+ chars
+		agentctx.NewUserMessage(strings.Repeat("b", 1000)), // 1000+ chars
+		agentctx.NewUserMessage(strings.Repeat("c", 1000)), // 1000+ chars
+		agentctx.NewUserMessage(strings.Repeat("d", 1000)), // 1000+ chars
+		agentctx.NewUserMessage(strings.Repeat("e", 500)),  // 500+ chars
+	}
+
+	// Budget for ~2 messages (2000 chars)
+	truncated := truncateConversationToCharBudget(messages, 2500)
+	if len(truncated) >= len(messages) {
+		t.Fatalf("expected truncation, got %d messages (same as original %d)", len(truncated), len(messages))
+	}
+	// Should keep the most recent messages
+	if len(truncated) < 2 {
+		t.Fatalf("expected at least 2 messages kept, got %d", len(truncated))
+	}
+	lastText := truncated[len(truncated)-1].ExtractText()
+	if !strings.HasPrefix(lastText, strings.Repeat("e", 10)) {
+		t.Fatalf("expected last message to be 'e' message, got %s...", lastText[:20])
+	}
+}
+
+func TestTruncateConversationToCharBudget_NoTruncationNeeded(t *testing.T) {
+	messages := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("short"),
+		agentctx.NewUserMessage("also short"),
+	}
+
+	// Budget larger than total
+	truncated := truncateConversationToCharBudget(messages, 10000)
+	if len(truncated) != len(messages) {
+		t.Fatalf("expected no truncation, got %d messages (original %d)", len(truncated), len(messages))
+	}
+}
+
+func TestCompact_ForcedSplitWhenManyMessagesButNoOldMessages(t *testing.T) {
+	// Create a compactor with a large keep-recent budget
+	// so that splitMessagesByTokenBudget returns oldMessages=[]
+	// but we have enough messages to trigger the forced split
+	cfg := &Config{
+		KeepRecentTokens: 100000, // Large enough that all messages "fit"
+		AutoCompact:      true,
+		ReserveTokens:    1000,
+	}
+
+	// Create 60 short messages that easily fit within 100k tokens budget
+	messages := make([]agentctx.AgentMessage, 60)
+	for i := 0; i < 60; i++ {
+		messages[i] = agentctx.NewUserMessage(fmt.Sprintf("message %d", i))
+	}
+
+	_ = agentctx.NewAgentContext("sys")
+
+	// Use a compactor to verify config
+	c := NewCompactor(cfg, llm.Model{ID: "test"}, "test-key", "test prompt", 200000)
+	_ = c
+
+	// Test the split logic directly
+	oldMsgs, recentMsgs := splitMessagesByTokenBudget(messages, 100000)
+	if len(oldMsgs) != 0 {
+		t.Fatalf("expected oldMessages=0 with large budget, got %d", len(oldMsgs))
+	}
+
+	// Verify the forced split logic would trigger
+	if len(messages) <= 50 {
+		t.Fatal("test setup error: need > 50 messages to trigger forced split")
+	}
+
+	// Simulate the forced split logic
+	const forceSplitMinMessages = 50
+	if len(messages) > forceSplitMinMessages {
+		keepCount := max(10, int(float64(len(messages))*0.3))
+		splitIndex := len(messages) - keepCount
+		oldMsgs = messages[:splitIndex]
+		recentMsgs = messages[splitIndex:]
+	}
+
+	if len(oldMsgs) == 0 {
+		t.Fatal("forced split should have produced oldMessages")
+	}
+	if len(recentMsgs) != max(10, int(float64(60)*0.3)) {
+		t.Fatalf("expected %d recent messages, got %d", max(10, int(float64(60)*0.3)), len(recentMsgs))
 	}
 }

--- a/pkg/llm/errors.go
+++ b/pkg/llm/errors.go
@@ -205,6 +205,14 @@ func extractAPIErrorMessage(payload string) string {
 	return ""
 }
 
+// IsContextLengthStopReason reports whether an LLM stopReason indicates that
+// the context window was exceeded. Some providers return this as a normal
+// completion event rather than an API error, so we must check the stopReason
+// field in addition to error classification.
+func IsContextLengthStopReason(stopReason string) bool {
+	return looksLikeContextLengthExceeded(stopReason)
+}
+
 func looksLikeContextLengthExceeded(s string) bool {
 	s = strings.ToLower(strings.TrimSpace(s))
 	if s == "" {
@@ -213,7 +221,9 @@ func looksLikeContextLengthExceeded(s string) bool {
 
 	needles := []string{
 		"context length",
+		"context_length",
 		"context window",
+		"context_window",
 		"contextwindow",
 		"maximum context",
 		"max context",
@@ -223,7 +233,6 @@ func looksLikeContextLengthExceeded(s string) bool {
 		"prompt is too long",
 		"token limit exceeded",
 		"contextlength",
-		"context_window_exceeded",
 		"contextwindowexceeded",
 		"finishreasonlength",
 	}

--- a/pkg/llm/errors_test.go
+++ b/pkg/llm/errors_test.go
@@ -32,6 +32,32 @@ func TestClassifyAPIErrorGeneric(t *testing.T) {
 	}
 }
 
+func TestIsContextLengthStopReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		stopReason string
+		want       bool
+	}{
+		{"model_context_window_exceeded", "model_context_window_exceeded", true},
+		{"context_window_exceeded", "context_window_exceeded", true},
+		{"context_length_exceeded", "context_length_exceeded", true},
+		{"stop", "stop", false},
+		{"tool_calls", "tool_calls", false},
+		{"length", "length", false},
+		{"empty", "", false},
+		{"end_turn", "end_turn", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsContextLengthStopReason(tt.stopReason)
+			if got != tt.want {
+				t.Errorf("IsContextLengthStopReason(%q) = %v, want %v", tt.stopReason, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsContextLengthExceeded(t *testing.T) {
 	if !IsContextLengthExceeded(&ContextLengthExceededError{Message: "context window exceeded"}) {
 		t.Fatal("expected typed context length error to match")


### PR DESCRIPTION
## Workpad

```
geniusdeMBP:/Users/genius/.symphony/workspaces/be41d296-c790-49e7-b489-150b5fd873c5@fb1805b
```

### Plan

- [x] 1. Investigate codebase and understand all 4 layers of failure
  - [x] 1.1 Read `llm_stream.go` ChunkDone handler (returns `&finalMessage, nil` regardless of stopReason)
  - [x] 1.2 Read `loop.go` context_limit_recovery path (checks `err != nil` → dead code)
  - [x] 1.3 Read `compact.go` Compact(), serializeConversation(), splitMessagesByTokenBudget()
  - [x] 1.4 Read `rpc_app.go` compactBeforeRequest (logs error but continues)
- [ ] 2. **Layer 1 (P0)**: Fix context_limit_recovery dead code
  - [ ] 2.1 In `llm_stream.go` ChunkDone handler: when stopReason matches context-length patterns, return `ContextLengthExceededError` instead of `(msg, nil)`
  - [ ] 2.2 Unit test: stopReason=context_window_exceeded → error returned
- [ ] 3. **Layer 2 (P1)**: Fix compaction LLM request too large
  - [ ] 3.1 Add token/size limit check to `GenerateSummaryWithPrevious()` before sending to LLM
  - [ ] 3.2 Truncate oldest messages if serialized conversation exceeds ~50% of model context window
  - [ ] 3.3 Unit test: large conversation → truncation before LLM call
- [ ] 4. **Layer 3 (P2)**: Fix no-op compaction
  - [ ] 4.1 After `splitMessagesByTokenBudget`, if `oldMessages` is empty but message count > threshold, force a split
  - [ ] 4.2 Unit test: no-op detection and forced split
- [ ] 5. **Layer 4 (P2)**: Add nuclear fallback
  - [ ] 5.1 Track consecutive compaction failures in `compactBeforeRequest`
  - [ ] 5.2 After N failures, force-truncate oldest messages without LLM summary
  - [ ] 5.3 Unit test
- [ ] 6. Run full test suite
- [ ] 7. Commit, push, create PR
- [ ] 8. Self-review

### Acceptance Criteria

- [ ] `stopReason=model_context_window_exceeded` in ChunkDone → `streamAssistantResponse` returns `ContextLengthExceededError`
- [ ] `loop.go` context_limit_recovery path triggers when LLM returns context-limit stopReason
- [ ] Compaction serializes conversation with size limit (truncates if too large for model)
- [ ] No-op compaction detected and forced split applied when message count is high
- [ ] Nuclear fallback force-truncates after consecutive compaction failures
- [ ] All existing tests continue to pass

### Validation

- [ ] targeted tests: `go test ./pkg/agent -v -run "TestRunInnerLoopCompaction|TestStreamAssistantResponseWithRetry"`
- [ ] targeted tests: `go test ./pkg/compact -v`
- [ ] full suite: `go test ./...`

### Notes

- (2025-05-17) Root cause confirmed: ChunkDone handler returns `(msg, nil)` for all stopReasons including context-limit ones
- (2025-05-17) `looksLikeContextLengthExceeded` already has `context_window_exceeded` pattern which matches `model_context_window_exceeded`
- (2025-05-17) The `splitMessagesByTokenBudget` returns `oldMessages=[]` when all messages fit within the keepRecent budget (e.g. 20k tokens), which is the no-op case

### Confusions

- None so far