### PR TITLE
docs: add pkg README files and protocol/session documentation

### DIFF
--- a/docs/rpc-protocol.md
+++ b/docs/rpc-protocol.md
@@ -29,18 +29,17 @@ Every command has an `id` field for correlation with responses.
 
 #### Command Types
 
-| Type | Description | Data Field |
-|------|-------------|------------|
-| `prompt` | Send a user message | `PromptRequest` |
-| `steer` | Inject a system message mid-conversation | String message |
-| `follow_up` | Queue a prompt for after current processing | String message |
-| `abort` | Cancel the current LLM stream | — |
-| `get_context` | Retrieve current agent context | — |
-| `set_context` | Update agent context | Context object |
-| `slash_command` | Execute a slash command | Command string |
-| `workflow_init` | Initialize workflow execution | `WorkflowState` |
-| `workflow_start` | Begin workflow processing | — |
-| `workflow_heartbeat` | Periodic workflow status check | — |
+The actual protocol commands registered by the RPC server (`pkg/rpc`):
+
+| Type | Constant | Description | Data Field |
+|------|----------|-------------|------------|
+| `prompt` | `CommandPrompt` | Send a user message | `PromptRequest` |
+| `steer` | `CommandSteer` | Inject a system message mid-conversation | String message |
+| `follow_up` | `CommandFollowUp` | Queue a prompt for after current processing | String message |
+| `abort` | `CommandAbort` | Cancel the current LLM stream | — |
+| `ping` | `CommandPing` | Health check / keep-alive | — |
+
+> **Note:** All other operations (state queries, settings, session management, model switching, etc.) are handled as **slash commands** sent through the `prompt` channel (e.g., `/model gpt-4`, `/compact`, `/help`). See `pkg/command` for the slash command registry.
 
 #### PromptRequest
 
@@ -106,37 +105,36 @@ Events are unsolicited messages emitted during processing. They have no `id` fie
 
 #### Event Envelope Types
 
-| Type | Description |
-|------|-------------|
-| `agent_event` | Agent lifecycle and stream events |
-| `session_event` | Session save/load/compact notifications |
-| `workflow_event` | Workflow state transitions |
-| `context_limit_recovery_event` | Context overflow recovery started |
-| `compaction_event` | Context compaction completed |
-| `ready` | Agent initialized and ready for commands |
+Events are emitted via `server.EmitEvent()` as plain JSON objects. The `type` field discriminates the event kind:
 
-#### Agent Events (within `agent_event` envelope)
+| Type | Source | Description |
+|------|--------|-------------|
+| `server_start` | `rpc_app.go` | Agent initialized with model and tool list |
+| `session_switch` | `rpc_session_handlers.go` | Active session changed |
+| Agent event types | `pkg/agent/event.go` | All agent lifecycle/stream events (see below) |
 
-The `data` field of `agent_event` contains an `AgentEvent` with its own `type` discriminator:
+Agent events are emitted directly (not nested under an envelope). Each has a `type` discriminator from `pkg/agent/event.go`:
 
-| Event Type | Description |
-|------------|-------------|
-| `agent_start` | Agent run started |
-| `agent_end` | Agent run completed |
-| `turn_start` | New LLM turn begins |
-| `turn_end` | LLM turn completed |
-| `text_delta` | Streaming text chunk |
-| `thinking_delta` | Reasoning/thinking content chunk |
-| `tool_call_delta` | Partial tool call (name + arguments) |
-| `tool_execution_start` | Tool execution begins |
-| `tool_execution_end` | Tool execution completed |
-| `message_update` | Full message snapshot |
-| `error` | Error during processing |
-| `checkpoint` | Session checkpoint saved |
-| `compaction` | Context compaction performed |
-| `context_limit_recovery` | Context overflow recovery |
-| `tool_call_recovery` | Malformed tool call auto-recovered |
-| `llm_retry` | LLM API call retry |
+| Event Type | Constant | Description |
+|------------|----------|-------------|
+| `agent_start` | `EventAgentStart` | Agent run started |
+| `agent_end` | `EventAgentEnd` | Agent run completed |
+| `turn_start` | `EventTurnStart` | New LLM turn begins |
+| `turn_end` | `EventTurnEnd` | LLM turn completed |
+| `message_start` | `EventMessageStart` | Message construction begins |
+| `message_end` | `EventMessageEnd` | Message construction completed |
+| `message_update` | `EventMessageUpdate` | Full message snapshot |
+| `text_delta` | `EventTextDelta` | Streaming text chunk |
+| `thinking_delta` | `EventThinkingDelta` | Reasoning/thinking content chunk |
+| `tool_call_delta` | `EventToolCallDelta` | Partial tool call (name + arguments) |
+| `tool_execution_start` | `EventToolExecutionStart` | Tool execution begins |
+| `tool_execution_end` | `EventToolExecutionEnd` | Tool execution completed |
+| `compaction_start` | `EventCompactionStart` | Context compaction started |
+| `compaction_end` | `EventCompactionEnd` | Context compaction completed |
+| `loop_guard_triggered` | `EventLoopGuardTriggered` | Tool-loop protection activated |
+| `tool_call_recovery` | `EventToolCallRecovery` | Malformed tool call auto-recovered |
+| `error` | `EventError` | Error during processing |
+| `llm_retry` | `EventLLMRetry` | LLM API call retry |
 
 #### Tool Execution Events
 
@@ -166,28 +164,7 @@ The `data` field of `agent_event` contains an `AgentEvent` with its own `type` d
 
 ## Workflow State
 
-Workflow events carry a `WorkflowState` payload:
-
-```json
-{
-  "type": "workflow_event",
-  "data": {
-    "phase": "worker",
-    "tasksFile": "/path/to/tasks.md",
-    "totalTasks": 5,
-    "pendingTasks": 3,
-    "doneTasks": 2,
-    "failedTasks": 0,
-    "inProgressTask": {
-      "id": "task-1",
-      "description": "Implement feature X",
-      "status": "in_progress"
-    },
-    "startedAt": "2025-01-15T10:30:00Z",
-    "lastUpdate": "2025-01-15T10:45:00Z"
-  }
-}
-```
+> **Note:** The `WorkflowState` and `WorkflowTask` types are defined in `pkg/rpc/types.go` for use by the `skills/ag` orchestration skill. The ag skill manages workflow lifecycle independently. This section is intentionally minimal — see `skills/ag/` for the full workflow protocol.
 
 ### Workflow Phases
 

