### PR TITLE
fix: remove workspace from global config.json - workspace is session-scoped

### DIFF
--- a/cmd/ai/rpc_setup.go
+++ b/cmd/ai/rpc_setup.go
@@ -49,8 +49,6 @@ func newRPCApp(sessionPath string, params rpcAppSetupParams) (*rpcApp, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get working directory: %w", err)
 	}
-	cfg.Workspace = cwd
-
 	// --- Session ---
 	sessionPath, err = normalizeSessionPath(sessionPath)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,9 +35,6 @@ type Config struct {
 
 	// Logging configuration
 	Log *LogConfig `json:"log,omitempty"`
-
-	// Workspace is the working directory path (the git repo path bound at startup)
-	Workspace string `json:"workspace,omitempty"`
 }
 
 // LogConfig contains logging configuration.


### PR DESCRIPTION
## Problem

The global config file `~/.ai/config.json` contained a `workspace` field that was set at startup (`cfg.Workspace = cwd`). Since `config.json` is shared by all sessions, this caused workspace clobbering when multiple sessions ran in different directories.

## Fix

- **Removed `Workspace string` field** from `config.Config` struct (`pkg/config/config.go`)
- **Removed `cfg.Workspace = cwd`** from `cmd/ai/rpc_setup.go`

## Why this is safe

- `cfg.Workspace` was **never read** anywhere in the codebase — only written
- Workspace is already properly scoped at the session level via:
  - `SessionMeta.Workspace` in session manager
  - `app.ws.GetGitRoot()` used in RPC handlers for workspace info
  - `app.cwd` field on rpcApp
- After this fix, any existing `workspace` key in `~/.ai/config.json` will be silently ignored on load (Go's JSON unmarshaler ignores unknown fields), and omitted on the next save

## Testing

- `go test ./pkg/config/... ./pkg/session/... ./pkg/context/... ./pkg/rpc/... ./pkg/agent/...` — all pass
- `go build ./...` — compiles cleanly