### PR TITLE
fix: update trace handler session ID on session switch

### DIFF
--- a/cmd/ai/rpc_session_handlers.go
+++ b/cmd/ai/rpc_session_handlers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tiancaiamao/ai/pkg/rpc"
 	"github.com/tiancaiamao/ai/pkg/session"
+	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
 )
 
 // --- Session management handlers --@
@@ -21,6 +22,14 @@ func (app *rpcApp) setSession(newSess *session.Session, newID, newName string) {
 
 	if err := app.updateCheckpointManager(); err != nil {
 		slog.Warn("Failed to update checkpoint manager", "error", err)
+	}
+
+	// Update trace handler to use the new session ID.
+	if handler := traceevent.GetHandler(); handler != nil {
+		if fh, ok := handler.(*traceevent.FileHandler); ok {
+			fh.SetSessionID(newID)
+			app.traceOutputPath = fh.TraceFilePath("")
+		}
 	}
 
 	app.stateMu.Lock()

--- a/pkg/traceevent/trace_test.go
+++ b/pkg/traceevent/trace_test.go
@@ -823,7 +823,83 @@ func TestBuildTraceEventJSONToolCallTidStableForSpanPair(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected end tid to be int, got %T", endJSON["tid"])
 	}
-	if beginTid != endTid {
+		if beginTid != endTid {
 		t.Fatalf("expected same tid for span pair, got begin=%d end=%d", beginTid, endTid)
+	}
+}
+
+func TestSetSessionID_UpdatesTraceFilePath(t *testing.T) {
+	tmp := t.TempDir()
+	h, err := NewFileHandler(tmp)
+	if err != nil {
+		t.Fatalf("NewFileHandler failed: %v", err)
+	}
+
+	// Initial state: no session ID set.
+	initialPath := h.TraceFilePath("")
+	if !strings.Contains(initialPath, "sessunknown") {
+		t.Fatalf("expected 'sessunknown' in initial path, got %s", initialPath)
+	}
+
+	// Set session A.
+	h.SetSessionID("session-alpha")
+	pathA := h.TraceFilePath("")
+	if !strings.Contains(pathA, "sesssession-alpha") {
+		t.Fatalf("expected 'sesssession-alpha' in path, got %s", pathA)
+	}
+
+	// Switch to session B — regression test: TraceFilePath must reflect the new ID.
+	h.SetSessionID("session-beta")
+	pathB := h.TraceFilePath("")
+	if !strings.Contains(pathB, "sesssession-beta") {
+		t.Fatalf("expected 'sesssession-beta' in path after switch, got %s", pathB)
+	}
+	if pathA == pathB {
+		t.Fatalf("paths should differ after session switch, both are %s", pathA)
+	}
+}
+
+func TestSetSessionID_ClosesOpenStreams(t *testing.T) {
+	tmp := t.TempDir()
+	h, err := NewFileHandler(tmp)
+	if err != nil {
+		t.Fatalf("NewFileHandler failed: %v", err)
+	}
+	h.SetSessionID("session-old")
+
+	// Write a trace to open a stream file.
+	traceID := []byte("trace-1")
+	events := []TraceEvent{
+		{Timestamp: time.Now(), Name: "test", Phase: PhaseBegin, Category: CategoryEvent},
+		{Timestamp: time.Now(), Name: "test", Phase: PhaseEnd, Category: CategoryEvent},
+	}
+	if err := h.HandleChunk(context.Background(), traceID, events, true); err != nil {
+		t.Fatalf("HandleChunk failed: %v", err)
+	}
+
+	// Verify the old trace file exists.
+	oldPaths, err := filepath.Glob(filepath.Join(tmp, "*session-old*"))
+	if err != nil {
+		t.Fatalf("Glob failed: %v", err)
+	}
+	if len(oldPaths) == 0 {
+		t.Fatal("expected trace file for session-old to exist")
+	}
+
+	// Switch session — should close old streams.
+	h.SetSessionID("session-new")
+
+	// Write a new trace under the new session.
+	traceID2 := []byte("trace-2")
+	if err := h.HandleChunk(context.Background(), traceID2, events, true); err != nil {
+		t.Fatalf("HandleChunk after switch failed: %v", err)
+	}
+
+	newPaths, err := filepath.Glob(filepath.Join(tmp, "*session-new*"))
+	if err != nil {
+		t.Fatalf("Glob failed: %v", err)
+	}
+	if len(newPaths) == 0 {
+		t.Fatal("expected trace file for session-new to exist after switch")
 	}
 }


### PR DESCRIPTION
## Problem

When switching sessions via `/resume`, `/new`, or `/fork`, the `ai-log` path displayed by `/session` shows the **previous** session's trace file instead of the new one.

```
# After /resume to a different session, /session still shows:
  ai-log: /Users/.../pid94347-sesse5f76edf-ea3a-469b-bd39-f40edad34bc2.3.perfetto.json
                    ^^^^^^^^^^^^ old session ID
```

## Root Cause

`setSession()` updates `sessionID`, `sessionName`, `sess`, and the checkpoint manager — but does **not** update the global `FileHandler`'s session ID or `app.traceOutputPath`. Both remain pointing at the old session's trace file.

## Fix

In `setSession()`, after updating the checkpoint manager, call `FileHandler.SetSessionID(newID)` which:
1. Closes existing trace streams (flushes pending data)
2. Updates the session ID used for trace file naming
3. Refresh `app.traceOutputPath` so `/session` displays the correct path

Affects `/resume`, `/new`, and `/fork` — all three call `setSession()`.