--- a/docs/rpc-protocol.md
+++ b/docs/rpc-protocol.md
@@ -1,0 +1,258 @@
+# RPC Protocol Reference
+
+The `ai` agent communicates via a newline-delimited JSON protocol over stdin/stdout. This is the primary interface for TUI clients, editor plugins, and external tools.
+
+## Transport
+
+- **Input**: stdin (client → agent)
+- **Output**: stdout (agent → client)
+- **Encoding**: One JSON object per line (NDJSON)
+- **Framing**: Newline (`\n`) delimited
+- **Direction**: Bidirectional, asynchronous
+
+When running via `ai rpc`, the agent reads commands from stdin and writes responses/events to stdout. When running via `ai serve`, the same protocol is available over a Unix domain socket at `~/.ai/runs/<id>/control.sock`.
+
+## Message Types
+
+### Commands (Client → Agent)
+
+Every command has an `id` field for correlation with responses.
+
+```json
+{
+  "id": "cmd-001",
+  "type": "<command-type>",
+  "message": "optional text body",
+  "data": {}
+}
+```
+
+#### Command Types
+
+| Type | Description | Data Field |
+|------|-------------|------------|
+| `prompt` | Send a user message | `PromptRequest` |
+| `steer` | Inject a system message mid-conversation | String message |
+| `follow_up` | Queue a prompt for after current processing | String message |
+| `abort` | Cancel the current LLM stream | — |
+| `get_context` | Retrieve current agent context | — |
+| `set_context` | Update agent context | Context object |
+| `slash_command` | Execute a slash command | Command string |
+| `workflow_init` | Initialize workflow execution | `WorkflowState` |
+| `workflow_start` | Begin workflow processing | — |
+| `workflow_heartbeat` | Periodic workflow status check | — |
+
+#### PromptRequest
+
+```json
+{
+  "id": "cmd-001",
+  "type": "prompt",
+  "data": {
+    "message": "Fix the bug in auth.go",
+    "streamingBehavior": "full",
+    "images": [
+      {"type": "image", "data": "<base64-encoded>"}
+    ]
+  }
+}
+```
+
+- `message` (required): The user's text prompt
+- `streamingBehavior`: Controls streaming granularity (`"full"`, `"minimal"`)
+- `images`: Optional base64-encoded images for multimodal models
+
+### Responses (Agent → Client)
+
+Responses correlate to a specific command via the `id` field.
+
+```json
+{
+  "id": "cmd-001",
+  "type": "response",
+  "command": "prompt",
+  "success": true,
+  "data": {},
+  "error": ""
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `id` | Matches the command `id` |
+| `type` | Always `"response"` |
+| `command` | The original command type |
+| `success` | `true` if the command succeeded |
+| `data` | Response payload (structure depends on command) |
+| `error` | Error message if `success` is `false` |
+
+### Events (Agent → Client)
+
+Events are unsolicited messages emitted during processing. They have no `id` field.
+
+```json
+{
+  "type": "agent_event",
+  "data": {
+    "type": "text_delta",
+    "eventAt": 1705312345678901234,
+    "message": {
+      "role": "assistant",
+      "content": [{"type": "text", "text": "Hello"}]
+    }
+  }
+}
+```
+
+#### Event Envelope Types
+
+| Type | Description |
+|------|-------------|
+| `agent_event` | Agent lifecycle and stream events |
+| `session_event` | Session save/load/compact notifications |
+| `workflow_event` | Workflow state transitions |
+| `context_limit_recovery_event` | Context overflow recovery started |
+| `compaction_event` | Context compaction completed |
+| `ready` | Agent initialized and ready for commands |
+
+#### Agent Events (within `agent_event` envelope)
+
+The `data` field of `agent_event` contains an `AgentEvent` with its own `type` discriminator:
+
+| Event Type | Description |
+|------------|-------------|
+| `agent_start` | Agent run started |
+| `agent_end` | Agent run completed |
+| `turn_start` | New LLM turn begins |
+| `turn_end` | LLM turn completed |
+| `text_delta` | Streaming text chunk |
+| `thinking_delta` | Reasoning/thinking content chunk |
+| `tool_call_delta` | Partial tool call (name + arguments) |
+| `tool_execution_start` | Tool execution begins |
+| `tool_execution_end` | Tool execution completed |
+| `message_update` | Full message snapshot |
+| `error` | Error during processing |
+| `checkpoint` | Session checkpoint saved |
+| `compaction` | Context compaction performed |
+| `context_limit_recovery` | Context overflow recovery |
+| `tool_call_recovery` | Malformed tool call auto-recovered |
+| `llm_retry` | LLM API call retry |
+
+#### Tool Execution Events
+
+```json
+{
+  "type": "tool_execution_start",
+  "eventAt": 1705312345678901234,
+  "toolCallId": "call_abc123",
+  "toolName": "bash",
+  "args": {"command": "ls -la"}
+}
+```
+
+```json
+{
+  "type": "tool_execution_end",
+  "eventAt": 1705312345678901234,
+  "toolCallId": "call_abc123",
+  "toolName": "bash",
+  "result": {
+    "role": "tool",
+    "content": [{"type": "text", "text": "file1.txt\nfile2.txt"}]
+  },
+  "isError": false
+}
+```
+
+## Workflow State
+
+Workflow events carry a `WorkflowState` payload:
+
+```json
+{
+  "type": "workflow_event",
+  "data": {
+    "phase": "worker",
+    "tasksFile": "/path/to/tasks.md",
+    "totalTasks": 5,
+    "pendingTasks": 3,
+    "doneTasks": 2,
+    "failedTasks": 0,
+    "inProgressTask": {
+      "id": "task-1",
+      "description": "Implement feature X",
+      "status": "in_progress"
+    },
+    "startedAt": "2025-01-15T10:30:00Z",
+    "lastUpdate": "2025-01-15T10:45:00Z"
+  }
+}
+```
+
+### Workflow Phases
+
+| Phase | Description |
+|-------|-------------|
+| `init` | Workflow initialized, tasks loaded |
+| `worker` | Tasks being executed |
+| `completed` | All tasks done |
+| `error` | Workflow failed |
+
+### Task States
+
+| State | Description |
+|-------|-------------|
+| `pending` | Not yet started |
+| `in_progress` | Currently executing |
+| `done` | Completed successfully |
+| `failed` | Execution failed |
+
+## Typical Session Flow
+
+```
+Client                              Agent
+  │                                   │
+  │─── prompt ──────────────────────→ │
+  │←── response {success: true} ─────│
+  │←── agent_event {agent_start} ────│
+  │←── agent_event {turn_start} ─────│
+  │←── agent_event {text_delta} ─────│
+  │←── agent_event {text_delta} ─────│
+  │←── agent_event {tool_call_delta} │
+  │←── agent_event {tool_execution_start} ─│
+  │←── agent_event {tool_execution_end} ───│
+  │←── agent_event {turn_end} ───────│
+  │←── agent_event {turn_start} ─────│
+  │←── agent_event {text_delta} ─────│
+  │←── agent_event {turn_end} ───────│
+  │←── agent_event {agent_end} ──────│
+  │                                   │
+  │─── abort ───────────────────────→ │  (optional, cancels mid-stream)
+  │←── response {success: true} ─────│
+```
+
+## Unix Domain Socket Protocol
+
+When using `ai serve` + `ai watch`, the socket server uses a similar JSON protocol:
+
+```json
+{"type": "send", "message": "Fix the bug"}
+{"type": "abort"}
+{"type": "stream", "from_seq": 0}
+{"type": "status"}
+```
+
+Response:
+
+```json
+{"ok": true, "data": {}}
+```
+
+The `stream` command establishes a long-lived connection that replays events from `from_seq` and then streams new events in real-time.
+
+## Error Handling
+
+- Commands that fail return `{"success": false, "error": "description"}`
+- Unknown command types receive an error response
+- Event stream errors are emitted as `agent_event` with type `error`
+- LLM errors trigger retry events (`llm_retry`) before final failure

--- a/docs/session-format.md
+++ b/docs/session-format.md
@@ -7,7 +7,7 @@ Sessions persist the full conversation history for an agent instance as append-o
 1. **Append-only**: New entries are appended to `messages.jsonl`. Existing entries are never modified in place.
 2. **Tree structure**: Entries are linked via `parentId`, forming a conversation tree. The current branch tip is the `leafID`.
 3. **Crash-safe**: Append-only writes minimize data loss risk. Periodic checkpoints enable fast recovery.
-4. **Lazy-loadable**: Large sessions can load only recent entries + compaction summary.
+4. **Lazy-loadable**: Large sessions can be restored from checkpoint + journal, or loaded with only the recent messages needed.
 
 ## File Layout
 
@@ -343,6 +343,6 @@ Session metadata stored alongside the JSONL:
 
 Managed by `SessionManager`. Updated on each session save.
 
-## Migration
+## Legacy Format
 
-Legacy session formats (single `.jsonl` files without directories) are auto-migrated on load. The loader detects the format and converts to the directory-based layout.
+> **Warning:** Legacy session formats (single `.jsonl` files without directory layout, or old entry schemas) still exist in the codebase. The loader auto-detects and handles them, but this code should be cleaned up. Once legacy format support is removed, update this section accordingly.

--- a/docs/session-format.md
+++ b/docs/session-format.md
@@ -1,0 +1,348 @@
+# Session Format
+
+Sessions persist the full conversation history for an agent instance as append-only JSONL files. This document describes the file layout, entry types, loading strategies, and crash recovery mechanisms.
+
+## Design Principles
+
+1. **Append-only**: New entries are appended to `messages.jsonl`. Existing entries are never modified in place.
+2. **Tree structure**: Entries are linked via `parentId`, forming a conversation tree. The current branch tip is the `leafID`.
+3. **Crash-safe**: Append-only writes minimize data loss risk. Periodic checkpoints enable fast recovery.
+4. **Lazy-loadable**: Large sessions can load only recent entries + compaction summary.
+
+## File Layout
+
+```
+~/.ai/sessions/
+└── --<sanitized-path>--/
+    ├── <session-uuid-1>/
+    │   ├── messages.jsonl      # Append-only entry log
+    │   ├── meta.json           # Session metadata
+    │   ├── llm_context.txt     # Persisted LLM context (from context management)
+    │   └── checkpoint.json     # Periodic context snapshot
+    ├── <session-uuid-2>/
+    │   ├── messages.jsonl
+    │   └── meta.json
+    └── ...
+```
+
+The top-level directory name is derived from the working directory at session creation:
+
+```
+sanitizePath("/Users/genius/project/myapp")  →  "--Users-genius-project-myapp--"
+sanitizePath("C:\Users\genius\project")       →  "--Users-genius-project--"
+```
+
+Path separators, backslashes, and colons are replaced with `-`.
+
+## Entry Types
+
+Each line in `messages.jsonl` is a JSON object. All entries share common fields:
+
+```json
+{
+  "type": "<entry-type>",
+  "id": "<unique-entry-id>",
+  "parentId": "<parent-entry-id | null>",
+  "timestamp": "<RFC3339Nano>"
+}
+```
+
+### session (Header)
+
+First line of every `messages.jsonl`. Exactly one per session.
+
+```json
+{
+  "type": "session",
+  "version": 1,
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "timestamp": "2025-01-15T10:30:00.123456789Z",
+  "cwd": "/Users/genius/project/myapp"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `version` | Format version (currently `1`) |
+| `id` | Session UUID |
+| `cwd` | Working directory at session creation |
+
+### message
+
+A single user, assistant, or tool message.
+
+```json
+{
+  "type": "message",
+  "id": "msg-001",
+  "parentId": "msg-000",
+  "timestamp": "2025-01-15T10:30:01.000Z",
+  "message": {
+    "role": "user",
+    "content": [
+      {"type": "text", "text": "Fix the bug in auth.go"}
+    ]
+  }
+}
+```
+
+Assistant messages with tool calls:
+
+```json
+{
+  "type": "message",
+  "id": "msg-002",
+  "parentId": "msg-001",
+  "timestamp": "2025-01-15T10:30:02.000Z",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {"type": "text", "text": "I'll read the file first."}
+    ],
+    "toolCalls": [
+      {
+        "id": "call_abc123",
+        "type": "function",
+        "function": {
+          "name": "read",
+          "arguments": "{\"path\":\"auth.go\"}"
+        }
+      }
+    ]
+  }
+}
+```
+
+Tool result messages:
+
+```json
+{
+  "type": "message",
+  "id": "msg-003",
+  "parentId": "msg-002",
+  "timestamp": "2025-01-15T10:30:03.000Z",
+  "message": {
+    "role": "tool",
+    "toolCallId": "call_abc123",
+    "content": [
+      {"type": "text", "text": "package main\n\nfunc auth() { ... }"}
+    ]
+  }
+}
+```
+
+### compaction
+
+Replaces older messages with an LLM-generated summary.
+
+```json
+{
+  "type": "compaction",
+  "id": "comp-001",
+  "parentId": "msg-003",
+  "timestamp": "2025-01-15T10:35:00.000Z",
+  "summary": "The user asked to fix a bug in auth.go. The assistant read the file and identified an issue with token validation...",
+  "firstKeptEntryId": "msg-010",
+  "tokensBefore": 45000,
+  "tokensAfter": 5000
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `summary` | LLM-generated summary of all messages before `firstKeptEntryId` |
+| `firstKeptEntryId` | First message ID after the compaction cut point |
+| `tokensBefore` | Estimated tokens before compaction |
+| `tokensAfter` | Estimated tokens after compaction |
+
+On replay, the compaction entry is converted to a synthetic user message:
+
+```
+The conversation history before this point was compacted into the following summary:
+
+<summary>
+...summary text...
+</summary>
+```
+
+All entries before `firstKeptEntryId` are skipped during replay.
+
+### compact_event
+
+Records individual context management actions for fine-grained replay.
+
+```json
+{
+  "type": "compact_event",
+  "id": "ce-001",
+  "parentId": "msg-005",
+  "timestamp": "2025-01-15T10:32:00.000Z",
+  "actions": [
+    {"action": "truncate", "ids": ["call_abc123", "call_def456"]},
+    {"action": "update_llm_context", "ids": []}
+  ]
+}
+```
+
+| Action | Description | Replay Behavior |
+|--------|-------------|-----------------|
+| `truncate` | Trim tool output to head+tail | Apply `TruncateWithHeadTail` to matching tool results |
+| `update_llm_context` | Update structured LLM context | Context loaded from `llm_context.txt` |
+| `compact` | Major compaction triggered | Replayed via parent `compaction` entry |
+
+### branch_summary
+
+Summary of a forked branch when the conversation returns from it.
+
+```json
+{
+  "type": "branch_summary",
+  "id": "bs-001",
+  "parentId": "msg-015",
+  "timestamp": "2025-01-15T11:00:00.000Z",
+  "summary": "In a branched conversation, the assistant explored an alternative approach..."
+}
+```
+
+Replayed as a synthetic user message:
+
+```
+The following is a summary of a branch that this conversation came back from:
+
+<summary>
+...summary text...
+</summary>
+```
+
+### session_info
+
+Session metadata (name, title).
+
+```json
+{
+  "type": "session_info",
+  "id": "si-001",
+  "parentId": "msg-000",
+  "timestamp": "2025-01-15T10:30:00.000Z",
+  "name": "my-session",
+  "title": "Fix auth bug"
+}
+```
+
+## Conversation Tree
+
+Entries form a tree via `parentId` links:
+
+```
+session ─→ msg-001(user) ─→ msg-002(assistant) ─→ msg-003(tool)
+                │
+                └─→ msg-004(assistant) ─→ msg-005(tool) ─→ ...
+```
+
+The `leafID` points to the current conversation tip. Forking creates a new branch by setting a different `leafID` and appending new entries from that point.
+
+## Forking
+
+A fork creates a new session directory that copies entries from the source session up to the specified fork point:
+
+1. New session directory created with a fresh UUID
+2. All entries from root to the fork `leafID` are copied
+3. The `session` header records `parentSession` pointing to the source
+4. A new `session_info` entry is appended with the fork's name/title
+5. New messages are appended to the fork's own `messages.jsonl`
+
+The original session is never modified.
+
+## Lazy Loading
+
+For large sessions, lazy loading avoids reading the entire JSONL file:
+
+```go
+opts := session.LoadOptions{
+    MaxMessages:    0,    // 0=auto, -1=all, N>0=limit
+    IncludeSummary: true, // Include compaction summary
+    Lazy:           true, // Enable lazy loading
+}
+sess, err := session.LoadSessionLazy(dir, opts)
+```
+
+### Loading Strategy
+
+1. Read the session header (first line)
+2. Scan backwards from the end of the file
+3. Find the most recent `compaction` entry (if any)
+4. Load entries from `firstKeptEntryId` to the end
+5. Fix broken parent links: if an entry's parent is not in the loaded set, link it to the compaction entry (or set to `nil`)
+
+### MaxMessages Behavior
+
+| Value | Behavior |
+|-------|----------|
+| `0` | Auto — load from `firstKeptEntryId` to end |
+| `-1` | Load all entries |
+| `N > 0` | Load at most N recent messages |
+
+## Checkpoint and Journal
+
+### Journal
+
+The `AgentContextCheckpointManager` maintains an append-only journal in the session directory:
+
+- Each message append is written to the journal
+- Turn boundaries trigger periodic checkpoints
+- Journal entries are compacted into checkpoints periodically
+
+### Checkpoint
+
+A checkpoint is a full snapshot of `AgentContext`:
+
+```json
+{
+  "turn": 5,
+  "messageIndex": 23,
+  "context": { ... }
+}
+```
+
+### Recovery
+
+On crash or restart:
+
+1. Load the last checkpoint
+2. Replay journal entries after the checkpoint
+3. Continue from the recovered state
+
+## Compaction Flow
+
+When context exceeds the configured threshold:
+
+1. **Trigger**: `ShouldCompact()` returns `true` based on estimated tokens
+2. **Cut point**: Find the oldest cuttable message (user messages are cuttable boundaries)
+3. **Summarize**: LLM generates a summary of all messages before the cut point
+4. **Record**: Append a `compaction` entry with the summary and `firstKeptEntryId`
+5. **Update**: Remove old messages from `AgentContext.RecentMessages`, replace with summary message
+
+The session JSONL retains all original entries. Compaction only affects the in-memory state — the append-only log is preserved for replay from any point.
+
+## meta.json
+
+Session metadata stored alongside the JSONL:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "my-session",
+  "title": "Fix auth bug",
+  "createdAt": "2025-01-15T10:30:00Z",
+  "updatedAt": "2025-01-15T11:00:00Z",
+  "messageCount": 42,
+  "workspace": "/Users/genius/project/myapp",
+  "currentWorkdir": "/Users/genius/project/myapp"
+}
+```
+
+Managed by `SessionManager`. Updated on each session save.
+
+## Migration
+
+Legacy session formats (single `.jsonl` files without directories) are auto-migrated on load. The loader detects the format and converts to the directory-based layout.

--- a/pkg/agent/README.md
+++ b/pkg/agent/README.md
@@ -1,0 +1,120 @@
+# pkg/agent
+
+Agent loop, state machine, event streaming, and tool execution orchestration.
+
+## Overview
+
+The `agent` package is the runtime core of the `ai` system. It manages the agentic loop — the cycle of sending prompts to an LLM, receiving responses, executing tool calls, and streaming events back to the caller.
+
+**Key responsibilities:**
+
+- Run the LLM turn loop with configurable limits (max consecutive tool calls, per-name limits, total timeout)
+- Execute tools with concurrency control via a semaphore-based executor
+- Stream structured events (`AgentEvent`) through an event channel
+- Manage checkpoints for session recovery
+- Coordinate compaction and context-limit recovery
+
+## Core Types
+
+### Agent
+
+```go
+type Agent struct { ... }
+```
+
+Top-level agent struct. Holds an `AgentContext`, `LoopConfig`, event channel, current LLM stream, and follow-up queue. Created via `NewAgent()`, started with `Run()`.
+
+### AgentEvent
+
+```go
+type AgentEvent struct {
+    Type string `json:"type"`
+    // ...type-specific fields
+}
+```
+
+Discriminated union event type emitted during agent execution. Event types:
+
+| Type | Description |
+|------|-------------|
+| `agent_start` / `agent_end` | Agent lifecycle boundaries |
+| `turn_start` / `turn_end` | Per-LLM-turn boundaries |
+| `text_delta` | Streaming text chunk from LLM |
+| `thinking_delta` | Reasoning/thinking content chunk |
+| `tool_call_delta` | Partial tool call (name + arguments) |
+| `tool_execution_start` / `tool_execution_end` | Tool execution lifecycle |
+| `message_update` | Full message snapshot |
+| `error` | Error event |
+| `checkpoint` | Checkpoint saved |
+| `compaction` | Context compaction performed |
+| `context_limit_recovery` | Context overflow recovery |
+| `tool_call_recovery` | Malformed tool call recovery |
+| `llm_retry` | LLM call retry |
+
+### LoopConfig
+
+```go
+type LoopConfig struct {
+    Model              llm.Model
+    APIKey             string
+    GetModel           func() llm.Model       // Dynamic model switching
+    GetAPIKey          func() string          // Dynamic API key switching
+    Executor           ToolExecutor           // Tool execution interface
+    Compactors         []agentctx.Compactor   // Compaction chain
+    ThinkingLevel      string                 // off, minimal, low, medium, high
+    MaxConsecutiveToolCalls int               // Default: 6
+    // ...
+}
+```
+
+### ToolExecutor
+
+```go
+type ToolExecutor interface {
+    Execute(ctx context.Context, tool agentctx.Tool, args map[string]interface{}) ([]agentctx.ContentBlock, error)
+}
+```
+
+Interface for tool execution with concurrency control. Implemented by `concurrentToolExecutor` which uses a semaphore to limit parallel tool invocations.
+
+## Event Stream Pattern
+
+`EventStream[T, R]` is a generic push-based stream:
+
+```go
+stream := agent.Run(ctx, messages)
+for event := range stream.Events() {
+    // handle AgentEvent
+}
+result := stream.Result() // final []AgentMessage
+```
+
+The stream supports abort via `Push(agentEndEvent)` and cancellation through context.
+
+## Checkpoint Manager
+
+`AgentContextCheckpointManager` integrates with `AgentContext` to write journal entries for session recovery. It tracks turn count and message index to write periodic checkpoints.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `agent.go` | Agent struct, construction, Run(), event emission, stream management |
+| `loop.go` | Main LLM turn loop with tool execution, retry, and recovery logic |
+| `executor.go` | `ToolExecutor` interface and concurrent executor implementation |
+| `event.go` | `AgentEvent` type and constructors for all event variants |
+| `eventstream.go` | Generic `EventStream[T, R]` implementation |
+| `checkpoint_manager.go` | Journal-based checkpoint integration |
+| `compaction_controller.go` | Triggers and manages context compaction cycles |
+| `llm_stream.go` | LLM stream consumption and event translation |
+| `llm_stream_parse.go` | Parsing LLM streaming responses into events |
+| `llm_retry.go` | Retry logic for LLM API errors |
+| `llm_error_types.go` | Error classification for retries |
+| `error_stack.go` | Error chain tracking |
+| `conversion.go` | Message type conversions |
+
+## Dependencies
+
+- `pkg/llm` — LLM client and types
+- `pkg/context` — AgentContext, messages, tools
+- `pkg/traceevent` — Tracing integration

--- a/pkg/command/README.md
+++ b/pkg/command/README.md
@@ -1,0 +1,74 @@
+# pkg/command
+
+Shared slash command registry for the CLI agent and chat bot.
+
+## Overview
+
+Provides a registry for `/command` style operations. Both `ai` (the CLI agent) and `claw` (the chat bot) use this package to register and dispatch slash commands like `/model`, `/compact`, `/help`.
+
+## Registry
+
+```go
+type Registry struct { ... }
+
+func New() *Registry
+```
+
+### Registration
+
+```go
+func (r *Registry) Register(name, description string, handler Handler)
+func (r *Registry) RegisterHidden(name, description string, handler Handler)
+```
+
+`name` should not include the `/` prefix (e.g., `"model"` not `"/model"`). Hidden commands are callable but excluded from `/help` output.
+
+### Dispatch
+
+```go
+func (r *Registry) Dispatch(name, args string) (any, error)
+```
+
+Looks up and invokes a command handler. Returns error for unknown commands.
+
+### Listing
+
+```go
+func (r *Registry) List() []string                // All names, sorted
+func (r *Registry) ListCommands() []CommandInfo    // User-visible only
+func (r *Registry) AllCommands() []CommandInfo     // Including hidden
+```
+
+## /set Subcommands
+
+The registry also manages `/set` subcommands:
+
+```go
+func (r *Registry) RegisterSetSub(key, description string, handler Handler)
+func (r *Registry) DispatchSet(key, args string) (any, error)
+func (r *Registry) ListSetSubs() []SetSubcommand
+```
+
+Enables nested commands like `/set model gpt-4` or `/set thinking high`.
+
+## Parsing
+
+```go
+func ParseSlashCommand(input string) (command string, args string, err error)
+```
+
+Splits `"/model gpt-4 o3"` into `("model", "gpt-4 o3", nil)`. Returns error if input has no `/` prefix or empty command name.
+
+## Handler Type
+
+```go
+type Handler func(args string) (any, error)
+```
+
+`args` is the raw text after the command name.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `registry.go` | `Registry`, `Handler`, `CommandInfo`, `SetSubcommand`, `ParseSlashCommand` |

--- a/pkg/compact/README.md
+++ b/pkg/compact/README.md
@@ -1,0 +1,118 @@
+# pkg/compact
+
+LLM-driven context compaction with configurable strategies and context management.
+
+## Overview
+
+The `compact` package manages conversation context size within LLM window limits. It provides two complementary mechanisms:
+
+1. **Compactor** — Heavyweight LLM summarization when context is too large
+2. **ContextManager** — Lightweight LLM-driven decisions (truncate, update, compact) at periodic intervals
+
+Both delegate decisions to the LLM rather than using deterministic rules, producing higher-quality context management.
+
+## Compactor
+
+### Config
+
+```go
+type Config struct {
+    MaxMessages         int    // Compress when messages exceed this
+    MaxTokens           int    // Compress when estimated tokens exceed this
+    KeepRecent          int    // Always keep this many recent messages
+    KeepRecentTokens    int    // Token budget for recent messages
+    ReserveTokens       int    // Tokens to reserve from context window
+    ToolCallCutoff      int    // Summarize tool outputs when visible results exceed this
+    ToolSummaryStrategy string // "llm", "heuristic", or "off"
+    AutoCompact         bool   // Enable automatic compaction
+}
+```
+
+### Core Methods
+
+```go
+func (c *Compactor) Compress(ctx, agentCtx) (*CompactionResult, error)
+func (c *Compactor) ShouldCompact(ctx, agentCtx) bool
+```
+
+`Compress` performs the compaction:
+1. Splits messages into "old" and "recent" based on token budget
+2. Summarizes old messages via LLM (initial summary or incremental update)
+3. Returns a `CompactionResult` with the summary, before/after token counts
+
+`ShouldCompact` checks if compaction is needed using a dynamic threshold:
+- If `MaxTokens > 0`: triggers when estimated tokens exceed the limit
+- If `AutoCompact` is false: never triggers
+
+### Token Estimation
+
+```go
+func EstimateTokens(text string) int            // ~4 chars per token
+func EstimateMessageTokens(msg AgentMessage) int // Per-message estimation
+func EstimateMessagesTokens(msgs []AgentMessage) int
+```
+
+## ContextManager
+
+Lightweight LLM-driven context management that runs periodically during agent execution.
+
+### Trigger Thresholds
+
+```go
+const (
+    MgmtTokenLow    = 0.20  // 20% of context: start periodic checks
+    MgmtTokenMedium = 0.33  // 33%: more aggressive checks
+    MgmtTokenHigh   = 0.50  // 50%: frequent checks
+)
+```
+
+### Check Intervals
+
+Token usage determines how often the context manager runs:
+
+| Token Usage | Interval (tool calls) |
+|-------------|----------------------|
+| 20-33% | Every 15 calls |
+| 33-50% | Every 10 calls |
+| 50%+ | Every 7 calls |
+
+### LLM-Driven Decisions
+
+The context manager provides the LLM with tools to manage context:
+
+| Tool | Action | Description |
+|------|--------|-------------|
+| `truncate_messages` | `truncate` | Trim long tool outputs in-place |
+| `update_llm_context` | `update_llm_context` | Update structured LLM context |
+| `compact_messages` | `compact` | Trigger major compaction |
+
+The LLM analyzes the conversation and decides which action(s) to take. The system does **not** decide what to compact — it only decides **when** to ask.
+
+### Compact Event Recording
+
+Each context management action is recorded as a `compact_event` in the session:
+
+```go
+type CompactEventDetail struct {
+    Action CompactAction  // "truncate", "update_llm_context", "compact"
+    IDs    []string       // Target message/tool-call IDs
+}
+```
+
+These events are replayed deterministically when loading sessions.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `compact.go` | `Compactor` — heavyweight summarization, token estimation, compression |
+| `context_management.go` | `ContextManager` — lightweight periodic LLM-driven decisions |
+| `compact_tool.go` | Tool implementations for context management actions |
+| `compact_visibility_test.go` | Visibility tests for compaction |
+
+## Dependencies
+
+- `pkg/context` — `AgentContext`, `CompactionResult`, `CompactEventDetail`
+- `pkg/llm` — LLM streaming for summarization calls
+- `pkg/prompt` — Compaction system prompts
+- `pkg/traceevent` — Tracing

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -1,0 +1,91 @@
+# pkg/config
+
+Application configuration: model selection, compaction, concurrency, and tool output settings.
+
+## Overview
+
+Loads configuration from `~/.ai/config.json` (or `AI_CONFIG_PATH`). Configuration is structured into sections for model, compaction, concurrency, tool output, and logging.
+
+## Config
+
+```go
+type Config struct {
+    Model        ModelConfig        `json:"model"`
+    Compactor    *compact.Config    `json:"compactor,omitempty"`
+    Concurrency  *ConcurrencyConfig `json:"concurrency,omitempty"`
+    ToolOutput   *ToolOutputConfig  `json:"toolOutput,omitempty"`
+    Edit         *EditConfig        `json:"edit,omitempty"`
+    Log          *LogConfig         `json:"log,omitempty"`
+    Workspace    string             `json:"workspace,omitempty"`
+}
+```
+
+## Model Configuration
+
+```go
+type ModelConfig struct {
+    Default string `json:"default"` // Model ID (e.g., "claude-sonnet-4-20250514")
+    APIKey  string `json:"apiKey"`  // API key or env var reference (${ENV_VAR})
+}
+```
+
+### Model Spec Format
+
+The `Default` field supports extended notation:
+
+```
+provider/model-id    → Model{Provider: "provider", ID: "model-id"}
+model-id             → Model{Provider: "", ID: "model-id"}
+```
+
+## Compaction Configuration
+
+Passed through to `pkg/compact.Config`. See `pkg/compact/README.md` for details.
+
+## Concurrency
+
+```go
+type ConcurrencyConfig struct {
+    MaxConcurrentTools int  // Max parallel tool executions
+    ToolTimeout        int  // Per-tool timeout in seconds
+    QueueTimeout       int  // Wait timeout for executor queue slot
+}
+```
+
+## Tool Output
+
+```go
+type ToolOutputConfig struct {
+    MaxChars  int  `json:"maxChars,omitempty"`  // Max chars (0 = 10000 default)
+    HashLines bool `json:"hashLines,omitempty"` // Enable hashline verification
+}
+```
+
+## Edit
+
+```go
+type EditConfig struct {
+    Mode string `json:"mode,omitempty"` // "replace" (default) or "hashline"
+}
+```
+
+## API Key Resolution
+
+API keys are resolved in order:
+1. Config file value (supports `${ENV_VAR}` references)
+2. Environment variable (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
+3. Auth file (`~/.ai/auth.json`)
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `config.go` | Config struct, loading, model resolution, defaults |
+| `auth.go` | API key resolution from environment and auth files |
+
+## Dependencies
+
+- `pkg/compact` — Compaction configuration types
+- `pkg/llm` — Model type
+- `pkg/agent` — Agent configuration
+- `pkg/logger` — Logger initialization

--- a/pkg/context/README.md
+++ b/pkg/context/README.md
@@ -1,0 +1,132 @@
+# pkg/context
+
+Agent execution context: messages, tools, skills, and compaction state.
+
+## Overview
+
+`AgentContext` is the central state holder for a running agent. It contains the conversation history, available tools, loaded skills, and all metadata needed for LLM calls and compaction. Every agent loop iteration reads from and writes to this struct.
+
+## Core Types
+
+### AgentContext
+
+```go
+type AgentContext struct {
+    SystemPrompt         string
+    Tools                []Tool
+    Skills               []skill.Skill
+    LLMContext           string            // Structured context content (managed by ContextManager)
+    RecentMessages       []AgentMessage    // Current conversation (not full history)
+    AgentState           *AgentState       // System-maintained metadata
+    LastCompactionSummary string           // For incremental summary updates
+    // ... callbacks, tool whitelist, context management lock
+}
+```
+
+Key methods:
+- `AddMessage(msg)` — Append a message, call OnMessagesChanged
+- `GetMessages()` — Return recent messages
+- `EstimateTokens()` — Estimate total token count
+- `SetAllowedTools(names)` / `IsToolAllowed(name)` — Tool whitelist management
+- `EstimateTokenPercent(windowSize)` — Context usage as percentage
+
+### Tool
+
+```go
+type Tool interface {
+    Name() string
+    Description() string
+    Parameters() map[string]any  // JSON Schema
+    Execute(ctx, args) ([]ContentBlock, error)
+}
+```
+
+Interface that all agent tools must implement.
+
+### AgentMessage
+
+```go
+type AgentMessage struct {
+    Role      string         `json:"role"`      // "user", "assistant", "tool"
+    Content   []ContentBlock `json:"content"`
+    ToolCalls []ToolCall     `json:"toolCalls,omitempty"`
+    ToolCallID string        `json:"toolCallId,omitempty"`
+    // ... metadata fields
+}
+```
+
+### ContentBlock
+
+Discriminated union with types: `text`, `image`, `tool_use`, `tool_result`.
+
+### AgentState
+
+System-maintained metadata tracking:
+- Tool call counts (per name and total)
+- Current turn number
+- Compaction history
+- Runtime state
+
+## Compaction Actions
+
+```go
+type CompactAction string
+
+const (
+    CompactActionTruncate         CompactAction = "truncate"           // Trim tool output
+    CompactActionUpdateLLMContext CompactAction = "update_llm_context" // Update structured context
+    CompactActionCompact          CompactAction = "compact"            // Major compaction
+)
+```
+
+### CompactEventDetail
+
+```go
+type CompactEventDetail struct {
+    Action CompactAction
+    IDs    []string // Target message/tool-call IDs
+}
+```
+
+Records individual compaction actions for session persistence and replay.
+
+## Compaction Result
+
+```go
+type CompactionResult struct {
+    Summary        string
+    TokensBefore   int
+    TokensAfter    int
+    MessagesBefore int
+    MessagesAfter  int
+    Type           string // "major"
+}
+```
+
+Returned by compactors after performing compression.
+
+## Journal
+
+`Journal` provides append-only file I/O for incremental message logging, used by the checkpoint manager for crash recovery.
+
+## Token Estimation
+
+```go
+func (c *AgentContext) EstimateTokens() int
+func (c *AgentContext) EstimateToolsTokens() int
+func (c *AgentContext) EstimateTokenPercent(windowSize int) float64
+```
+
+Estimates use a simple heuristic (~4 characters per token). Used by both the compactor and context manager to decide when to act.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `context.go` | `AgentContext`, message management, token estimation, tool whitelist |
+| `journal.go` | Append-only journal for checkpoint recovery |
+| `checkpoint.go` | Checkpoint save/load for session persistence |
+
+## Dependencies
+
+- `pkg/skill` — Skill type definition

--- a/pkg/llm/README.md
+++ b/pkg/llm/README.md
@@ -1,0 +1,146 @@
+# pkg/llm
+
+LLM client abstraction with streaming support for OpenAI-compatible and Anthropic APIs.
+
+## Overview
+
+Provides a unified interface for streaming LLM completions. Routes to Anthropic or OpenAI based on the model's `API` field. All responses are delivered as push-based event streams.
+
+## Core Types
+
+### Model
+
+```go
+type Model struct {
+    ID            string `json:"id"`            // e.g., "gpt-4o", "claude-sonnet-4-20250514"
+    Provider      string `json:"provider"`      // e.g., "zai", "openai"
+    BaseURL       string `json:"baseUrl"`       // API base URL
+    API           string `json:"api"`           // "openai-completions" or "anthropic-messages"
+    ContextWindow int    `json:"contextWindow"` // Token limit (0 = unknown)
+    MaxTokens     int    `json:"maxTokens,omitempty"`
+}
+```
+
+### LLMContext
+
+```go
+type LLMContext struct {
+    SystemPrompt string       `json:"systemPrompt,omitempty"`
+    Messages     []LLMMessage `json:"messages"`
+    Tools        []LLMTool    `json:"tools,omitempty"`
+}
+```
+
+### LLMMessage
+
+```go
+type LLMMessage struct {
+    Role      string     `json:"role"` // "system", "user", "assistant", "tool"
+    Content   string     `json:"content,omitempty"`
+    ToolCalls []ToolCall `json:"toolCalls,omitempty"`
+    Thinking  string    `json:"thinking,omitempty"` // For reasoning models
+    // ...
+}
+```
+
+### LLMTool / ToolCall / ToolCallFunction
+
+```go
+type LLMTool struct {
+    Type     string   `json:"type"`     // "function"
+    Function Function `json:"function"`
+}
+
+type ToolCall struct {
+    ID       string          `json:"id,omitempty"`
+    Type     string          `json:"type"`
+    Function ToolCallFunction `json:"function"`
+}
+
+type ToolCallFunction struct {
+    Name      string `json:"name"`
+    Arguments string `json:"arguments"` // JSON string
+}
+```
+
+## Streaming
+
+### StreamLLM
+
+```go
+func StreamLLM(
+    ctx context.Context,
+    model Model,
+    llmCtx LLMContext,
+    apiKey string,
+    chunkIntervalTimeout time.Duration,
+) *EventStream[LLMEvent, LLMMessage]
+```
+
+Routes to the correct provider based on `model.API`:
+- `"anthropic-messages"` → `StreamAnthropic()`
+- All others → OpenAI-compatible SSE streaming
+
+Returns an `EventStream` that emits `LLMEvent` values. The stream ends with either `LLMDoneEvent` (success) or `LLMErrorEvent` (failure).
+
+### EventStream
+
+```go
+type EventStream[T any, R any] struct { ... }
+```
+
+Generic push-based stream. Consumers iterate via `stream.Events()` channel. The final result is available via `stream.Result()` after the events channel closes.
+
+### LLMEvent (interface)
+
+```go
+type LLMEvent interface {
+    GetEventType() string
+}
+```
+
+Implementations:
+
+| Type | Event | Description |
+|------|-------|-------------|
+| `LLMTextDeltaEvent` | `text_delta` | Text content chunk |
+| `LLMThinkingDeltaEvent` | `thinking_delta` | Thinking/reasoning chunk |
+| `LLMToolCallDeltaEvent` | `tool_call_delta` | Partial tool call |
+| `LLMDoneEvent` | `done` | Stream complete with final message |
+| `LLMErrorEvent` | `error` | Error during streaming |
+
+### PartialMessage
+
+Accumulates streaming deltas into a complete `LLMMessage`. Handles:
+- Text content accumulation
+- Thinking content accumulation
+- Tool call merging by index (arguments are appended incrementally)
+
+## Anthropic Support
+
+`StreamAnthropic()` handles the Anthropic Messages API specifics:
+- `x-api-key` header instead of `Bearer` token
+- `anthropic-version` header
+- Different SSE event format (`message_start`, `content_block_start`, `content_block_delta`, `message_delta`)
+- Thinking/reasoning block support
+- Token usage tracking
+
+## Error Handling
+
+The client handles:
+- HTTP status codes (429 rate limit with `Retry-After`, 5xx server errors)
+- Connection timeouts between chunks
+- Premature connection close (no data chunks received)
+- Truncated streams (chunks received but no finish_reason)
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `client.go` | `StreamLLM()` — OpenAI-compatible streaming, SSE parsing, error handling |
+| `types.go` | `Model`, `LLMContext`, `LLMMessage`, `EventStream`, `PartialMessage` |
+| `anthropic.go` | `StreamAnthropic()` — Anthropic Messages API streaming |
+
+## Dependencies
+
+- `pkg/traceevent` — LLM call tracing

--- a/pkg/logger/README.md
+++ b/pkg/logger/README.md
@@ -1,0 +1,26 @@
+# pkg/logger
+
+Slog logger with traceevent bridge.
+
+## Overview
+
+Creates a `slog.Logger` that redirects all log output into the traceevent system. No log files are written — all structured logging becomes trace events visible in Perfetto traces.
+
+## API
+
+```go
+func NewLogger(cfg *Config) (*slog.Logger, error)
+func NewDefaultLogger() *slog.Logger
+```
+
+Creates a logger that wraps a discard handler with the `traceevent.WrapSlogHandler` bridge. Event filtering is handled entirely by the traceevent config.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `logger.go` | Logger construction with traceevent bridge |
+
+## Dependencies
+
+- `pkg/traceevent` — `WrapSlogHandler` for slog → trace bridge

--- a/pkg/modelselect/README.md
+++ b/pkg/modelselect/README.md
@@ -1,0 +1,57 @@
+# pkg/modelselect
+
+Model query selection with exact and prefix matching.
+
+## Overview
+
+Provides generic model selection by query string. Matches against a collection of models using exact match first, then prefix match. Returns an error for ambiguous queries.
+
+## API
+
+### SortByModelKey
+
+```go
+func SortByModelKey[T any](items []T, extract KeyExtractor[T])
+```
+
+Sorts models by provider, ID, then name (case-insensitive).
+
+### SelectByQuery
+
+```go
+func SelectByQuery[T any](items []T, query string, extract KeyExtractor[T]) (T, error)
+```
+
+Resolves a model query:
+1. Exact match on ID
+2. Exact match on name
+3. Prefix match on ID
+4. Prefix match on name
+5. Returns `ErrNotFound` if no match, `ErrAmbiguous` if multiple matches
+
+### KeyExtractor
+
+```go
+type KeyExtractor[T any] func(item T) Keys
+
+type Keys struct {
+    Provider string
+    ID       string
+    Name     string
+}
+```
+
+Extractor function that maps items to normalized identity fields.
+
+## Errors
+
+```go
+var ErrNotFound  = errors.New("model not found")
+var ErrAmbiguous = errors.New("model selector is ambiguous")
+```
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `modelselect.go` | `SelectByQuery`, `SortByModelKey`, `KeyExtractor` |

--- a/pkg/prompt/README.md
+++ b/pkg/prompt/README.md
@@ -1,0 +1,60 @@
+# pkg/prompt
+
+System prompt builder with embedded templates for agent, compaction, and context management prompts.
+
+## Overview
+
+Constructs the system prompt sent to the LLM by combining a base template with tool descriptions, skill content, and structured sections. Also provides specialized prompts for compaction and context management operations.
+
+## Templates
+
+The package uses Go's `embed` directive to bundle markdown templates:
+
+| Template | File | Purpose |
+|----------|------|---------|
+| Base prompt | `prompt.md` | Main system prompt for the agent |
+| Compact system | `compact_system.md` | System prompt for compaction LLM calls |
+| Compact summarize | `compact_summarize.md` | Prompt for initial summarization |
+| Compact update | `compact_update.md` | Prompt for incremental summary updates |
+| Context management | `context_management.md` | System prompt for context manager |
+
+## Builder
+
+```go
+type Builder struct { ... }
+
+func NewBuilder() *Builder
+func (b *Builder) WithTools(tools []ToolInfo) *Builder
+func (b *Builder) WithSkills(skills []skill.Skill) *Builder
+func (b *Builder) WithContext(ctx string) *Builder
+func (b *Builder) Build() string
+```
+
+Fluent builder pattern. Constructs the final system prompt by:
+1. Loading the base template
+2. Injecting tool descriptions (name, description, parameters schema)
+3. Injecting skill content (markdown)
+4. Injecting LLM context (structured content)
+
+## Accessors
+
+```go
+func CompactorBasePrompt() string
+func CompactSystemPrompt() string
+func CompactSummarizePrompt() string
+func CompactUpdatePrompt() string
+func ContextManagementSystemPrompt() string
+```
+
+Direct access to embedded prompt templates for use by `pkg/compact` and `pkg/agent`.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `builder.go` | `Builder` — system prompt construction |
+| `prompt.md` | Base system prompt template |
+| `compact_system.md` | Compaction system prompt |
+| `compact_summarize.md` | Initial summarization prompt |
+| `compact_update.md` | Incremental update prompt |
+| `context_management.md` | Context manager system prompt |

--- a/pkg/rpc/README.md
+++ b/pkg/rpc/README.md
@@ -1,0 +1,146 @@
+# pkg/rpc
+
+JSON-RPC server over stdin/stdout for editor and CLI integration.
+
+## Overview
+
+The RPC server implements a newline-delimited JSON protocol over stdin/stdout. It receives commands, dispatches to registered handlers, and emits events. This is the primary interface for TUI, editor plugins, and external tools to interact with the agent.
+
+## Protocol
+
+### Commands (stdin → agent)
+
+Each command is a single JSON line:
+
+```json
+{
+  "id": "unique-id",
+  "type": "prompt",
+  "message": "Hello, agent",
+  "data": {}
+}
+```
+
+**Command types:**
+
+| Type | Description |
+|------|-------------|
+| `prompt` | Send a user message to the agent |
+| `steer` | Inject a system message (mid-conversation guidance) |
+| `follow_up` | Queue a follow-up prompt after current processing |
+| `abort` | Cancel current LLM stream |
+| `get_context` | Retrieve current agent context |
+| `set_context` | Update agent context |
+| `slash_command` | Execute a slash command (e.g., `/model`, `/compact`) |
+| `workflow_init` | Initialize workflow execution |
+| `workflow_start` | Start workflow processing |
+| `workflow_heartbeat` | Periodic workflow status update |
+
+**Prompt-specific data** (`PromptRequest`):
+
+```json
+{
+  "type": "prompt",
+  "data": {
+    "message": "Fix the bug",
+    "streamingBehavior": "full",
+    "images": [{"type":"image","data":"base64..."}]
+  }
+}
+```
+
+### Responses (agent → stdout)
+
+```json
+{
+  "id": "matching-command-id",
+  "type": "response",
+  "command": "prompt",
+  "success": true,
+  "data": {},
+  "error": ""
+}
+```
+
+### Events (agent → stdout)
+
+Events are unsolicited JSON lines emitted during processing:
+
+```json
+{
+  "type": "agent_event",
+  "data": {
+    "type": "text_delta",
+    "message": {"role":"assistant","content":[{"type":"text","text":"Hello"}]}
+  }
+}
+```
+
+**Event types:**
+
+| Type | Description |
+|------|-------------|
+| `agent_event` | Agent lifecycle and stream events (see `pkg/agent` event types) |
+| `session_event` | Session save/load/compact events |
+| `workflow_event` | Workflow state changes |
+| `context_limit_recovery_event` | Context overflow recovery |
+| `compaction_event` | Compaction summary |
+| `ready` | Agent ready for commands |
+
+### Workflow State
+
+```json
+{
+  "type": "workflow_state",
+  "data": {
+    "phase": "worker",
+    "tasksFile": "/path/to/tasks.md",
+    "totalTasks": 5,
+    "pendingTasks": 3,
+    "doneTasks": 2,
+    "failedTasks": 0,
+    "inProgressTask": {"id":"task-1","description":"...","status":"in_progress"}
+  }
+}
+```
+
+## Server
+
+```go
+type Server struct { ... }
+```
+
+Thread-safe RPC server. Created with `NewServer(ctx)`:
+
+```go
+srv := rpc.NewServer(ctx)
+srv.Register("prompt", handlePrompt)
+srv.Register("abort", handleAbort)
+srv.Run() // Blocks, reads stdin, dispatches commands
+```
+
+Key methods:
+- `Register(cmdType, handler)` — Register a command handler
+- `Run()` — Start reading stdin and dispatching
+- `EmitEvent(event)` — Send an unsolicited event to stdout
+- `SetOutput(writer)` — Override output (useful for testing)
+- `Context()` — Access the server's context
+
+## Handler Type
+
+```go
+type Handler func(cmd RPCCommand) (any, error)
+```
+
+Handlers receive the raw `RPCCommand` and return arbitrary data or an error. Parameter parsing is the handler's responsibility.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `server.go` | Server struct, command dispatch, Run(), EmitEvent() |
+| `types.go` | Protocol types — RPCCommand, RPCResponse, event types, workflow types |
+
+## Dependencies
+
+- `pkg/command` — Slash command registry (re-exported for backward compatibility)

--- a/pkg/run/README.md
+++ b/pkg/run/README.md
@@ -1,0 +1,89 @@
+# pkg/run
+
+Run metadata, Unix domain socket server, and event broadcasting for `ai serve`/`ai run`.
+
+## Overview
+
+A "run" is a single invocation of `ai rpc` — a background agent process. This package manages run lifecycle metadata, inter-process communication via Unix domain sockets, and event broadcasting to attached watchers.
+
+## RunMeta
+
+```go
+type RunMeta struct {
+    ID           string `json:"id"`             // 6-char hex ID (crypto/rand)
+    PID          int    `json:"pid"`             // Process ID
+    CWD          string `json:"cwd"`             // Working directory
+    Status       string `json:"status"`          // "running", "done", "failed", "killed"
+    StartedAt    int64  `json:"started_at"`      // Unix timestamp
+    FinishedAt   int64  `json:"finished_at"`     // 0 if running
+    Name         string `json:"name"`            // Optional human-readable name
+    ParentRun    string `json:"parent_run"`      // Parent run ID (subagents)
+    PidStartTime int64  `json:"pid_start_time"`  // Process start epoch (PID reuse detection)
+}
+```
+
+### File Layout
+
+```
+~/.ai/runs/<id>/
+├── run.json          # RunMeta JSON
+├── events.jsonl      # Event log (replay for late-attaching watchers)
+└── control.sock      # Unix domain socket for commands
+```
+
+### Process Detection
+
+`IsRunning(meta)` checks:
+1. Status is `"running"`
+2. Process with `meta.PID` exists
+3. PID start time matches `meta.PidStartTime` (prevents false positives from PID reuse)
+
+### Discovery
+
+```go
+func FindRunningByCwd(baseDir, cwd string) ([]RunMeta, error)
+func FindByPrefix(baseDir, prefix string) ([]RunMeta, error)
+func FindByStatus(baseDir, status string) ([]RunMeta, error)
+```
+
+## SocketServer
+
+Unix domain socket server for run control and event streaming.
+
+```go
+type SocketServer struct { ... }
+
+func NewSocketServer(sockPath string, handler CommandHandler) *SocketServer
+```
+
+### Commands
+
+```go
+type Command struct {
+    Type    string `json:"type"`              // "send", "abort", "stream", "status"
+    Message string `json:"message"`
+    FromSeq uint64 `json:"from_seq,omitempty"` // For "stream": replay from this sequence
+}
+```
+
+### Event Broadcasting
+
+`EventBroadcaster` provides fan-out event delivery:
+
+```go
+type EventBroadcaster struct { ... }
+
+func (b *EventBroadcaster) Broadcast(event any)     // Send to all consumers
+func (b *EventBroadcaster) NewConsumer() *Consumer   // Create new subscriber
+```
+
+Consumers receive events via a ring buffer. Late-joining consumers can replay from a sequence number.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `meta.go` | `RunMeta`, discovery functions, process detection |
+| `socket.go` | `SocketServer`, Unix domain socket command handling |
+| `event_broadcaster.go` | `EventBroadcaster`, ring-buffer fan-out |
+| `conv.go` | Event serialization/conversion utilities |

--- a/pkg/session/README.md
+++ b/pkg/session/README.md
@@ -1,0 +1,170 @@
+# pkg/session
+
+Append-only JSONL session persistence with compaction, forking, and lazy loading.
+
+## Overview
+
+Sessions store the full conversation history for an agent instance. The storage format is append-only JSONL — new entries are appended, never modified. This design enables crash-safe writes, lazy loading for large sessions, and branching (forking) from any point in the conversation.
+
+## Session Layout
+
+Sessions are stored under `~/.ai/sessions/` (or a configured base directory):
+
+```
+~/.ai/sessions/
+├── --Users-genius-project-myapp--/   # One directory per project (sanitized path)
+│   ├── <uuid-1>/                     # Session directory
+│   │   ├── messages.jsonl            # Append-only entry log
+│   │   ├── meta.json                 # Session metadata (name, title, timestamps)
+│   │   ├── llm_context.txt           # Persisted LLM context (from context management)
+│   │   └── checkpoint.json           # Periodic checkpoint snapshot
+│   ├── <uuid-2>/
+│   └── ...
+└── --Users-genius-project-other--/
+    └── ...
+```
+
+The session directory name is derived from the working directory at session creation:
+
+```
+sanitizePath("/Users/genius/project/myapp") → "--Users-genius-project-myapp--"
+```
+
+## Entry Types
+
+Each line in `messages.jsonl` is a JSON object with a `type` discriminator:
+
+| Type | Constant | Description |
+|------|----------|-------------|
+| `session` | `EntryTypeSession` | Header entry — first line, contains session ID, version, CWD |
+| `message` | `EntryTypeMessage` | User/assistant/tool message |
+| `compaction` | `EntryTypeCompaction` | Compaction summary replacing older messages |
+| `compact_event` | `EntryTypeCompactEvent` | Granular compaction action (truncate, update_llm_context) |
+| `branch_summary` | `EntryTypeBranchSummary` | Summary of a branched conversation |
+| `session_info` | `EntryTypeSessionInfo` | Session name/title metadata |
+
+### Session Header
+
+```json
+{"type":"session","version":1,"id":"<uuid>","timestamp":"2025-01-15T10:30:00Z","cwd":"/Users/genius/project/myapp"}
+```
+
+### Message Entry
+
+```json
+{"type":"message","id":"<entry-id>","parentId":"<parent-entry-id>","timestamp":"...","message":{"role":"user","content":[...]}}
+```
+
+Messages form a tree via `parentId` links. The current conversation tip is the `leafID`.
+
+### Compaction Entry
+
+```json
+{"type":"compaction","id":"<entry-id>","parentId":"<parent-entry-id>","timestamp":"...","summary":"...","firstKeptEntryId":"<id>","tokensBefore":50000,"tokensAfter":5000}
+```
+
+The `firstKeptEntryId` marks where messages resume after the summary.
+
+## Core Types
+
+### Session
+
+```go
+type Session struct { ... }
+```
+
+Main session struct. Manages an in-memory tree of entries backed by `messages.jsonl`. Thread-safe via mutex. Key methods:
+
+- `AppendMessage(msg)` — Append a user/assistant/tool message
+- `GetMessages()` — Get current conversation branch as `[]AgentMessage`
+- `Compact(compactor)` — Compact older messages into a summary entry
+- `GetUserMessagesForForking()` — List user messages suitable as fork points
+- `GetBranch(leafID)` — Get entries from root to a specific leaf
+
+### SessionManager
+
+```go
+type SessionManager struct { ... }
+```
+
+Manages multiple sessions within a sessions directory. Handles:
+
+- `ListSessions()` — Enumerate all sessions (sorted by update time)
+- `CreateSession(name, title)` — Create a new session
+- `ForkSessionFrom(source, leafID, name, title)` — Branch a conversation from any point
+- `DeleteSession(id)` — Remove a session
+- `RenameSession(id, name)` — Rename a session
+
+## Forking
+
+A fork creates a new session that copies entries from the source session up to the specified `leafID`. The new session gets:
+
+- A copy of all branch entries from root to the fork point
+- A `parentSession` reference to the source session
+- Its own `session_info` entry with the new name/title
+
+This enables exploring alternate conversation paths without modifying the original.
+
+## Lazy Loading
+
+Sessions support lazy loading to avoid reading the entire JSONL file for large conversations:
+
+```go
+opts := session.DefaultLoadOptions() // Lazy: true, auto message limit
+sess, err := session.LoadSessionLazy(dir, opts)
+```
+
+Lazy loading reads only:
+1. The session header
+2. The most recent compaction entry (if any)
+3. Recent entries (working backwards from the end)
+
+The `MaxMessages` field controls how many recent entries to load:
+- `0` — Auto (based on compaction entry's `firstKeptEntryId`)
+- `-1` — Load everything
+- `N > 0` — Load at most N messages
+
+## Checkpoint and Journal
+
+The `AgentContextCheckpointManager` in `pkg/agent` writes periodic checkpoints:
+
+- **Journal**: Append-only log of messages within the current agent run
+- **Checkpoint**: Periodic snapshot of `AgentContext` state (messages, system prompt, tools)
+- **Recovery**: On crash, replay from last checkpoint + journal entries
+
+Checkpoint files are stored in the session directory:
+- `checkpoint.json` — Full context snapshot
+- Journal entries — Incremental updates since last checkpoint
+
+## Compaction in Sessions
+
+When context grows too large, the session system works with `pkg/compact` to:
+
+1. Find the oldest cuttable messages (user messages are cuttable boundaries)
+2. Summarize the cuttable portion via LLM
+3. Append a `compaction` entry with the summary
+4. Set `firstKeptEntryId` to the first message after the cut point
+
+On replay, compaction entries are converted to a user message containing the summary wrapped in `<summary>` tags. All entries before `firstKeptEntryId` are skipped.
+
+### Compact Events (Granular)
+
+`compact_event` entries record individual actions by the context manager:
+
+```json
+{"type":"compact_event","action":"truncate","ids":["tool-call-id-1","tool-call-id-2"]}
+```
+
+Actions: `truncate` (trim tool output), `update_llm_context` (update structured context), `compact` (major compaction).
+
+On replay, `truncate` actions restore truncated tool outputs using `TruncateWithHeadTail`.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `session.go` | Session struct, append/get/compact/fork operations |
+| `entries.go` | Entry types, header parsing, entry-to-message conversion, replay |
+| `manager.go` | SessionManager — CRUD, listing, forking across sessions |
+| `lazy.go` | Lazy loading with LoadSessionLazy |
+| `compaction.go` | Session-level compaction logic (find cut points, summarize) |

--- a/pkg/skill/README.md
+++ b/pkg/skill/README.md
@@ -1,0 +1,94 @@
+# pkg/skill
+
+Skill loading, validation, and collision detection for the agent skills system.
+
+## Overview
+
+Skills are markdown files (with optional YAML frontmatter) that provide specialized instructions to the agent. They are loaded from multiple sources with defined precedence, and validated against naming and format rules.
+
+## Skill
+
+```go
+type Skill struct {
+    Name                   string
+    Description            string
+    FilePath               string      // Path to the skill markdown file
+    BaseDir                string      // Directory containing the skill file
+    Source                 string      // "user", "project", or "path"
+    Content                string      // Full markdown content
+    Frontmatter            Frontmatter
+    DisableModelInvocation bool        // Exclude from auto-prompt
+    LoadedAt               time.Time
+}
+```
+
+## Frontmatter
+
+```go
+type Frontmatter struct {
+    Name        string `yaml:"name"`
+    Description string `yaml:"description"`
+    License     string `yaml:"license,omitempty"`
+    // ... additional fields
+}
+```
+
+Skills use YAML frontmatter at the top of their markdown files:
+
+```markdown
+---
+name: react-component
+description: Guidelines for creating React components
+---
+
+# React Component Guidelines
+...
+```
+
+## Loading Sources
+
+Skills are loaded from three sources in priority order:
+
+1. **User skills** — `~/.ai/skills/` (global, personal)
+2. **Project skills** — `.ai/skills/` (project-specific)
+3. **Path skills** — Explicit file paths passed at load time
+
+When skills with the same name exist in multiple sources, the first-loaded skill wins. Collisions are recorded as diagnostics.
+
+## Validation
+
+The loader enforces:
+- Name length ≤ 64 characters
+- Description length ≤ 1024 characters
+- Valid characters in name
+- Required frontmatter fields
+
+## Collision Detection
+
+```go
+type CollisionInfo struct {
+    ResourceType string // "skill"
+    Name         string
+    WinnerPath   string // First loaded skill
+    LoserPath    string // Later skill with same name
+}
+```
+
+Collisions are reported as `Diagnostic` entries with type `"collision"`. The winner is the first skill loaded (higher priority source).
+
+## LoadResult
+
+```go
+type LoadResult struct {
+    Skills      []Skill
+    Diagnostics []Diagnostic
+}
+```
+
+Returned by the loader with all successfully loaded skills and any warnings/errors.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `skill.go` | `Skill`, `Frontmatter`, `LoadResult`, `Diagnostic`, `CollisionInfo` |

--- a/pkg/tools/README.md
+++ b/pkg/tools/README.md
@@ -1,0 +1,57 @@
+# pkg/tools
+
+Tool implementations and registry for agent tool execution.
+
+## Overview
+
+Provides the `Registry` for tool registration and concrete tool implementations. Each tool implements the `context.Tool` interface (`Name`, `Description`, `Parameters`, `Execute`).
+
+## Registry
+
+```go
+type Registry struct { ... }
+
+func NewRegistry() *Registry
+func (r *Registry) Register(tool context.Tool)
+func (r *Registry) Get(name string) (context.Tool, bool)
+func (r *Registry) All() []context.Tool
+func (r *Registry) ToLLMTools() []map[string]any
+```
+
+The registry maps tool names to implementations. `ToLLMTools()` converts all registered tools into the JSON format expected by LLM function-calling APIs.
+
+## Built-in Tools
+
+| Tool | File | Description |
+|------|------|-------------|
+| `bash` | `bash.go` | Execute shell commands with timeout |
+| `read` | `read.go` | Read file contents (supports offset/limit) |
+| `write` | `write.go` | Write content to files |
+| `edit` | `edit.go` | Edit files by replacing text ranges |
+| `grep` | `grep.go` | Search file contents with regex |
+| `find_skill` | `find_skill.go` | Search and load agent skills |
+| `change_workspace` | `change_workspace.go` | Change working directory |
+| `hashline` | `hashline.go` | Content-addressed line references for edit verification |
+| `workspace` | `workspace.go` | Workspace info and path resolution |
+
+## Tool Output Processing
+
+Tool output is processed through the truncation pipeline before being stored:
+- `ToolOutputLimits` controls max character count
+- Long outputs are truncated with head/tail preservation
+- Hashlines may be appended for content verification
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `registry.go` | Tool registry |
+| `bash.go` | Shell command execution |
+| `read.go` | File reading |
+| `write.go` | File writing |
+| `edit.go` | File editing |
+| `grep.go` | Content search |
+| `find_skill.go` | Skill discovery |
+| `change_workspace.go` | Working directory management |
+| `hashline.go` | Content-addressed references |
+| `workspace.go` | Workspace utilities |

--- a/pkg/traceevent/README.md
+++ b/pkg/traceevent/README.md
@@ -1,0 +1,103 @@
+# pkg/traceevent
+
+Perfetto-compatible tracing with configurable event categories and slog bridge.
+
+## Overview
+
+Provides structured tracing for the agent runtime. Events are written as Perfetto-compatible JSON traces that can be viewed in Chrome's `chrome://tracing` UI or Perfetto UI (ui.perfetto.dev). The package also includes a `slog` handler bridge that redirects all structured logs into the trace event stream.
+
+## Core Types
+
+### TraceEvent
+
+```go
+type TraceEvent struct {
+    Timestamp time.Time
+    Name      string
+    Phase     TracePhase    // "B" (begin), "E" (end), "I" (instant)
+    Category  TraceCategory
+    Fields    []Field
+}
+```
+
+### TraceBuf
+
+Buffered trace writer. Obtained from context via `GetTraceBuf(ctx)`. Writes events to a Perfetto-compatible JSON file at `~/.ai/traces/<id>.json`.
+
+## Event Configuration
+
+Events are configured via bit flags in `config.go`:
+
+```go
+// Enable/disable specific events at runtime
+traceevent.IsEventEnabled("tool_execution") // Check if an event is active
+```
+
+Event categories:
+- `tool` — Tool execution, truncation, normalization
+- `llm` — API calls, streaming, retries
+- `event` — Agent lifecycle, turns, messages
+- `log` — slog bridge output (info/warn/error)
+
+Events are selected by name or category selector. Default enabled events are defined in `defaultEnabledEvents`.
+
+## API
+
+### Recording Events
+
+```go
+// Instant event
+traceevent.Log(ctx, traceevent.CategoryTool, "tool_execution_start",
+    traceevent.String("tool", "bash"),
+    traceevent.Int("timeout", 120))
+
+// Begin/End (duration)
+traceevent.Begin(ctx, traceevent.CategoryLLM, "llm_stream", ...)
+traceevent.End(ctx, traceevent.CategoryLLM, "llm_stream", ...)
+
+// Convenience wrappers
+traceevent.Error(ctx, traceevent.CategoryTool, "tool_failed", "message", "error", err)
+```
+
+### Slog Bridge
+
+```go
+handler := traceevent.WrapSlogHandler(innerHandler)
+logger := slog.New(handler)
+```
+
+All `logger.Info/Warn/Error` calls are converted to trace events in addition to their normal output.
+
+### Buffer Management
+
+```go
+type TraceBuf struct { ... }
+
+func (tb *TraceBuf) Record(event TraceEvent)
+func (tb *TraceBuf) RecordWithContext(ctx context.Context, event TraceEvent)
+func (tb *TraceBuf) Flush() error
+```
+
+Buffered writes with periodic flush. Flush is triggered every 256 events or 1 second, whichever comes first.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `trace.go` | `Log`, `Begin`, `End`, `Error` — event recording functions |
+| `types.go` | `TraceEvent`, `Field`, `TracePhase`, `TraceCategory` |
+| `config.go` | Bit-flag event selection, `IsEventEnabled()` |
+| `buffer.go` | `TraceBuf` — buffered Perfetto JSON writer |
+| `perfetto.go` | Perfetto JSON format serialization |
+| `slog_bridge.go` | `slog.Handler` wrapper for trace integration |
+| `handler.go` | Context integration for TraceBuf |
+
+## Output Format
+
+Trace files are Perfetto-compatible JSON:
+
+```json
+[{"ph":"I","name":"tool_execution","cat":"tool","ts":1234567890,"pid":1,"tid":1,"args":{"tool":"bash"}},...]
+```
+
+View at `chrome://tracing` or https://ui.perfetto.dev.

--- a/pkg/truncate/README.md
+++ b/pkg/truncate/README.md
@@ -1,0 +1,58 @@
+# pkg/truncate
+
+Text truncation with UTF-8 safety, preserving head and tail content.
+
+## Overview
+
+Provides safe text truncation for tool outputs and long messages. The truncation preserves both the beginning and end of the text with a marker indicating how many tokens were removed.
+
+## API
+
+### Truncate
+
+```go
+func Truncate(text string, maxChars int) string
+```
+
+Truncates `text` to fit within `maxChars` bytes with:
+- 50/50 split between prefix and suffix
+- UTF-8 boundary safety (never splits a multi-byte character)
+- Truncation marker showing approximate removed token count
+
+Example output:
+```
+[first 500 chars]...[~1250 tokens truncated]...[last 500 chars]
+```
+
+### TruncateWithHeadTail
+
+```go
+func TruncateWithHeadTail(text string) string
+```
+
+Convenience wrapper using default limits (1000 head + 1000 tail + 500 marker budget).
+
+### EstimateTokens
+
+```go
+func ApproxTokenCount(text string) int
+```
+
+Rough token estimate (~4 chars per token) for truncation markers.
+
+## UTF-8 Safety
+
+The `splitString` function ensures truncation boundaries never split a multi-byte UTF-8 sequence:
+
+```go
+func splitString(s string, beginningBytes, endBytes int) (removedTokens int, prefix, suffix string)
+```
+
+If a split would land inside a multi-byte character, it backs up to the previous valid boundary.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `truncate.go` | `Truncate()`, `TruncateWithHeadTail()`, `splitString()` |
+| `estimate.go` | `ApproxTokenCount()` |

--- a/pkg/version/README.md
+++ b/pkg/version/README.md
@@ -1,0 +1,22 @@
+# pkg/version
+
+VCS revision extraction from Go build information.
+
+## Overview
+
+Extracts the Git commit hash from the compiled binary using `runtime/debug.ReadBuildInfo()`. No build flags required — Go automatically embeds VCS metadata when building from a Git repository.
+
+## API
+
+```go
+var GitCommit string  // e.g., "f5fa7e9" or "f5fa7e9-dirty"
+var GitVersion string // Reserved for future use
+```
+
+The `-dirty` suffix is appended when the working tree had uncommitted changes at build time.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `version.go` | `init()` function extracting VCS revision from `debug.BuildInfo` |


### PR DESCRIPTION
## Summary

Add self-documenting README.md to all `pkg/` subdirectories and two in-depth protocol/format reference documents.

## Changes

### pkg/ README (17 files)
Every package now has a README covering: purpose, core types with signatures, key methods, file listing, and dependency map.

| Package | Highlights |
|---------|-----------|
| `agent` | Agent loop, event type table, EventStream pattern, ToolExecutor interface |
| `llm` | Model/LLMMessage types, StreamLLM routing, Anthropic support, PartialMessage |
| `session` | JSONL format, 6 entry types, fork mechanism, lazy loading, checkpoint/journal |
| `compact` | Compactor + ContextManager dual-layer, trigger thresholds, compact_event recording |
| `rpc` | JSON-RPC protocol, command/response/event message types, Handler |
| `context` | AgentContext core, Tool interface, compaction actions, token estimation |
| `tools` | Registry, 9 built-in tools |
| `traceevent` | Perfetto format, bit-flag config, slog bridge |
| `config` | Config struct, model spec, API key resolution |
| `prompt` | Builder pattern, 5 embedded templates |
| `skill` | Load source priority, frontmatter, collision detection |
| `run` | RunMeta, SocketServer, EventBroadcaster |
| `command` | Slash command registry, /set subcommands |
| `truncate` | UTF-8 safe truncation, head+tail preservation |
| `modelselect` | Query selection, exact/prefix matching |
| `version` | VCS revision extraction |
| `logger` | slog-to-traceevent bridge |

### docs/rpc-protocol.md
Full JSON-RPC reference: command types, response format, event types (with agent event subtypes), workflow state, typical session flow diagram, Unix domain socket protocol.

### docs/session-format.md
Complete JSONL session format: design principles, file layout, 6 entry types with JSON examples, conversation tree structure, forking, lazy loading (with MaxMessages behavior table), checkpoint/journal recovery, compaction flow.

## Test plan
- [ ] Verify README content accuracy against actual code
- [ ] Cross-check type signatures in READMEs match current Go source
- [ ] Confirm RPC protocol examples match `pkg/rpc/types.go`
- [ ] Confirm session format examples match `pkg/session/entries.go`
