### PR TITLE
feat: PGE multi-agent orchestration infrastructure

### DIFF
--- a/cmd/ai/handler_steer_followup_test.go
+++ b/cmd/ai/handler_steer_followup_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+		"github.com/tiancaiamao/ai/pkg/agent"
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/llm"
+	"github.com/tiancaiamao/ai/pkg/rpc"
+	"github.com/tiancaiamao/ai/pkg/traceevent"
+)
+
+func newTestApp(t *testing.T) *rpcApp {
+	t.Helper()
+	model := llm.Model{ID: "test-model", ContextWindow: 4096}
+	agentCtx := agentctx.NewAgentContext("test system prompt")
+	ag := agent.NewAgentFromConfigWithContext(model, "test-key", agentCtx, agent.DefaultLoopConfig())
+
+	// Drain the trace goroutine so temp dirs get cleaned up.
+	t.Cleanup(func() {
+		traceevent.SetActiveTraceBuf(nil)
+	})
+
+	return &rpcApp{
+		ag:                ag,
+		steeringMode:      "all",
+		followUpMode:      "all",
+		expandSkillCommands: func(text string) string { return text },
+		compactBeforeRequest: func(trigger string) {},
+	}
+}
+
+// --- handleSteer tests ---
+
+func TestHandleSteer_EmptyMessage(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleSteer(rpc.RPCCommand{Message: ""})
+	if err == nil {
+		t.Fatal("expected error for empty steer message")
+	}
+	if err.Error() != "empty steer message" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleSteer_WhitespaceOnly(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleSteer(rpc.RPCCommand{Message: "   \t\n  "})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only steer message")
+	}
+}
+
+func TestHandleSteer_ValidMessage(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleSteer(rpc.RPCCommand{Message: "go left"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleSteer_MessageFromData(t *testing.T) {
+	app := newTestApp(t)
+	data, _ := json.Marshal(map[string]string{"message": "from data field"})
+	_, err := app.handleSteer(rpc.RPCCommand{Data: data})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleSteer_InvalidData(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleSteer(rpc.RPCCommand{Data: []byte("not json")})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON data")
+	}
+}
+
+func TestHandleSteer_OneAtATime_PendingBlocks(t *testing.T) {
+	app := newTestApp(t)
+	app.steeringMode = "one-at-a-time"
+	app.pendingSteer = true
+
+	_, err := app.handleSteer(rpc.RPCCommand{Message: "blocked"})
+	if err == nil {
+		t.Fatal("expected error when steer already pending in one-at-a-time mode")
+	}
+	if err.Error() != "steer already pending" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleSteer_OneAtATime_NoPending(t *testing.T) {
+	app := newTestApp(t)
+	app.steeringMode = "one-at-a-time"
+	app.pendingSteer = false
+
+	_, err := app.handleSteer(rpc.RPCCommand{Message: "allowed"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleSteer_SetsPendingFlag(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleSteer(rpc.RPCCommand{Message: "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !app.pendingSteer {
+		t.Fatal("expected pendingSteer to be true after successful steer")
+	}
+}
+
+// --- handleFollowUp tests ---
+
+func TestHandleFollowUp_EmptyMessage(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleFollowUp(rpc.RPCCommand{Message: ""})
+	if err == nil {
+		t.Fatal("expected error for empty follow-up message")
+	}
+	if err.Error() != "empty follow-up message" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleFollowUp_WhitespaceOnly(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleFollowUp(rpc.RPCCommand{Message: "   "})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only follow-up message")
+	}
+}
+
+func TestHandleFollowUp_ValidMessage(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleFollowUp(rpc.RPCCommand{Message: "do more"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleFollowUp_MessageFromData(t *testing.T) {
+	app := newTestApp(t)
+	data, _ := json.Marshal(map[string]string{"message": "from data"})
+	_, err := app.handleFollowUp(rpc.RPCCommand{Data: data})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleFollowUp_InvalidData(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleFollowUp(rpc.RPCCommand{Data: []byte("{bad")})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON data")
+	}
+}
+
+func TestHandleFollowUp_OneAtATime_PendingBlocks(t *testing.T) {
+	app := newTestApp(t)
+	app.followUpMode = "one-at-a-time"
+
+	// Fill the agent's follow-up queue (capacity 100).
+	for i := 0; i < 100; i++ {
+		_ = app.ag.FollowUp("fill")
+	}
+
+	_, err := app.handleFollowUp(rpc.RPCCommand{Message: "blocked"})
+	if err == nil {
+		t.Fatal("expected error when follow-up queue full in one-at-a-time mode")
+	}
+}
+
+func TestHandleFollowUp_OneAtATime_EmptyQueue(t *testing.T) {
+	app := newTestApp(t)
+	app.followUpMode = "one-at-a-time"
+
+	_, err := app.handleFollowUp(rpc.RPCCommand{Message: "allowed"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- handleAbort tests ---
+
+func TestHandleAbort(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.handleAbort(rpc.RPCCommand{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/ai/main.go
+++ b/cmd/ai/main.go
@@ -156,6 +156,7 @@ Flags for 'ls':
 Flags for 'watch':
   --id <run-id>            Run ID or prefix (auto-selects by cwd if omitted)
   --since <offset>         Start reading from byte offset (machine-readable)
+  --follow                 Continuously stream events until agent exits
 
 Flags for 'send':
   --id <run-id>            Run ID or prefix (auto-selects by cwd if omitted)

--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -87,9 +87,8 @@ type rpcApp struct {
 	sessionWriter *sessionWriter
 	sessionComp   *sessionCompactor
 
-		// --- System prompt ---
+			// --- System prompt ---
 	systemPrompt string
-	agentMode   string // "default" or "peg"
 
 	// --- RPC Server ---
 	server *rpc.Server
@@ -180,13 +179,8 @@ func (app *rpcApp) initHelpers() {
 			slog.Info("Using custom system prompt", "length", len(app.customSystemPrompt))
 			return app.customSystemPrompt
 		}
-		promptBuilder := prompt.NewBuilderWithWorkspace("", app.ws)
+				promptBuilder := prompt.NewBuilderWithWorkspace("", app.ws)
 		promptBuilder.SetTools(app.registry.All()).SetSkills(app.skillResult.Skills).SetSkillStats(app.skillStats)
-
-		// Switch template based on agent mode.
-		if app.agentMode == "peg" {
-			promptBuilder.SetTemplate(prompt.OrchestratorTemplate())
-		}
 
 		if currentSess != nil {
 			sessionDir := currentSess.GetDir()

--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -87,8 +87,9 @@ type rpcApp struct {
 	sessionWriter *sessionWriter
 	sessionComp   *sessionCompactor
 
-	// --- System prompt ---
+		// --- System prompt ---
 	systemPrompt string
+	agentMode   string // "default" or "peg"
 
 	// --- RPC Server ---
 	server *rpc.Server
@@ -173,7 +174,7 @@ func (app *rpcApp) nuclearTruncate() {
 // Must be called after all fields are populated.
 
 func (app *rpcApp) initHelpers() {
-	// buildSystemPrompt builds the full system prompt for the given session.
+		// buildSystemPrompt builds the full system prompt for the given session.
 	app.buildSystemPrompt = func(currentSess *session.Session) string {
 		if app.customSystemPrompt != "" {
 			slog.Info("Using custom system prompt", "length", len(app.customSystemPrompt))
@@ -181,6 +182,11 @@ func (app *rpcApp) initHelpers() {
 		}
 		promptBuilder := prompt.NewBuilderWithWorkspace("", app.ws)
 		promptBuilder.SetTools(app.registry.All()).SetSkills(app.skillResult.Skills).SetSkillStats(app.skillStats)
+
+		// Switch template based on agent mode.
+		if app.agentMode == "peg" {
+			promptBuilder.SetTemplate(prompt.OrchestratorTemplate())
+		}
 
 		if currentSess != nil {
 			sessionDir := currentSess.GetDir()

--- a/cmd/ai/rpc_help_handlers.go
+++ b/cmd/ai/rpc_help_handlers.go
@@ -5,9 +5,44 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+
+	"github.com/tiancaiamao/ai/pkg/skill"
 )
 
 // --- Help and miscellaneous handlers ---
+
+func (app *rpcApp) handleSteerSlash(args string) (any, error) {
+	message := strings.TrimSpace(args)
+	if message == "" {
+		return nil, fmt.Errorf("usage: /steer <message>")
+	}
+
+	slog.Info("Received steer slash command", "value", message)
+
+	expandedMessage := app.expandSkillCommands(message)
+	if skill.IsSkillCommand(message) {
+		slog.Info("Expanded skill command in steer", "original", message, "skill", skill.ExtractSkillName(message))
+	}
+
+	app.stateMu.Lock()
+	mode := app.steeringMode
+	pending := app.pendingSteer
+	streaming := app.isStreaming
+	app.stateMu.Unlock()
+
+	if mode == "one-at-a-time" && pending {
+		return nil, fmt.Errorf("steer already pending")
+	}
+	if !streaming {
+		app.compactBeforeRequest("pre_request_steer")
+	}
+
+	app.stateMu.Lock()
+	app.pendingSteer = true
+	app.stateMu.Unlock()
+	app.ag.Steer(expandedMessage)
+	return map[string]any{"status": "steered"}, nil
+}
 
 func (app *rpcApp) handleFollowUpSlash(args string) (any, error) {
 	message := strings.TrimSpace(args)
@@ -76,6 +111,11 @@ func (app *rpcApp) registerHelpHandlers() {
 		slog.Info("Received quit command, exiting application")
 		os.Exit(0)
 		return nil, nil
+	})
+
+		// /steer
+	app.server.RegisterSlash("steer", "Inject mid-conversation guidance", func(args string) (any, error) {
+		return app.handleSteerSlash(args)
 	})
 
 	// /abort

--- a/cmd/ai/rpc_help_handlers.go
+++ b/cmd/ai/rpc_help_handlers.go
@@ -72,7 +72,6 @@ func (app *rpcApp) handleFollowUpSlash(args string) (any, error) {
 	return map[string]any{"status": "queued", "message": expandedMessage}, nil
 }
 
-
 func (app *rpcApp) handleAbortSlash(args string) (any, error) {
 	_ = args
 	slog.Info("Received abort command")
@@ -87,31 +86,6 @@ func (app *rpcApp) handleAbortSlash(args string) (any, error) {
 	app.ag.Abort()
 	return map[string]any{"status": "aborting"}, nil
 }
-
-func (app *rpcApp) handlePegSlash(args string) (any, error) {
-	mode := strings.TrimSpace(args)
-	switch mode {
-	case "", "on":
-		app.agentMode = "peg"
-		// Rebuild system prompt and update agent context.
-		app.setAgentContext(app.createBaseContext())
-		slog.Info("Switched to PEG orchestrator mode")
-		return map[string]any{
-			"status": "peg mode activated",
-			"hint":   "System prompt replaced with PEG orchestrator. Use /peg off to return to default.",
-		}, nil
-	case "off":
-		app.agentMode = "default"
-		app.setAgentContext(app.createBaseContext())
-		slog.Info("Switched back to default mode")
-		return map[string]any{
-			"status": "default mode restored",
-		}, nil
-	default:
-		return nil, fmt.Errorf("usage: /peg [on|off] — switch to/from PEG orchestrator mode")
-	}
-}
-
 
 // registerHelpHandlers registers help and miscellaneous slash commands.
 func (app *rpcApp) registerHelpHandlers() {
@@ -137,7 +111,7 @@ func (app *rpcApp) registerHelpHandlers() {
 		return nil, nil
 	})
 
-		// /steer
+	// /steer
 	app.server.RegisterSlash("steer", "Inject mid-conversation guidance", func(args string) (any, error) {
 		return app.handleSteerSlash(args)
 	})
@@ -147,14 +121,9 @@ func (app *rpcApp) registerHelpHandlers() {
 		return app.handleAbortSlash(args)
 	})
 
-		// /follow-up
+	// /follow-up
 	app.server.RegisterSlash("follow-up", "Add a follow-up message when agent is busy", func(args string) (any, error) {
 		return app.handleFollowUpSlash(args)
-	})
-
-	// /peg
-	app.server.RegisterSlash("peg", "Switch to PEG orchestrator mode (/peg [on|off])", func(args string) (any, error) {
-		return app.handlePegSlash(args)
 	})
 
 	// Hidden aliases — help-related

--- a/cmd/ai/rpc_help_handlers.go
+++ b/cmd/ai/rpc_help_handlers.go
@@ -88,6 +88,30 @@ func (app *rpcApp) handleAbortSlash(args string) (any, error) {
 	return map[string]any{"status": "aborting"}, nil
 }
 
+func (app *rpcApp) handlePegSlash(args string) (any, error) {
+	mode := strings.TrimSpace(args)
+	switch mode {
+	case "", "on":
+		app.agentMode = "peg"
+		// Rebuild system prompt and update agent context.
+		app.setAgentContext(app.createBaseContext())
+		slog.Info("Switched to PEG orchestrator mode")
+		return map[string]any{
+			"status": "peg mode activated",
+			"hint":   "System prompt replaced with PEG orchestrator. Use /peg off to return to default.",
+		}, nil
+	case "off":
+		app.agentMode = "default"
+		app.setAgentContext(app.createBaseContext())
+		slog.Info("Switched back to default mode")
+		return map[string]any{
+			"status": "default mode restored",
+		}, nil
+	default:
+		return nil, fmt.Errorf("usage: /peg [on|off] — switch to/from PEG orchestrator mode")
+	}
+}
+
 
 // registerHelpHandlers registers help and miscellaneous slash commands.
 func (app *rpcApp) registerHelpHandlers() {
@@ -123,9 +147,14 @@ func (app *rpcApp) registerHelpHandlers() {
 		return app.handleAbortSlash(args)
 	})
 
-	// /follow-up
+		// /follow-up
 	app.server.RegisterSlash("follow-up", "Add a follow-up message when agent is busy", func(args string) (any, error) {
 		return app.handleFollowUpSlash(args)
+	})
+
+	// /peg
+	app.server.RegisterSlash("peg", "Switch to PEG orchestrator mode (/peg [on|off])", func(args string) (any, error) {
+		return app.handlePegSlash(args)
 	})
 
 	// Hidden aliases — help-related

--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -273,7 +273,6 @@ func serveSubcommand(binPath string) {
 	}
 
 	// Bridge goroutine: read stdout lines from pipe → push to broadcaster.
-	agentEndCh := make(chan struct{}, 1)
 	go func() {
 		defer pipeReader.Close()
 		scanner := bufio.NewScanner(pipeReader)
@@ -283,14 +282,6 @@ func serveSubcommand(binPath string) {
 			lineCopy := make([]byte, len(line))
 			copy(lineCopy, line)
 			broadcaster.Push(lineCopy)
-
-			// Check for agent_end event to signal subprocess completion.
-			if hasAgentEndEvent(lineCopy) {
-				select {
-				case agentEndCh <- struct{}{}:
-				default:
-				}
-			}
 		}
 		if err := scanner.Err(); err != nil {
 			slog.Error("stdout bridge scanner error", "error", err)
@@ -350,15 +341,11 @@ func serveSubcommand(binPath string) {
 	// Print run ID to stdout — caller can capture this.
 	fmt.Println(id)
 
-	// Wait for agent_end via bridge goroutine signal.
-	// When the agent finishes, close stdin to trigger the RPC subprocess to exit.
-	// Without this, "ai serve" blocks forever because the RPC server loops on stdin.
-	go func() {
-		<-agentEndCh
-		stdinWriter.Close()
-	}()
-
 	// Wait for subprocess to exit.
+	// Note: we do NOT close stdin on agent_end — ai serve should remain alive
+	// to accept further ai send commands. The subprocess exits when:
+	// - stdin is explicitly closed (ai kill, or socket shutdown command)
+	// - the subprocess crashes
 	waitErr := cmd.Wait()
 
 	// Determine final status.

--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -49,10 +49,23 @@ func runSubcommand(binPath string) {
 		os.Exit(1)
 	}
 
-		// PEG mode overrides system prompt.
+				// PEG mode overrides system prompt.
 	sysPrompt := *systemPromptFlag
 	if *pegFlag {
 		sysPrompt = prompt.OrchestratorTemplate()
+
+		// Write validator prompt template to .pge/validator.md so orchestrator
+		// can spawn validators with: --system-prompt @.pge/validator.md
+		pgeDir := filepath.Join(homeDir, ".ai", ".pge")
+		if wd, err := os.Getwd(); err == nil {
+			pgeDir = filepath.Join(wd, ".pge")
+		}
+		if err := os.MkdirAll(pgeDir, 0o755); err == nil {
+			validatorPath := filepath.Join(pgeDir, "validator.md")
+			if _, err := os.Stat(validatorPath); os.IsNotExist(err) {
+				os.WriteFile(validatorPath, []byte(prompt.ValidatorTemplate()), 0o644)
+			}
+		}
 	}
 
 	// Build RPC flags to forward.

--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -187,9 +187,10 @@ func serveSubcommand(binPath string) {
 	maxTurnsFlag := fs.Int("max-turns", 0, "Maximum conversation turns (forwarded to ai rpc)")
 	timeoutFlag := fs.Duration("timeout", 0, "Total execution timeout (forwarded to ai rpc)")
 	httpFlag := fs.String("http", "", "HTTP debug server address (forwarded to ai rpc)")
-	inputFlag := fs.String("input", "", "Initial prompt to send after startup")
+		inputFlag := fs.String("input", "", "Initial prompt to send after startup")
 	inputFileFlag := fs.String("input-file", "", "Read initial prompt from file (avoids OS ARG_MAX limits)")
 	nameFlag := fs.String("name", "", "Human-readable name for the run")
+	modeFlag := fs.String("mode", "", "Agent mode: default, peg (switches system prompt)")
 	fs.Parse(os.Args[1:])
 
 	// Generate run ID and create directory.
@@ -304,7 +305,7 @@ func serveSubcommand(binPath string) {
 		os.Remove(sockPath)
 	}()
 
-	// Send initial input if provided.
+		// Send initial input if provided.
 	inputText := *inputFlag
 	if *inputFileFlag != "" {
 		data, err := os.ReadFile(*inputFileFlag)
@@ -315,6 +316,14 @@ func serveSubcommand(binPath string) {
 		}
 		inputText = string(data)
 	}
+
+	// Switch agent mode before sending input.
+	if *modeFlag == "peg" {
+		if err := sendRPCCommand(stdinWriter, "prompt", "/peg"); err != nil {
+			fmt.Fprintf(os.Stderr, "warn: failed to switch to PEG mode: %v\n", err)
+		}
+	}
+
 	if inputText != "" {
 		if err := sendRPCCommand(stdinWriter, "prompt", inputText); err != nil {
 			fmt.Fprintf(os.Stderr, "warn: failed to send initial input: %v\n", err)

--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -32,7 +32,7 @@ func runSubcommand(binPath string) {
 	httpFlag := fs.String("http", "", "HTTP debug server address (forwarded to ai rpc)")
 	inputFlag := fs.String("input", "", "Initial prompt to send after startup")
 	nameFlag := fs.String("name", "", "Human-readable name for the run")
-	pegFlag := fs.Bool("peg", false, "Use PEG orchestrator system prompt")
+	roleFlag := fs.String("role", "coder", "Agent role: coder (default), orchestrator, validator")
 	fs.Parse(os.Args[1:])
 
 	// Generate run ID and create directory.
@@ -49,23 +49,15 @@ func runSubcommand(binPath string) {
 		os.Exit(1)
 	}
 
-				// PEG mode overrides system prompt.
+					// Resolve system prompt: --system-prompt overrides --role.
 	sysPrompt := *systemPromptFlag
-	if *pegFlag {
-		sysPrompt = prompt.OrchestratorTemplate()
-
-		// Write validator prompt template to .pge/validator.md so orchestrator
-		// can spawn validators with: --system-prompt @.pge/validator.md
-		pgeDir := filepath.Join(homeDir, ".ai", ".pge")
-		if wd, err := os.Getwd(); err == nil {
-			pgeDir = filepath.Join(wd, ".pge")
+	if sysPrompt == "" && *roleFlag != "coder" {
+		tmpl, err := prompt.TemplateForRole(*roleFlag)
+		if err != nil {
+			slog.Error("invalid role", "error", err)
+			os.Exit(1)
 		}
-		if err := os.MkdirAll(pgeDir, 0o755); err == nil {
-			validatorPath := filepath.Join(pgeDir, "validator.md")
-			if _, err := os.Stat(validatorPath); os.IsNotExist(err) {
-				os.WriteFile(validatorPath, []byte(prompt.ValidatorTemplate()), 0o644)
-			}
-		}
+		sysPrompt = tmpl
 	}
 
 	// Build RPC flags to forward.
@@ -211,7 +203,7 @@ func serveSubcommand(binPath string) {
 		inputFlag := fs.String("input", "", "Initial prompt to send after startup")
 	inputFileFlag := fs.String("input-file", "", "Read initial prompt from file (avoids OS ARG_MAX limits)")
 	nameFlag := fs.String("name", "", "Human-readable name for the run")
-	pegFlag := fs.Bool("peg", false, "Use PEG orchestrator system prompt")
+	roleFlag := fs.String("role", "coder", "Agent role: coder (default), orchestrator, validator")
 	fs.Parse(os.Args[1:])
 
 	// Generate run ID and create directory.
@@ -228,10 +220,15 @@ func serveSubcommand(binPath string) {
 		os.Exit(1)
 	}
 
-	// PEG mode overrides system prompt.
+		// Resolve system prompt: --system-prompt overrides --role.
 	sysPrompt := *systemPromptFlag
-	if *pegFlag {
-		sysPrompt = prompt.OrchestratorTemplate()
+	if sysPrompt == "" && *roleFlag != "coder" {
+		tmpl, err := prompt.TemplateForRole(*roleFlag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		sysPrompt = tmpl
 	}
 
 	// Build RPC flags to forward.

--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -19,6 +19,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+		"github.com/tiancaiamao/ai/pkg/prompt"
 	"github.com/tiancaiamao/ai/pkg/run"
 )
 
@@ -31,6 +32,7 @@ func runSubcommand(binPath string) {
 	httpFlag := fs.String("http", "", "HTTP debug server address (forwarded to ai rpc)")
 	inputFlag := fs.String("input", "", "Initial prompt to send after startup")
 	nameFlag := fs.String("name", "", "Human-readable name for the run")
+	pegFlag := fs.Bool("peg", false, "Use PEG orchestrator system prompt")
 	fs.Parse(os.Args[1:])
 
 	// Generate run ID and create directory.
@@ -47,8 +49,14 @@ func runSubcommand(binPath string) {
 		os.Exit(1)
 	}
 
+		// PEG mode overrides system prompt.
+	sysPrompt := *systemPromptFlag
+	if *pegFlag {
+		sysPrompt = prompt.OrchestratorTemplate()
+	}
+
 	// Build RPC flags to forward.
-	rpcFlags := buildRPCFlags(*sessionFlag, *systemPromptFlag, *maxTurnsFlag, *timeoutFlag, *httpFlag)
+	rpcFlags := buildRPCFlags(*sessionFlag, sysPrompt, *maxTurnsFlag, *timeoutFlag, *httpFlag)
 
 	if runtime.GOOS == "linux" {
 		binPath = "/proc/self/exe"
@@ -190,7 +198,7 @@ func serveSubcommand(binPath string) {
 		inputFlag := fs.String("input", "", "Initial prompt to send after startup")
 	inputFileFlag := fs.String("input-file", "", "Read initial prompt from file (avoids OS ARG_MAX limits)")
 	nameFlag := fs.String("name", "", "Human-readable name for the run")
-	modeFlag := fs.String("mode", "", "Agent mode: default, peg (switches system prompt)")
+	pegFlag := fs.Bool("peg", false, "Use PEG orchestrator system prompt")
 	fs.Parse(os.Args[1:])
 
 	// Generate run ID and create directory.
@@ -207,8 +215,14 @@ func serveSubcommand(binPath string) {
 		os.Exit(1)
 	}
 
+	// PEG mode overrides system prompt.
+	sysPrompt := *systemPromptFlag
+	if *pegFlag {
+		sysPrompt = prompt.OrchestratorTemplate()
+	}
+
 	// Build RPC flags to forward.
-	rpcFlags := buildRPCFlags(*sessionFlag, *systemPromptFlag, *maxTurnsFlag, *timeoutFlag, *httpFlag)
+	rpcFlags := buildRPCFlags(*sessionFlag, sysPrompt, *maxTurnsFlag, *timeoutFlag, *httpFlag)
 
 	if runtime.GOOS == "linux" {
 		binPath = "/proc/self/exe"
@@ -315,14 +329,7 @@ func serveSubcommand(binPath string) {
 			os.Exit(1)
 		}
 		inputText = string(data)
-	}
-
-	// Switch agent mode before sending input.
-	if *modeFlag == "peg" {
-		if err := sendRPCCommand(stdinWriter, "prompt", "/peg"); err != nil {
-			fmt.Fprintf(os.Stderr, "warn: failed to switch to PEG mode: %v\n", err)
 		}
-	}
 
 	if inputText != "" {
 		if err := sendRPCCommand(stdinWriter, "prompt", inputText); err != nil {

--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -818,11 +818,11 @@ func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
 // --- Pretty printing helpers ---
 
 type prettyContentBlock struct {
-	Type     string          `json:"type"`
-	Text     string          `json:"text"`
-	Thinking string          `json:"thinking"`
-	Name     string          `json:"name"`
-	Input    json.RawMessage `json:"input"`
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	Thinking  string          `json:"thinking"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
 }
 
 type prettyMessage struct {
@@ -893,7 +893,11 @@ func prettyPrintAgentEnd(line string) {
 		return
 	}
 
-			for _, msg := range event.Messages {
+				for _, msg := range event.Messages {
+		// Skip tool result messages — output is too verbose.
+		if msg.Role == "toolResult" {
+			continue
+		}
 		for _, block := range msg.Content {
 			switch block.Type {
 			case "text":
@@ -915,10 +919,8 @@ func prettyPrintAgentEnd(line string) {
 					t = t[:300] + "..."
 				}
 				fmt.Printf("thinking: %s\n", t)
-			case "tool_use":
-				fmt.Printf("tool: %s(%s)\n", block.Name, summarizeToolInput(block.Name, block.Input))
-			case "tool_result":
-				// Skip — too verbose. The assistant's text summarizes results.
+			case "toolCall":
+				fmt.Printf("tool: %s(%s)\n", block.Name, summarizeToolInput(block.Name, block.Arguments))
 			}
 		}
 	}

--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -668,6 +668,7 @@ func watchSubcommand() {
 	idFlag := fs.String("id", "", "run ID or prefix (auto-selects by cwd if omitted)")
 	sinceFlag := fs.Int64("since", -1, "start reading from byte offset (machine-readable mode). Use 0 for beginning.")
 	followFlag := fs.Bool("follow", false, "follow mode: continuously stream events until agent exits (machine-readable)")
+	prettyFlag := fs.Bool("pretty", false, "with --follow: format output as readable conversation instead of raw JSONL")
 	fs.Parse(os.Args[1:])
 
 	machineMode := *followFlag || *sinceFlag >= 0
@@ -688,14 +689,14 @@ func watchSubcommand() {
 
 	eventsPath := run.EventsPath("", meta.ID)
 
-		// Follow mode: continuously stream events until agent exits.
+	// Follow mode: continuously stream events until agent exits.
 	if *followFlag {
 		// --follow requires the agent to be running (uses socket stream).
 		if !run.IsRunning(meta) {
 			fmt.Fprintf(os.Stderr, "error: run %s is not running (status: %s), --follow requires a live agent\n", meta.ID, meta.Status)
 			os.Exit(1)
 		}
-		followWatch(meta, 0)
+		followWatch(meta, 0, *prettyFlag)
 		return
 	}
 
@@ -760,7 +761,7 @@ func machineWatch(eventsPath string, offset int64) {
 // followWatch continuously streams events from the agent via socket.
 // It connects to the Unix domain socket and subscribes to the event stream,
 // printing each event line to stdout until the connection closes (agent exits).
-func followWatch(meta *run.RunMeta, fromSeq uint64) {
+func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
 	sockPath := run.SocketPath("", meta.ID)
 
 	client := run.NewSocketClient(sockPath)
@@ -772,16 +773,165 @@ func followWatch(meta *run.RunMeta, fromSeq uint64) {
 	defer conn.Close()
 
 	scanner := bufio.NewScanner(conn)
-	seq := fromSeq
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	if !pretty {
+		// Raw JSONL mode (original behavior).
+		seq := fromSeq
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			fmt.Println(line)
+			seq++
 		}
-		fmt.Println(line)
-		seq++
+		fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
+		return
 	}
-	fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
+
+	// Pretty mode: format agent_end into readable conversation.
+	// Silently consume all events, format on agent_end.
+	var agentEndLine string
+			seq := fromSeq
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			seq++
+
+			// Detect agent_end — contains full message history.
+			if strings.Contains(line, `"agent_end"`) {
+				agentEndLine = line
+			}
+		}
+
+		if agentEndLine != "" {
+			prettyPrintAgentEnd(agentEndLine)
+		} else {
+			fmt.Fprintln(os.Stderr, "--- agent ended without agent_end event ---")
+		}
+		fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
+}
+
+// --- Pretty printing helpers ---
+
+type prettyContentBlock struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text"`
+	Thinking string          `json:"thinking"`
+	Name     string          `json:"name"`
+	Input    json.RawMessage `json:"input"`
+}
+
+type prettyMessage struct {
+	Role    string               `json:"role"`
+	Content []prettyContentBlock `json:"content"`
+}
+
+// summarizeToolInput returns a short summary of a tool call's input.
+func summarizeToolInput(name string, raw json.RawMessage) string {
+	if raw == nil {
+		return ""
+	}
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return string(raw)
+	}
+	switch name {
+	case "bash":
+		if v, ok := input["command"]; ok {
+			s := strings.Trim(string(v), `"`)
+			if len(s) > 120 {
+				return s[:120] + "..."
+			}
+			return s
+		}
+	case "read":
+		if v, ok := input["path"]; ok {
+			return strings.Trim(string(v), `"`)
+		}
+	case "write":
+		if v, ok := input["path"]; ok {
+			return strings.Trim(string(v), `"`)
+		}
+	case "edit":
+		path := ""
+		if v, ok := input["path"]; ok {
+			path = strings.Trim(string(v), `"`)
+		}
+		return path
+	case "grep":
+		parts := []string{}
+		if v, ok := input["pattern"]; ok {
+			parts = append(parts, strings.Trim(string(v), `"`))
+		}
+		if v, ok := input["path"]; ok {
+			parts = append(parts, strings.Trim(string(v), `"`))
+		}
+		return strings.Join(parts, " in ")
+	}
+	// Generic: show first field.
+	for k, v := range input {
+		s := strings.Trim(string(v), `"`)
+		if len(s) > 80 {
+			s = s[:80] + "..."
+		}
+		return k + "=" + s
+	}
+	return ""
+}
+
+// prettyPrintAgentEnd formats the complete conversation from agent_end.
+func prettyPrintAgentEnd(line string) {
+	var event struct {
+		Messages []prettyMessage `json:"messages"`
+	}
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to parse agent_end: %v\n", err)
+		return
+	}
+
+			for _, msg := range event.Messages {
+		for _, block := range msg.Content {
+			switch block.Type {
+			case "text":
+				text := strings.TrimSpace(block.Text)
+				if text == "" {
+					continue
+				}
+				if msg.Role == "user" {
+					fmt.Printf("user: %s\n", text)
+				} else {
+					fmt.Printf("assistant: %s\n", text)
+				}
+			case "thinking":
+				t := strings.TrimSpace(block.Thinking)
+				if t == "" {
+					continue
+				}
+				if len(t) > 300 {
+					t = t[:300] + "..."
+				}
+				fmt.Printf("thinking: %s\n", t)
+			case "tool_use":
+				fmt.Printf("tool: %s(%s)\n", block.Name, summarizeToolInput(block.Name, block.Input))
+			case "tool_result":
+				// Skip — too verbose. The assistant's text summarizes results.
+			}
+		}
+	}
+
+	// Extract stop reason from the raw line.
+	if idx := strings.Index(line, `"stopReason":"`); idx != -1 {
+		start := idx + len(`"stopReason":"`)
+		end := strings.IndexByte(line[start:], '"')
+		if end > 0 {
+			reason := line[start : start+end]
+			fmt.Printf("--- done (stopReason: %s) ---\n", reason)
+		}
+	}
 }
 
 // resolveRunForWatch resolves a run by ID flag or auto-selection.

--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -790,29 +790,59 @@ func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
 		return
 	}
 
-	// Pretty mode: format agent_end into readable conversation.
-	// Silently consume all events, format on agent_end.
-	var agentEndLine string
-			seq := fromSeq
-		for scanner.Scan() {
-			line := scanner.Text()
-			if line == "" {
-				continue
-			}
-			seq++
+	// Pretty mode: stream formatted output in real-time using ParseEvent.
+	// Each incremental event (text_delta, thinking_delta, tool_execution, etc.)
+	// is formatted and printed immediately.
+	seq := fromSeq
+	lastKind := run.EventKind("")
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		seq++
 
-			// Detect agent_end — contains full message history.
-			if strings.Contains(line, `"agent_end"`) {
-				agentEndLine = line
-			}
+		evt := run.ParseEvent(line)
+		if evt == nil {
+			continue
 		}
 
-		if agentEndLine != "" {
-			prettyPrintAgentEnd(agentEndLine)
-		} else {
-			fmt.Fprintln(os.Stderr, "--- agent ended without agent_end event ---")
+		switch evt.Kind {
+		case run.KindText:
+			if lastKind != run.KindText {
+				fmt.Print("\033[0m") // reset if coming from thinking
+			}
+			fmt.Print(evt.Text)
+		case run.KindThinking:
+			if lastKind != run.KindThinking {
+				fmt.Print("\033[2m") // dim
+			}
+			fmt.Print(evt.Text)
+		case run.KindTool:
+			fmt.Print("\033[0m") // reset
+			fmt.Printf("\n\033[36m  %s\033[0m\n", evt.Text)
+		case run.KindMeta:
+			fmt.Print("\033[0m")
+			fmt.Fprintf(os.Stderr, "%s\n", evt.Text)
+		case run.KindResponse:
+			fmt.Print("\033[0m")
+			fmt.Print(evt.Text)
+		case run.KindSessionSwitch:
+			fmt.Fprintf(os.Stderr, "%s\n", evt.Text)
 		}
-		fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
+		if evt.Kind != run.KindMeta && evt.Kind != run.KindSessionSwitch {
+			lastKind = evt.Kind
+		}
+
+		// On agent_end, flush and exit.
+		if strings.Contains(line, `"agent_end"`) {
+			fmt.Print("\033[0m\n")
+			fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
+			return
+		}
+	}
+	fmt.Fprintf(os.Stderr, "--- agent stream ended without agent_end event ---\n")
+	fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
 }
 
 // --- Pretty printing helpers ---

--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -1043,11 +1043,7 @@ func resolveRunForMachineWatch(idFlag string) (*run.RunMeta, error) {
 		return nil, fmt.Errorf("multiple running instances in %s: %v (use --id to select)", cwd, ids)
 	}
 
-	// No running instances — fall back to most recent run in this cwd.
-	if len(running) > 0 {
-		return &running[0], nil
-	}
-	return nil, fmt.Errorf("no runs found in %s", cwd)
+		return nil, fmt.Errorf("no running instances in %s (use --id to select a specific run)", cwd)
 }
 
 // processEvent handles a single parsed event with role-aware streaming.

--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -667,19 +667,41 @@ func watchSubcommand() {
 	fs := flag.NewFlagSet("watch", flag.ExitOnError)
 	idFlag := fs.String("id", "", "run ID or prefix (auto-selects by cwd if omitted)")
 	sinceFlag := fs.Int64("since", -1, "start reading from byte offset (machine-readable mode). Use 0 for beginning.")
+	followFlag := fs.Bool("follow", false, "follow mode: continuously stream events until agent exits (machine-readable)")
 	fs.Parse(os.Args[1:])
 
-	// Resolve the run.
-	meta, err := resolveRunForWatch(*idFlag)
+	machineMode := *followFlag || *sinceFlag >= 0
+
+	// Machine-readable modes (--since, --follow) allow completed runs.
+	// TUI mode requires a running agent (for live socket stream).
+	var meta *run.RunMeta
+	var err error
+	if machineMode {
+		meta, err = resolveRunForMachineWatch(*idFlag)
+	} else {
+		meta, err = resolveRunForWatch(*idFlag)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 
+	eventsPath := run.EventsPath("", meta.ID)
+
+		// Follow mode: continuously stream events until agent exits.
+	if *followFlag {
+		// --follow requires the agent to be running (uses socket stream).
+		if !run.IsRunning(meta) {
+			fmt.Fprintf(os.Stderr, "error: run %s is not running (status: %s), --follow requires a live agent\n", meta.ID, meta.Status)
+			os.Exit(1)
+		}
+		followWatch(meta, 0)
+		return
+	}
+
 	// Machine-readable mode: print raw events + final offset.
 	// This still uses file-based polling since machine mode is a one-shot read.
 	if *sinceFlag >= 0 {
-		eventsPath := run.EventsPath("", meta.ID)
 		machineWatch(eventsPath, *sinceFlag)
 		return
 	}
@@ -731,8 +753,35 @@ func machineWatch(eventsPath string, offset int64) {
 			break
 		}
 	}
-	// Print final offset as last line.
+		// Print final offset as last line.
 	fmt.Printf("__offset:%d\n", lastOffset)
+}
+
+// followWatch continuously streams events from the agent via socket.
+// It connects to the Unix domain socket and subscribes to the event stream,
+// printing each event line to stdout until the connection closes (agent exits).
+func followWatch(meta *run.RunMeta, fromSeq uint64) {
+	sockPath := run.SocketPath("", meta.ID)
+
+	client := run.NewSocketClient(sockPath)
+	conn, _, err := client.Stream(fromSeq)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: cannot connect to agent stream: %v\n", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	scanner := bufio.NewScanner(conn)
+	seq := fromSeq
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		fmt.Println(line)
+		seq++
+	}
+	fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
 }
 
 // resolveRunForWatch resolves a run by ID flag or auto-selection.
@@ -792,7 +841,63 @@ func resolveRunForWatch(idFlag string) (*run.RunMeta, error) {
 		}
 		return nil, fmt.Errorf("multiple running instances in %s: %v (use --id to select)", cwd, ids)
 	}
-	return &alive[0], nil
+		return &alive[0], nil
+}
+
+// resolveRunForMachineWatch resolves a run without requiring it to be running.
+// Used by --since and --follow modes for replaying completed runs.
+func resolveRunForMachineWatch(idFlag string) (*run.RunMeta, error) {
+	if idFlag != "" {
+		// Try exact match first.
+		meta, err := run.LoadRunMeta(run.RunMetaPath("", idFlag))
+		if err == nil {
+			return meta, nil
+		}
+		// Try prefix match.
+		results, err := run.FindByPrefix("", idFlag)
+		if err != nil {
+			return nil, fmt.Errorf("prefix lookup for %q: %w", idFlag, err)
+		}
+		if len(results) == 0 {
+			return nil, fmt.Errorf("no run found matching %q", idFlag)
+		}
+		if len(results) == 1 {
+			return &results[0], nil
+		}
+		return nil, fmt.Errorf("ambiguous prefix %q matches %d runs", idFlag, len(results))
+	}
+
+	// Auto-select by cwd — prefer running, fall back to most recent.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get cwd: %w", err)
+	}
+	running, err := run.FindRunningByCwd("", cwd)
+	if err != nil {
+		return nil, fmt.Errorf("find runs: %w", err)
+	}
+	var alive []run.RunMeta
+	for _, r := range running {
+		if run.IsRunning(&r) {
+			alive = append(alive, r)
+		}
+	}
+	if len(alive) == 1 {
+		return &alive[0], nil
+	}
+	if len(alive) > 1 {
+		ids := make([]string, len(alive))
+		for i, r := range alive {
+			ids[i] = r.ID
+		}
+		return nil, fmt.Errorf("multiple running instances in %s: %v (use --id to select)", cwd, ids)
+	}
+
+	// No running instances — fall back to most recent run in this cwd.
+	if len(running) > 0 {
+		return &running[0], nil
+	}
+	return nil, fmt.Errorf("no runs found in %s", cwd)
 }
 
 // processEvent handles a single parsed event with role-aware streaming.

--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -802,30 +802,48 @@ func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
 		}
 		seq++
 
-		evt := run.ParseEvent(line)
+				evt := run.ParseEvent(line)
 		if evt == nil {
 			continue
 		}
 
+		// On kind transition, add visual separation.
+		transition := evt.Kind != lastKind && lastKind != ""
+		if transition {
+			switch {
+			case lastKind == run.KindThinking && evt.Kind == run.KindText:
+				fmt.Print("\033[0m\n") // end thinking block, new line for response
+			case lastKind == run.KindText && evt.Kind == run.KindThinking:
+				fmt.Print("\n\033[2m") // new line, start thinking block
+			case lastKind == run.KindTool && evt.Kind == run.KindText:
+				fmt.Print("\033[0m") // tool already has its own newlines
+			case evt.Kind == run.KindTool:
+				fmt.Print("\033[0m") // reset before tool
+			default:
+				fmt.Print("\033[0m\n") // generic: reset + newline
+			}
+		}
+
 		switch evt.Kind {
 		case run.KindText:
-			if lastKind != run.KindText {
-				fmt.Print("\033[0m") // reset if coming from thinking
+			if !transition {
+				if lastKind != run.KindText {
+					fmt.Print("\033[0m")
+				}
 			}
 			fmt.Print(evt.Text)
 		case run.KindThinking:
-			if lastKind != run.KindThinking {
-				fmt.Print("\033[2m") // dim
+			if !transition {
+				if lastKind != run.KindThinking {
+					fmt.Print("\033[2m")
+				}
 			}
 			fmt.Print(evt.Text)
 		case run.KindTool:
-			fmt.Print("\033[0m") // reset
-			fmt.Printf("\n\033[36m  %s\033[0m\n", evt.Text)
+			fmt.Printf("\033[36m  %s\033[0m\n", evt.Text)
 		case run.KindMeta:
-			fmt.Print("\033[0m")
 			fmt.Fprintf(os.Stderr, "%s\n", evt.Text)
 		case run.KindResponse:
-			fmt.Print("\033[0m")
 			fmt.Print(evt.Text)
 		case run.KindSessionSwitch:
 			fmt.Fprintf(os.Stderr, "%s\n", evt.Text)

--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -791,8 +791,7 @@ func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
 	}
 
 	// Pretty mode: stream formatted output in real-time using ParseEvent.
-	// Each incremental event (text_delta, thinking_delta, tool_execution, etc.)
-	// is formatted and printed immediately.
+	// No ANSI colors — this output is consumed by agents, not humans.
 	seq := fromSeq
 	lastKind := run.EventKind("")
 	for scanner.Scan() {
@@ -802,45 +801,23 @@ func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
 		}
 		seq++
 
-				evt := run.ParseEvent(line)
+		evt := run.ParseEvent(line)
 		if evt == nil {
 			continue
 		}
 
-		// On kind transition, add visual separation.
-		transition := evt.Kind != lastKind && lastKind != ""
-		if transition {
-			switch {
-			case lastKind == run.KindThinking && evt.Kind == run.KindText:
-				fmt.Print("\033[0m\n") // end thinking block, new line for response
-			case lastKind == run.KindText && evt.Kind == run.KindThinking:
-				fmt.Print("\n\033[2m") // new line, start thinking block
-			case lastKind == run.KindTool && evt.Kind == run.KindText:
-				fmt.Print("\033[0m") // tool already has its own newlines
-			case evt.Kind == run.KindTool:
-				fmt.Print("\033[0m") // reset before tool
-			default:
-				fmt.Print("\033[0m\n") // generic: reset + newline
-			}
+		// On kind transition, add line break for readability.
+		if evt.Kind != lastKind && lastKind != "" && lastKind != run.KindTool {
+			fmt.Println()
 		}
 
 		switch evt.Kind {
 		case run.KindText:
-			if !transition {
-				if lastKind != run.KindText {
-					fmt.Print("\033[0m")
-				}
-			}
 			fmt.Print(evt.Text)
 		case run.KindThinking:
-			if !transition {
-				if lastKind != run.KindThinking {
-					fmt.Print("\033[2m")
-				}
-			}
 			fmt.Print(evt.Text)
 		case run.KindTool:
-			fmt.Printf("\033[36m  %s\033[0m\n", evt.Text)
+			fmt.Printf("  %s\n", evt.Text)
 		case run.KindMeta:
 			fmt.Fprintf(os.Stderr, "%s\n", evt.Text)
 		case run.KindResponse:
@@ -854,7 +831,7 @@ func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
 
 		// On agent_end, flush and exit.
 		if strings.Contains(line, `"agent_end"`) {
-			fmt.Print("\033[0m\n")
+			fmt.Println()
 			fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
 			return
 		}

--- a/docs/design/ai-agent-control.md
+++ b/docs/design/ai-agent-control.md
@@ -1,0 +1,246 @@
+# ai 基础设施：Agent 控制 Agent
+
+## 1. 现状
+
+`ai` 已经有完整的 RPC 协议（prompt、steer、abort、follow-up）和 CLI 子命令（serve、send、watch、kill、ls）。但 agent 想控制另一个 agent 时，存在两个断裂点：
+
+### 问题 1：`ai send` 不能发 steer
+
+`ai send` 把所有消息都当 `prompt` 类型发到 socket。RPC server 的 prompt handler 走 slash 命令分发。
+
+- `/abort` → 已注册为 slash 命令 ✅ → `ai send "/abort"` 可用
+- `/follow-up xxx` → 已注册为 slash 命令 ✅ → `ai send "/follow-up xxx"` 可用
+- `/steer xxx` → **没有注册为 slash 命令** ❌ → `ai send "/steer xxx"` 报 unknown command
+- `/model opus`、`/compact` 等 → 已注册 ✅
+
+`/steer` 只能通过发送 `{"type": "steer", "message": "xxx"}` 这种原生 RPC 命令触发，但 `ai send` 不支持指定命令类型。
+
+### 问题 2：`ai watch` 只有 TUI
+
+`ai watch` 默认启动 Bubble Tea TUI 界面。`--since` 参数提供了一次性文件读取模式（machineWatch），输出原始事件行 + `__offset`。但：
+
+- 一次性读取，不是持续流
+- agent 需要轮询才能获取新事件
+- 没有阻塞等待新事件的能力
+- 没有结构化输出（事件是原始 JSONL，格式随内部实现变化）
+
+### 问题 3：ag 是不必要的中间层
+
+当前 agent 间协作通过 `ag` CLI，它封装了 `ai serve` 的启动和 socket 通信。但 ag 引入了：
+- task/channel 额外抽象
+- 6k+ 行 Go 代码维护负担
+- spawn/wait/prompt/steer 是 ag 定义的 API，不是 `ai` 原生能力
+
+如果 `ai` 本身就提供完整的 agent 控制能力，ag 的核心价值就只剩 task DAG 调度——而这正是 PGE 要替代的。
+
+## 2. 为什么改
+
+目标：**agent 用 `ai` 的 CLI 命令控制其他 agent，跟人类操作体验一致。**
+
+```
+人类操作 agent 的方式：         agent 操作 agent 的方式（改后）：
+ai serve                       ai serve
+ai send "消息"                 ai send "消息"
+ai send "/steer 换方向"        ai send "/steer 换方向"
+ai send "/abort"               ai send "/abort"
+ai send "/model opus"          ai send "/model opus"
+ai watch                       ai watch --follow --output json
+ai kill                        ai kill
+```
+
+完全一样，没有额外抽象。
+
+## 3. 关键设计决策
+
+### 决策 1：所有能力通过 slash 命令暴露
+
+**选择：** `ai send` 始终发 prompt，`/steer`、`/abort`、`/follow-up` 等全部注册为 slash 命令。
+
+**不选：** 给 `ai send` 加 `--type steer` 之类的参数。
+
+理由：
+- 一个入口，心智模型简单
+- 新增能力只需注册 slash handler，不改 `ai send` 代码
+- 跟人类操作方式完全一致
+
+### 决策 2：`ai watch` 增加 `--follow` 持续监听模式
+
+**选择：** `ai watch --follow --output json` 持续输出事件流，直到 agent 结束或被 Ctrl+C。
+
+**不选：** 让 agent 轮询 `ai watch --since`。
+
+理由：
+- 轮询浪费且有延迟
+- `--follow` 是 Unix 惯例（`tail -f`）
+- agent 可以作为子进程启动 `ai watch --follow`，读 stdout 获取实时事件
+
+### 决策 3：ag 暂时保留但不作为 PGE 的依赖
+
+ag 不删不废，但 PGE 架构直接基于 `ai` CLI 构建。ag 作为遗留方案保留给不想迁移的场景。
+
+## 4. 怎么做
+
+### 4.1 注册 `/steer` 为 slash 命令
+
+**文件：** `cmd/ai/rpc_help_handlers.go`
+
+在 `registerHelpHandlers()` 中添加：
+
+```go
+// /steer
+app.server.RegisterSlash("steer", "Inject mid-conversation guidance", func(args string) (any, error) {
+    message := strings.TrimSpace(args)
+    if message == "" {
+        return nil, fmt.Errorf("usage: /steer <message>")
+    }
+    expandedMessage := app.expandSkillCommands(message)
+    app.stateMu.Lock()
+    mode := app.steeringMode
+    pending := app.pendingSteer
+    streaming := app.isStreaming
+    app.stateMu.Unlock()
+    if mode == "one-at-a-time" && pending {
+        return nil, fmt.Errorf("steer already pending")
+    }
+    if !streaming {
+        app.compactBeforeRequest("pre_request_steer")
+    }
+    app.stateMu.Lock()
+    app.pendingSteer = true
+    app.stateMu.Unlock()
+    app.ag.Steer(expandedMessage)
+    return map[string]any{"status": "steered"}, nil
+})
+```
+
+注意：这段逻辑跟 `handleSteer`（rpc_app.go:677）基本一样。理想情况应该复用，但 `handleSteer` 从 RPCCommand 取 message 的方式跟 slash handler 从 args 取不一样。可以做一个小重构：
+
+```go
+func (app *rpcApp) steerAgent(message string) (any, error) {
+    message = strings.TrimSpace(message)
+    if message == "" {
+        return nil, fmt.Errorf("empty steer message")
+    }
+    expandedMessage := app.expandSkillCommands(message)
+    // ... 共用的状态检查和 Steer 调用 ...
+    app.ag.Steer(expandedMessage)
+    return nil, nil
+}
+```
+
+然后 `handleSteer` 和 slash handler 都调 `steerAgent`。
+
+### 4.2 `ai watch --follow` 持续监听模式
+
+**文件：** `cmd/ai/watch.go`
+
+新增 `--follow` flag：
+
+```
+ai watch --follow              # 持续输出事件（默认格式：每行一个 JSON 事件）
+ai watch --follow --output json # 同上，显式 json
+ai watch --since 0             # 一次性读取（现有行为不变）
+ai watch                       # TUI（现有行为不变）
+```
+
+实现思路：
+
+```
+--follow 模式:
+1. 读 events 文件从 offset 0 开始（或 --since 指定的 offset）
+2. 输出到 stdout，每行一个 JSON 事件
+3. 文件读到末尾后，poll 间隔 200ms 继续读
+4. 检测到 agent 进程退出（读 run.json 的 status 字段）→ 输出完剩余事件后退出
+5. 每个事件后跟一个 __offset:NNN 行（跟现有 --since 模式一致）
+```
+
+为什么用文件 poll 而不是 socket stream：
+- 文件 poll 实现简单，不需要维护 socket 连接
+- events 文件本身就是 append-only JSONL，天然适合 tail
+- agent 进程退出后文件还在，不会丢失最后几个事件
+- 200ms 延迟对 agent 间通信可接受
+
+### 4.3 agent 控制命令速查
+
+改完后，agent 控制 agent 的完整命令集：
+
+```bash
+# 启动一个 agent
+ai serve --input "初始 prompt" --system-prompt "@prompt.md" --session /path/to/session
+
+# 发送消息（等 agent 空闲时处理）
+ai send "继续实现下一个功能"
+
+# 中途给方向（agent 正在工作时）
+ai send "/steer 优先处理错误处理逻辑"
+
+# 排队消息（agent 忙完后自动处理）
+ai send "/follow-up 做完后跑一下测试"
+
+# 取消当前操作
+ai send "/abort"
+
+# 切换模型
+ai send "/model opus"
+
+# 压缩上下文
+ai send "/compact"
+
+# 查看实时输出
+ai watch --follow
+
+# 查看一次性历史输出
+ai watch --since 0
+
+# 终止 agent
+ai kill
+
+# 列出运行中的 agent
+ai ls
+```
+
+### 4.4 事件输出格式
+
+`ai watch --follow` 输出的事件需要让 agent 能解析。当前 events 文件里的格式：
+
+```jsonl
+{"type":"text_delta","text":"Hello","turn":1,"seq":1}
+{"type":"tool_execution_start","toolName":"bash","args":{"command":"ls"},"seq":2}
+{"type":"tool_execution_end","toolName":"bash","result":"...","seq":3}
+{"type":"agent_end","seq":4}
+```
+
+`--follow` 直接输出原始 JSONL 行，agent 用 `jq` 或代码解析即可。关键是 `agent_end` 事件——agent 用它判断 subagent 做完了。
+
+## 5. 验收场景
+
+### P0: `/steer` slash 命令
+
+**Acceptance Scenarios:**
+1. `ai serve` 启动后，`ai send "/steer 换个思路"` 成功执行，agent 收到 steer 消息并调整方向
+2. agent 不在 streaming 状态时发 `/steer`，自动触发 compact 后再执行
+3. 空 steer 消息 `ai send "/steer"` 返回错误提示
+4. 跟 `handleSteer` RPC 命令行为一致（skill expansion、pending 检查等）
+
+### P0: `ai watch --follow` 持续监听
+
+**Acceptance Scenarios:**
+1. `ai watch --follow` 启动后持续输出事件，每行一个 JSON
+2. agent 完成后输出 `agent_end` 事件然后 `watch` 进程退出
+3. `--since` 和 `--follow` 可以组合使用：先读历史，再持续跟新事件
+4. Ctrl+C 能干净退出，不丢已读事件的 __offset
+5. agent 被 kill 后，`watch --follow` 检测到进程退出，输出完剩余事件后退出
+
+### P1: agent 间协作端到端验证
+
+**Acceptance Scenarios:**
+1. 用 `ai serve` 启动 subagent → `ai send` 发任务 → `ai watch --follow` 看到完成 → `ai kill` 清理
+2. subagent 工作中发 `ai send "/steer xxx"` → subagent 实际改变方向
+3. subagent 工作中发 `ai send "/abort"` → subagent 停止当前操作
+
+## 6. 边界条件
+
+- **send 超时**：`ai send` 当前有 30s socket 超时。如果 agent 正在忙（LLM 调用中），prompt 和 slash 命令会排队。steer 和 follow-up 不受此限制（它们是异步的）。需要确认 30s 超时是否足够。
+- **watch --follow 的退出检测**：怎么判断 agent 进程退出了？检查 run.json 的 status 字段，或者检查 agent 进程 PID 是否存活。文件 poll 的好处是不依赖 socket 连接，坏处是需要额外的退出检测机制。
+- **并发 send**：多个 agent 同时给一个 subagent 发 send，socket 是串行的，不会有并发问题。但逻辑上可能有 steer 和 prompt 冲突。
+- **session 文件冲突**：多个 `ai serve` 不能共用同一个 session 文件。这已经是现有行为（`ai ls` 按 cwd 区分），不需要额外处理。

--- a/pkg/prompt/builder.go
+++ b/pkg/prompt/builder.go
@@ -28,6 +28,9 @@ var compactUpdatePrompt string
 //go:embed "context_management.md"
 var contextManagementSystemPrompt string
 
+//go:embed "orchestrator.md"
+var orchestratorTemplate string
+
 // CompactorBasePrompt returns the baseline prompt used by compactor requests.
 func CompactorBasePrompt() string {
 	return "You are a context management assistant. You are called periodically by the system to maintain conversation context health."
@@ -79,6 +82,9 @@ type Builder struct {
 
 	// Skill usage stats (optional, for progressive disclosure)
 	skillStats *skill.SkillStatsFile
+
+		// Custom template (if empty, uses embedded promptTemplate)
+	template string
 
 	// Context meta (for runtime_state telemetry, set by agent loop)
 	contextMeta string
@@ -162,6 +168,12 @@ func (b *Builder) SetSkillStats(stats *skill.SkillStatsFile) *Builder {
 	return b
 }
 
+// SetTemplate sets a custom prompt template. If empty, uses the default embedded prompt.md.
+func (b *Builder) SetTemplate(t string) *Builder {
+	b.template = t
+	return b
+}
+
 // SetContextMeta sets the runtime_state telemetry metadata.
 func (b *Builder) SetContextMeta(meta string) *Builder {
 	b.contextMeta = meta
@@ -177,6 +189,9 @@ func (b *Builder) SetTokensPercent(pct float64) *Builder {
 // Build builds final system prompt by replacing placeholders in the template.
 func (b *Builder) Build() string {
 	result := promptTemplate
+	if b.template != "" {
+		result = b.template
+	}
 
 	// Replace workspace section (optional - empty when noWorkspace is true)
 	workspaceSection := ""
@@ -337,4 +352,9 @@ func NormalizeThinkingLevel(level string) string {
 // ContextManagementSystemPrompt returns system prompt for context management.
 func ContextManagementSystemPrompt() string {
 	return contextManagementSystemPrompt
+}
+
+// OrchestratorTemplate returns the PEG orchestrator prompt template.
+func OrchestratorTemplate() string {
+	return orchestratorTemplate
 }

--- a/pkg/prompt/builder.go
+++ b/pkg/prompt/builder.go
@@ -31,6 +31,9 @@ var contextManagementSystemPrompt string
 //go:embed "orchestrator.md"
 var orchestratorTemplate string
 
+//go:embed "validator.md"
+var validatorTemplate string
+
 // CompactorBasePrompt returns the baseline prompt used by compactor requests.
 func CompactorBasePrompt() string {
 	return "You are a context management assistant. You are called periodically by the system to maintain conversation context health."
@@ -354,7 +357,12 @@ func ContextManagementSystemPrompt() string {
 	return contextManagementSystemPrompt
 }
 
-// OrchestratorTemplate returns the PEG orchestrator prompt template.
+// OrchestratorTemplate returns the PGE orchestrator prompt template.
 func OrchestratorTemplate() string {
 	return orchestratorTemplate
+}
+
+// ValidatorTemplate returns the PGE validator prompt template.
+func ValidatorTemplate() string {
+	return validatorTemplate
 }

--- a/pkg/prompt/builder.go
+++ b/pkg/prompt/builder.go
@@ -366,3 +366,19 @@ func OrchestratorTemplate() string {
 func ValidatorTemplate() string {
 	return validatorTemplate
 }
+
+// TemplateForRole returns the system prompt template for the given role.
+// Supported roles: "coder" (default), "orchestrator", "validator".
+// Returns empty string for unknown roles.
+func TemplateForRole(role string) (string, error) {
+	switch role {
+	case "", "coder":
+		return promptTemplate, nil
+	case "orchestrator":
+		return orchestratorTemplate, nil
+	case "validator":
+		return validatorTemplate, nil
+	default:
+		return "", fmt.Errorf("unknown role %q (valid: coder, orchestrator, validator)", role)
+	}
+}

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -51,10 +51,25 @@ tmux capture-pane -t "gen-NNN" -p -S -50       # See agent stderr
 
 | Role | Purpose |
 |------|---------|
-| **Generator** | Implements code, fixes bugs, executes tasks |
-| **Validator** | Validates completed work against spec acceptance criteria |
+| **Generator** | Implements code, fixes bugs, executes tasks. **MUST NOT write test files.** |
+| **Validator** | Validates completed work against spec acceptance criteria. **Must be independent agent, writes its own tests from spec.** |
 
 Both are normal `ai serve` instances (default coding agent prompt).
+
+### ⚠️ CRITICAL: Role Separation
+
+**Generator 写测试 = 自己考自己 = 没有验证。** 这是最常见的 PGE 失败模式。
+
+| 谁 | 做什么 | 不做什么 |
+|----|--------|----------|
+| Generator | 实现功能代码，确保 `go build` 通过 | ❌ 不写测试、不修改 spec |
+| Validator | 从 spec 验收标准写独立测试，逐条验证 | ❌ 不看 Generator 的实现代码 |
+
+**Generator Task 指令必须包含：**
+> 只实现功能代码，不需要写测试文件。确保 go build ./... 通过。
+
+**Validator Task 指令必须包含：**
+> 你是独立验证者。不要查看实现代码。对 spec.md 中每条验收标准写独立测试来验证。
 
 ## Execution Model
 
@@ -71,9 +86,13 @@ Both are normal `ai serve` instances (default coding agent prompt).
 You dynamically create tasks and delegate:
 
 1. Create task files in `.pge/tasks/` (e.g., `001-add-auth.md`)
-2. Spawn a Generator sub-agent for each task (via tmux pattern above)
+2. Spawn a **Generator** sub-agent for each task (via tmux pattern)
+   - Task MUST say "不需要写测试文件，确保 go build 通过"
 3. Monitor progress via `ai watch --follow`
-4. When enough tasks are done, spawn a Validator
+4. **MANDATORY: After Generator completes, spawn an independent Validator**
+   - Validator MUST be a separate tmux session
+   - Validator MUST write tests from spec acceptance criteria, NOT from Generator's output
+   - Validator MUST NOT look at implementation code
 5. Review validation results — fix, retry, or adjust plan
 6. Loop until all acceptance criteria pass
 

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -93,7 +93,7 @@ Generator uses default coding prompt. Validator uses dedicated `validator.md` pr
 Validator 的验证方式由它自己决定——代码 review、写测试、运行构建检查、行为验证等均可。关键是它的结论是独立的。
 
 **Generator Task 指令必须包含：**
-> 只实现功能代码，不需要写测试文件。确保 go build ./... 通过。
+> Read .pge/spec.md and .pge/state.md for context. 只实现功能代码，不需要写测试文件。确保 go build ./... 通过。完成后列出修改的文件。
 
 **Validator Task 指令：**
 > Generator 完成了 <task>。独立验证 .pge/spec.md 的验收标准。验证方式由你决定。
@@ -116,12 +116,57 @@ You dynamically create tasks and delegate:
 2. Spawn a **Generator** sub-agent for each task (via tmux pattern)
    - Task MUST say "不需要写测试文件，确保 go build 通过"
 3. Monitor progress via `ai watch --follow`
-4. **MANDATORY: After Generator completes, spawn an independent Validator**
+4. **After each Generator completes, update `.pge/state.md`** — this is how subsequent generators know what changed
+5. **MANDATORY: After Generator completes, spawn an independent Validator**
    - Validator MUST be a separate tmux session with `--system-prompt @.pge/validator.md`
    - Validator decides its own validation method (review, tests, build checks, etc.)
    - **Only Validator's assessment counts as "done"** — Generator's self-report is meaningless
-5. Review validation results — fix, retry, or adjust plan based on Validator's feedback
-6. Loop until all acceptance criteria pass
+6. Review validation results — fix, retry, or adjust plan based on Validator's feedback
+7. Loop until all acceptance criteria pass
+
+### ⚠️ State Sync Between Generators
+
+Each generator runs in isolation — it does NOT know what other generators did. You must bridge this gap.
+
+**After every generator completes, write `.pge/state.md`:**
+
+```markdown
+# State
+
+## Completed
+- 001-add-auth: created src/auth/jwt.go, src/middleware/auth.go
+- 002-add-users: created src/models/user.go, modified src/db/schema.sql
+
+## Current File Map
+- src/auth/jwt.go — JWT token generation and validation
+- src/middleware/auth.go — HTTP auth middleware
+- src/models/user.go — User model
+- src/db/schema.sql — Added users table
+
+## Key Decisions
+- Using HMAC-SHA256 for JWT signing
+- User IDs are UUIDs
+```
+
+**Every generator task MUST start with:** "Read .pge/spec.md and .pge/state.md for context."
+
+### ⚠️ Parallel Task File Scope
+
+When spawning parallel generators, their file scopes MUST NOT overlap. Before spawning:
+
+1. Each parallel task declares which files it will modify/create
+2. You verify: no file appears in more than one parallel task
+3. If overlap exists → make them sequential, or split the contested file to one task
+
+```
+# ✅ Safe parallel: disjoint file sets
+gen-001: src/backend/*.go
+gen-002: src/frontend/*.tsx
+
+# ❌ Unsafe: both touch src/models/user.go
+gen-001: src/backend/*.go, src/models/user.go
+gen-002: src/frontend/*.tsx, src/models/user.go
+```
 
 ### Phase 3: Report
 - Summarize: what was done, deviations, final state
@@ -163,9 +208,11 @@ Generator is done when you see `agent_end`. Check last message's `stopReason`:
 ```
 .pge/
   spec.md          # Requirements + acceptance criteria (Phase 1 output)
+  state.md         # Current state — updated after each generator (Phase 2)
   tasks/
     001-xxx.md     # Task description (you create dynamically)
   progress.md      # Execution log (append-only)
+  validator.md     # Validator system prompt (auto-created by --peg)
 ```
 
 %WORKSPACE_SECTION%

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -63,7 +63,7 @@ cat /tmp/pge-val-NNN.log
 tmux kill-session -t "val-NNN" 2>/dev/null
 ```
 
-The `validator.md` file should be written to `.pge/validator.md` by the orchestrator at the start of execution. It instructs the agent to ONLY write tests, NEVER read implementation source, and validate against spec acceptance criteria.
+The `.pge/validator.md` file is auto-created by `ai serve --peg` at startup. It tells the validator agent to act as an independent judge — free to use any validation method, but must reach its own conclusions.
 
 ### Health Check
 
@@ -77,24 +77,26 @@ tmux capture-pane -t "gen-NNN" -p -S -50       # See agent stderr
 | Role | Purpose |
 |------|---------|
 | **Generator** | Implements code, fixes bugs, executes tasks. **MUST NOT write test files.** |
-| **Validator** | Validates completed work against spec acceptance criteria. **Must be independent agent, writes its own tests from spec.** |
+| **Validator** | Independent judge. Validates that work is actually done. Uses any method it chooses (review, tests, build checks, behavioral verification). **Only Validator's assessment counts as "done".** |
 
-Both are normal `ai serve` instances (default coding agent prompt).
+Generator uses default coding prompt. Validator uses dedicated `validator.md` prompt (auto-created by `--peg`).
 
 ### ⚠️ CRITICAL: Role Separation
 
-**Generator 写测试 = 自己考自己 = 没有验证。** 这是最常见的 PGE 失败模式。
+**Generator 说"完成了"不算数。只有 Validator 独立确认的完成才算数。** 这是最常见的 PGE 失败模式。
 
 | 谁 | 做什么 | 不做什么 |
 |----|--------|----------|
 | Generator | 实现功能代码，确保 `go build` 通过 | ❌ 不写测试、不修改 spec |
-| Validator | 从 spec 验收标准写独立测试，逐条验证 | ❌ 不看 Generator 的实现代码 |
+| Validator | **独立裁判**。用任何方式确认完成标准（review、测试、构建检查、行为验证等） | ❌ 不修改非测试源文件 |
+
+Validator 的验证方式由它自己决定——代码 review、写测试、运行构建检查、行为验证等均可。关键是它的结论是独立的。
 
 **Generator Task 指令必须包含：**
 > 只实现功能代码，不需要写测试文件。确保 go build ./... 通过。
 
-**Validator Task 指令必须包含：**
-> 你是独立验证者。不要查看实现代码。对 spec.md 中每条验收标准写独立测试来验证。
+**Validator Task 指令：**
+> Generator 完成了 <task>。独立验证 .pge/spec.md 的验收标准。验证方式由你决定。
 
 ## Execution Model
 
@@ -115,10 +117,10 @@ You dynamically create tasks and delegate:
    - Task MUST say "不需要写测试文件，确保 go build 通过"
 3. Monitor progress via `ai watch --follow`
 4. **MANDATORY: After Generator completes, spawn an independent Validator**
-   - Validator MUST be a separate tmux session
-   - Validator MUST write tests from spec acceptance criteria, NOT from Generator's output
-   - Validator MUST NOT look at implementation code
-5. Review validation results — fix, retry, or adjust plan
+   - Validator MUST be a separate tmux session with `--system-prompt @.pge/validator.md`
+   - Validator decides its own validation method (review, tests, build checks, etc.)
+   - **Only Validator's assessment counts as "done"** — Generator's self-report is meaningless
+5. Review validation results — fix, retry, or adjust plan based on Validator's feedback
 6. Loop until all acceptance criteria pass
 
 ### Phase 3: Report

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -1,4 +1,4 @@
-You are a PEG (Planner-Executor-Guard) orchestrator. You break down complex requests into tasks and delegate to specialist sub-agents. You coordinate work but NEVER implement code yourself.
+You are a PGE (Planner-Generator-Executor) orchestrator. You break down complex requests into tasks and delegate to specialist sub-agents. You coordinate work but NEVER implement code yourself.
 
 ## Core Principle
 
@@ -17,7 +17,7 @@ You are a PEG (Planner-Executor-Guard) orchestrator. You break down complex requ
 
 ### Phase 1: Requirements Alignment
 - Discuss with the user to understand requirements
-- Produce `.peg/spec.md` with:
+- Produce `.pge/spec.md` with:
   - Goal (one-sentence summary)
   - Acceptance criteria (specific, verifiable)
   - Technical constraints
@@ -27,7 +27,7 @@ You are a PEG (Planner-Executor-Guard) orchestrator. You break down complex requ
 ### Phase 2: Automated Execution
 You dynamically create tasks and delegate:
 
-1. Create task files in `.peg/tasks/` (e.g., `001-add-auth.md`)
+1. Create task files in `.pge/tasks/` (e.g., `001-add-auth.md`)
 2. Spawn a Generator sub-agent for each task
 3. Monitor progress via event stream
 4. When enough tasks are done, spawn a Validator
@@ -81,7 +81,7 @@ A Generator is done when you see `agent_end`. Check `stopReason`:
 ## File Conventions
 
 ```
-.peg/
+.pge/
   spec.md          # Requirements + acceptance criteria (Phase 1 output)
   tasks/
     001-xxx.md     # Task description (you create dynamically)
@@ -116,7 +116,7 @@ A Generator is done when you see `agent_end`. Check `stopReason`:
 ## Safety Rules
 
 - Same task failing 3 times → pause and report to user
-- User can modify `.peg/spec.md` at any time → re-evaluate affected tasks
+- User can modify `.pge/spec.md` at any time → re-evaluate affected tasks
 - Never delete or modify code you didn't create through sub-agents
 - Always commit after each successful Generator run
 
@@ -141,7 +141,7 @@ When delegating, describe WHAT needs to be done (the outcome), not HOW to do it.
 
 - **bash**: Use for `ai serve`/`ai send`/`ai watch`/`ai kill` sub-agent control. Default 2min timeout; use `timeout` for longer tasks.
 - **read**: Read task files, spec, progress log, and sub-agent output.
-- **write**: Create task files in `.peg/tasks/`, update `spec.md` and `progress.md`.
+- **write**: Create task files in `.pge/tasks/`, update `spec.md` and `progress.md`.
 - **grep**: Search codebase for context before creating tasks.
 
 ### Selection Strategy

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -40,6 +40,31 @@ ai send --id "$RUN_ID" "/steer <correction>"   # Adjust direction
 ai kill --id "$RUN_ID"                          # Terminate
 ```
 
+### Validator Spawn Pattern
+
+Validator MUST use dedicated system prompt for role separation:
+
+```bash
+# 1. Spawn validator with validator.md system prompt
+tmux new-session -d -s "val-NNN" \
+  "ai serve --name 'val-NNN-task-name' --system-prompt @.pge/validator.md"
+sleep 1
+VAL_ID=$(tmux capture-pane -t "val-NNN" -p | head -1)
+
+# 2. Watch and send validation task
+ai watch --follow --pretty --id "$VAL_ID" > /tmp/pge-val-NNN.log 2>&1 &
+WATCH_PID=$!
+sleep 0.5
+
+ai send --id "$VAL_ID" "验证 .pge/spec.md 中的验收标准。对每条写独立测试。"
+
+timeout 600 wait $WATCH_PID
+cat /tmp/pge-val-NNN.log
+tmux kill-session -t "val-NNN" 2>/dev/null
+```
+
+The `validator.md` file should be written to `.pge/validator.md` by the orchestrator at the start of execution. It instructs the agent to ONLY write tests, NEVER read implementation source, and validate against spec acceptance criteria.
+
 ### Health Check
 
 ```bash

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -45,9 +45,9 @@ ai kill --id "$RUN_ID"                          # Terminate
 Validator MUST use dedicated system prompt for role separation:
 
 ```bash
-# 1. Spawn validator with validator.md system prompt
+# 1. Spawn validator with dedicated system prompt
 tmux new-session -d -s "val-NNN" \
-  "ai serve --name 'val-NNN-task-name' --system-prompt @.pge/validator.md"
+  "ai serve --name 'val-NNN-task-name' --role validator"
 sleep 1
 VAL_ID=$(tmux capture-pane -t "val-NNN" -p | head -1)
 
@@ -63,7 +63,7 @@ cat /tmp/pge-val-NNN.log
 tmux kill-session -t "val-NNN" 2>/dev/null
 ```
 
-The `.pge/validator.md` file is auto-created by `ai serve --peg` at startup. It tells the validator agent to act as an independent judge — free to use any validation method, but must reach its own conclusions.
+The `--role validator` flag loads the validator system prompt from the embedded binary. No file management needed — the prompt is compiled into `ai`.
 
 ### Health Check
 
@@ -79,7 +79,7 @@ tmux capture-pane -t "gen-NNN" -p -S -50       # See agent stderr
 | **Generator** | Implements code, fixes bugs, executes tasks. **MUST NOT write test files.** |
 | **Validator** | Independent judge. Validates that work is actually done. Uses any method it chooses (review, tests, build checks, behavioral verification). **Only Validator's assessment counts as "done".** |
 
-Generator uses default coding prompt. Validator uses dedicated `validator.md` prompt (auto-created by `--peg`).
+Generator uses default coding prompt. Validator uses `--role validator` (embedded prompt). Orchestrator uses `--role orchestrator` (embedded prompt).
 
 ### ⚠️ CRITICAL: Role Separation
 
@@ -118,7 +118,7 @@ You dynamically create tasks and delegate:
 3. Monitor progress via `ai watch --follow`
 4. **After each Generator completes, update `.pge/state.md`** — this is how subsequent generators know what changed
 5. **MANDATORY: After Generator completes, spawn an independent Validator**
-   - Validator MUST be a separate tmux session with `--system-prompt @.pge/validator.md`
+      - Validator MUST be a separate tmux session with `--role validator`
    - Validator decides its own validation method (review, tests, build checks, etc.)
    - **Only Validator's assessment counts as "done"** — Generator's self-report is meaningless
 6. Review validation results — fix, retry, or adjust plan based on Validator's feedback
@@ -212,7 +212,6 @@ Generator is done when you see `agent_end`. Check last message's `stopReason`:
   tasks/
     001-xxx.md     # Task description (you create dynamically)
   progress.md      # Execution log (append-only)
-  validator.md     # Validator system prompt (auto-created by --peg)
 ```
 
 %WORKSPACE_SECTION%

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -1,0 +1,155 @@
+You are a PEG (Planner-Executor-Guard) orchestrator. You break down complex requests into tasks and delegate to specialist sub-agents. You coordinate work but NEVER implement code yourself.
+
+## Core Principle
+
+- **You plan, delegate, and validate.** You do not write implementation code.
+- **You are the sole orchestrator.** All feedback from sub-agents flows through you.
+- **User participates in planning only.** Execution phase is fully autonomous.
+
+## Sub-Agents
+
+| Role | Purpose |
+|------|---------|
+| **Generator** | Implements code, fixes bugs, executes tasks |
+| **Validator** | Validates completed work against spec acceptance criteria |
+
+## Execution Model
+
+### Phase 1: Requirements Alignment
+- Discuss with the user to understand requirements
+- Produce `.peg/spec.md` with:
+  - Goal (one-sentence summary)
+  - Acceptance criteria (specific, verifiable)
+  - Technical constraints
+  - Out of scope
+- User confirms → enter Phase 2
+
+### Phase 2: Automated Execution
+You dynamically create tasks and delegate:
+
+1. Create task files in `.peg/tasks/` (e.g., `001-add-auth.md`)
+2. Spawn a Generator sub-agent for each task
+3. Monitor progress via event stream
+4. When enough tasks are done, spawn a Validator
+5. Review validation results — fix, retry, or adjust plan
+6. Loop until all acceptance criteria pass
+
+### Phase 3: Report
+- Summarize: what was done, deviations, final state
+- User can review and request changes
+
+## Sub-Agent Control via `ai` CLI
+
+### Spawn and run a sub-agent
+```bash
+# 1. Start agent (outputs run ID)
+RUN_ID=$(ai serve --name "gen-001-add-auth")
+
+# 2. Send task instruction
+ai send "<task description>" --id $RUN_ID
+
+# 3. Watch output stream (continuous JSONL, exits when agent finishes)
+ai watch --follow --id $RUN_ID
+
+# 4. Kill if needed
+ai kill --id $RUN_ID
+```
+
+### Control a running agent
+```bash
+# Inject guidance mid-execution
+ai send "/steer <guidance>" --id $RUN_ID
+
+# Abort execution
+ai send "/abort" --id $RUN_ID
+
+# Queue follow-up message
+ai send "/follow-up <message>" --id $RUN_ID
+```
+
+### Parse agent output
+`ai watch --follow` outputs JSONL events. Key event types:
+- `agent_start` — Agent began
+- `message_update` — Streaming text delta (look for `assistantMessageEvent.type`)
+- `turn_end` — One turn complete (has final message with usage stats)
+- `agent_end` — Agent finished (has full message history)
+
+A Generator is done when you see `agent_end`. Check `stopReason`:
+- `"stop"` = completed normally
+- `"tool_use"` = stopped mid-tool (may need follow-up)
+
+## File Conventions
+
+```
+.peg/
+  spec.md          # Requirements + acceptance criteria (Phase 1 output)
+  tasks/
+    001-xxx.md     # Task description (you create dynamically)
+    002-xxx.md
+  progress.md      # Execution log (append-only)
+```
+
+### Task file format
+```markdown
+# Task: <short description>
+
+## Goal
+<what this task accomplishes>
+
+## Scope
+<files/modules to touch>
+
+## Notes
+<deviations or observations during execution>
+```
+
+## Parallelization Rules
+
+**PARALLEL when:**
+- Tasks touch different files
+- Tasks have no data dependencies
+
+**SEQUENTIAL when:**
+- Task B needs output from Task A
+- Tasks modify the same file
+
+## Safety Rules
+
+- Same task failing 3 times → pause and report to user
+- User can modify `.peg/spec.md` at any time → re-evaluate affected tasks
+- Never delete or modify code you didn't create through sub-agents
+- Always commit after each successful Generator run
+
+## Delegation Rules
+
+When delegating, describe WHAT needs to be done (the outcome), not HOW to do it.
+
+### ✅ CORRECT
+- "Fix the infinite loop error in SideMenu"
+- "Add a settings panel for the chat interface"
+- "Implement user authentication with JWT"
+
+### ❌ WRONG
+- "Fix the bug by wrapping the selector with useShallow"
+- "Add a button that calls handleClick and updates state"
+
+%WORKSPACE_SECTION%
+
+## Tools
+
+### Usage Rules
+
+- **bash**: Use for `ai serve`/`ai send`/`ai watch`/`ai kill` sub-agent control. Default 2min timeout; use `timeout` for longer tasks.
+- **read**: Read task files, spec, progress log, and sub-agent output.
+- **write**: Create task files in `.peg/tasks/`, update `spec.md` and `progress.md`.
+- **grep**: Search codebase for context before creating tasks.
+
+### Selection Strategy
+
+**Planning:** Read spec → break into tasks → create task files → spawn generators.
+**Monitoring:** `ai watch --follow` → parse output → decide next action.
+**Validating:** Spawn validator → check acceptance criteria → report results.
+
+%SKILLS%
+
+%PROJECT_CONTEXT%

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -6,12 +6,55 @@ You are a PGE (Planner-Generator-Executor) orchestrator. You break down complex 
 - **You are the sole orchestrator.** All feedback from sub-agents flows through you.
 - **User participates in planning only.** Execution phase is fully autonomous.
 
+## ⚠️ CRITICAL: ai serve is BLOCKING
+
+`ai serve` blocks until the agent finishes. You MUST wrap it in tmux. NEVER call `ai serve` directly.
+
+### Spawn Pattern (ALWAYS use this)
+
+```bash
+# 1. Spawn in tmux
+tmux new-session -d -s "gen-NNN" "ai serve --name 'gen-NNN-task-name'"
+sleep 1
+RUN_ID=$(tmux capture-pane -t "gen-NNN" -p | head -1)
+
+# 2. Watch before send (avoid missing early events)
+ai watch --follow --id "$RUN_ID" > /tmp/pge-gen-NNN.jsonl 2>&1 &
+WATCH_PID=$!
+sleep 0.5
+
+# 3. Send task
+ai send --id "$RUN_ID" "<task instruction>"
+
+# 4. Wait with timeout
+timeout 600 wait $WATCH_PID
+
+# 5. Parse result from agent_end event
+# 6. Cleanup: tmux kill-session -t "gen-NNN"
+```
+
+### Mid-Run Control
+
+```bash
+ai send --id "$RUN_ID" "/steer <correction>"   # Adjust direction
+ai kill --id "$RUN_ID"                          # Terminate
+```
+
+### Health Check
+
+```bash
+ai ls --json                                    # Check all run statuses
+tmux capture-pane -t "gen-NNN" -p -S -50       # See agent stderr
+```
+
 ## Sub-Agents
 
 | Role | Purpose |
 |------|---------|
 | **Generator** | Implements code, fixes bugs, executes tasks |
 | **Validator** | Validates completed work against spec acceptance criteria |
+
+Both are normal `ai serve` instances (default coding agent prompt).
 
 ## Execution Model
 
@@ -28,8 +71,8 @@ You are a PGE (Planner-Generator-Executor) orchestrator. You break down complex 
 You dynamically create tasks and delegate:
 
 1. Create task files in `.pge/tasks/` (e.g., `001-add-auth.md`)
-2. Spawn a Generator sub-agent for each task
-3. Monitor progress via event stream
+2. Spawn a Generator sub-agent for each task (via tmux pattern above)
+3. Monitor progress via `ai watch --follow`
 4. When enough tasks are done, spawn a Validator
 5. Review validation results — fix, retry, or adjust plan
 6. Loop until all acceptance criteria pass
@@ -38,45 +81,36 @@ You dynamically create tasks and delegate:
 - Summarize: what was done, deviations, final state
 - User can review and request changes
 
-## Sub-Agent Control via `ai` CLI
+## Delegation Rules
 
-### Spawn and run a sub-agent
-```bash
-# 1. Start agent (outputs run ID)
-RUN_ID=$(ai serve --name "gen-001-add-auth")
+Describe WHAT needs to be done (the outcome), not HOW to do it.
 
-# 2. Send task instruction
-ai send "<task description>" --id $RUN_ID
+### ✅ CORRECT
+- "Fix the infinite loop error in SideMenu"
+- "Implement user authentication with JWT"
 
-# 3. Watch output stream (continuous JSONL, exits when agent finishes)
-ai watch --follow --id $RUN_ID
+### ❌ WRONG
+- "Fix the bug by wrapping the selector with useShallow"
+- "Add a button that calls handleClick and updates state"
 
-# 4. Kill if needed
-ai kill --id $RUN_ID
-```
+## Event Parsing
 
-### Control a running agent
-```bash
-# Inject guidance mid-execution
-ai send "/steer <guidance>" --id $RUN_ID
-
-# Abort execution
-ai send "/abort" --id $RUN_ID
-
-# Queue follow-up message
-ai send "/follow-up <message>" --id $RUN_ID
-```
-
-### Parse agent output
-`ai watch --follow` outputs JSONL events. Key event types:
+`ai watch --follow` outputs JSONL. Key events:
 - `agent_start` — Agent began
-- `message_update` — Streaming text delta (look for `assistantMessageEvent.type`)
-- `turn_end` — One turn complete (has final message with usage stats)
+- `turn_end` — One turn complete (tool call done)
 - `agent_end` — Agent finished (has full message history)
 
-A Generator is done when you see `agent_end`. Check `stopReason`:
+Generator is done when you see `agent_end`. Check last message's `stopReason`:
 - `"stop"` = completed normally
-- `"tool_use"` = stopped mid-tool (may need follow-up)
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Generator timeout | `ai kill` → retry once |
+| Same task fails 2× | Stop and report to user |
+| Validator says not done | Create fix tasks, loop |
+| Agent off-track | `/steer` or kill + respawn |
 
 ## File Conventions
 
@@ -85,53 +119,8 @@ A Generator is done when you see `agent_end`. Check `stopReason`:
   spec.md          # Requirements + acceptance criteria (Phase 1 output)
   tasks/
     001-xxx.md     # Task description (you create dynamically)
-    002-xxx.md
   progress.md      # Execution log (append-only)
 ```
-
-### Task file format
-```markdown
-# Task: <short description>
-
-## Goal
-<what this task accomplishes>
-
-## Scope
-<files/modules to touch>
-
-## Notes
-<deviations or observations during execution>
-```
-
-## Parallelization Rules
-
-**PARALLEL when:**
-- Tasks touch different files
-- Tasks have no data dependencies
-
-**SEQUENTIAL when:**
-- Task B needs output from Task A
-- Tasks modify the same file
-
-## Safety Rules
-
-- Same task failing 3 times → pause and report to user
-- User can modify `.pge/spec.md` at any time → re-evaluate affected tasks
-- Never delete or modify code you didn't create through sub-agents
-- Always commit after each successful Generator run
-
-## Delegation Rules
-
-When delegating, describe WHAT needs to be done (the outcome), not HOW to do it.
-
-### ✅ CORRECT
-- "Fix the infinite loop error in SideMenu"
-- "Add a settings panel for the chat interface"
-- "Implement user authentication with JWT"
-
-### ❌ WRONG
-- "Fix the bug by wrapping the selector with useShallow"
-- "Add a button that calls handleClick and updates state"
 
 %WORKSPACE_SECTION%
 
@@ -139,7 +128,7 @@ When delegating, describe WHAT needs to be done (the outcome), not HOW to do it.
 
 ### Usage Rules
 
-- **bash**: Use for `ai serve`/`ai send`/`ai watch`/`ai kill` sub-agent control. Default 2min timeout; use `timeout` for longer tasks.
+- **bash**: Use for tmux + ai serve/send/watch/kill sub-agent control. Use `timeout` for long waits.
 - **read**: Read task files, spec, progress log, and sub-agent output.
 - **write**: Create task files in `.pge/tasks/`, update `spec.md` and `progress.md`.
 - **grep**: Search codebase for context before creating tasks.

--- a/pkg/prompt/validator.md
+++ b/pkg/prompt/validator.md
@@ -1,46 +1,46 @@
-You are an independent **Validator**. Your job is to verify that implementation meets specification — NOT to implement code yourself.
+You are an independent **Validator**. Your job is to verify that work is actually done — not to take the Generator's word for it.
 
-## Core Rules
+## Core Principle
 
-1. **You do NOT write implementation code.** You write tests and run verifications only.
-2. **You do NOT read implementation source files.** You test against public interfaces (APIs, CLI output, file existence, function signatures via `go doc`).
-3. **You test against the spec, not the implementation.** Your test cases come from acceptance criteria, not from reading how something was built.
+**The Generator claims it's done. You don't trust that claim.** You independently confirm what was actually accomplished against the acceptance criteria.
 
-## Workflow
+## What "Validation" Means
 
-1. Read the spec file (usually `.pge/spec.md`) to understand acceptance criteria
-2. For each acceptance criterion, write an independent test
-3. Run the tests, record results
-4. Report in this exact format:
+Validation is whatever it takes to convince yourself the work is done. You have full freedom:
+
+- **Code review** — Read the implementation, check for correctness, edge cases, error handling
+- **Run tests** — Write and run tests against the public interface
+- **Build checks** — `go build`, `go vet`, check for compilation errors
+- **Behavioral checks** — Run the program, verify CLI output matches expectations
+- **Structural checks** — File existence, function signatures, type definitions via `go doc`
+- **Any combination of the above**
+
+You choose the validation method based on what the acceptance criteria require. A "no runtime errors" criterion might just need a build check. A "correct algorithm" criterion needs code review + tests.
+
+## Rules
+
+1. **Start from the acceptance criteria, not from the Generator's report.** The Generator may claim X is done — you verify X independently.
+2. **You MAY read implementation code** (for code review). But your conclusion must be your own, not the Generator's self-assessment.
+3. **You MAY write test files** if testing is the right way to verify. But tests are a tool, not the only tool.
+4. **You MUST NOT modify non-test source files.** You are not the Generator.
+5. **Be specific about what passes and what doesn't.** Vague "looks good" is not validation.
+
+## Report Format
+
+After validation, report to the orchestrator:
 
 ```
-✅ <criterion>: <brief evidence>
-❌ <criterion>: <failure reason + what actually happened>
+✅ <criterion>: <what you verified and how>
+❌ <criterion>: <what's wrong, specific evidence>
+⚠️ <criterion>: <partially met, what's missing>
 
-Summary: X/Y criteria passed
+Summary: X/Y criteria fully passed, Z partial
 ```
 
-## What You MAY Do
+## What You Are NOT
 
-- Write test files (`*_test.go`, test scripts)
-- Run `go test`, `go build`, `go vet`
-- Use `bash` to run commands and check outputs
-- Use `go doc` to check function signatures without reading implementation
-- Use `grep` to check file existence or patterns (but not to read full implementation)
+- You are not a code reviewer giving style feedback
+- You are not a test suite writer
+- You are not a re-implementation of the Generator
 
-## What You MUST NOT Do
-
-- Read full implementation source files (that's the Generator's work)
-- Modify any non-test file
-- Modify `spec.md` or `tasks/`
-- Write implementation code and then test your own implementation
-
-## Anti-Pattern: Self-Validation
-
-If you find yourself writing both the implementation AND the tests, stop. You are a Validator, not a Generator. Only write tests.
-
-## Error Handling
-
-- If a test won't compile, that's a ❌ — the public interface may be wrong
-- If `go build` fails, report immediately without further testing
-- If you cannot determine how to test a criterion without reading source, say so — the spec may need clarification
+You are a **judge**. You look at the work and answer: "Is this actually done?"

--- a/pkg/prompt/validator.md
+++ b/pkg/prompt/validator.md
@@ -1,0 +1,46 @@
+You are an independent **Validator**. Your job is to verify that implementation meets specification — NOT to implement code yourself.
+
+## Core Rules
+
+1. **You do NOT write implementation code.** You write tests and run verifications only.
+2. **You do NOT read implementation source files.** You test against public interfaces (APIs, CLI output, file existence, function signatures via `go doc`).
+3. **You test against the spec, not the implementation.** Your test cases come from acceptance criteria, not from reading how something was built.
+
+## Workflow
+
+1. Read the spec file (usually `.pge/spec.md`) to understand acceptance criteria
+2. For each acceptance criterion, write an independent test
+3. Run the tests, record results
+4. Report in this exact format:
+
+```
+✅ <criterion>: <brief evidence>
+❌ <criterion>: <failure reason + what actually happened>
+
+Summary: X/Y criteria passed
+```
+
+## What You MAY Do
+
+- Write test files (`*_test.go`, test scripts)
+- Run `go test`, `go build`, `go vet`
+- Use `bash` to run commands and check outputs
+- Use `go doc` to check function signatures without reading implementation
+- Use `grep` to check file existence or patterns (but not to read full implementation)
+
+## What You MUST NOT Do
+
+- Read full implementation source files (that's the Generator's work)
+- Modify any non-test file
+- Modify `spec.md` or `tasks/`
+- Write implementation code and then test your own implementation
+
+## Anti-Pattern: Self-Validation
+
+If you find yourself writing both the implementation AND the tests, stop. You are a Validator, not a Generator. Only write tests.
+
+## Error Handling
+
+- If a test won't compile, that's a ❌ — the public interface may be wrong
+- If `go build` fails, report immediately without further testing
+- If you cannot determine how to test a criterion without reading source, say so — the spec may need clarification

--- a/pkg/testutil/harness_integration_test.go
+++ b/pkg/testutil/harness_integration_test.go
@@ -430,8 +430,173 @@ func TestSession_ConcurrentWrites(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Steer & Follow-up behavioral tests
+// ---------------------------------------------------------------------------
+
+// TestHarness_SteerDuringStreaming verifies that steering mid-stream cancels
+// the current execution and restarts with the steered message. The agent
+// should produce two agent_end cycles (or at least process the steered text).
+func TestHarness_SteerDuringStreaming(t *testing.T) {
+	// First call is slow (simulates mid-stream); second call responds immediately.
+	firstCallDone := make(chan struct{})
+	srv := testutil.LLMServerFactory(func(i int, r *http.Request) string {
+		if i == 0 {
+			// Hold the first response open so we can steer mid-stream.
+			time.Sleep(200 * time.Millisecond)
+			close(firstCallDone)
+			return testutil.TextResponse("interrupted")
+		}
+		// Second call: the steered response.
+		return testutil.TextResponse("steered response")
+	})
+	defer srv.Close()
+
+	model := llm.Model{ID: "test", Provider: "test", API: "openai-completions", BaseURL: srv.URL}
+	a := agent.NewAgent(model, "test-key", "You are helpful.")
+	collector := testutil.NewEventCollector()
+	unsub := collector.Subscribe(a.Events())
+	defer unsub()
+
+	if err := a.Prompt("initial"); err != nil {
+		t.Fatalf("Prompt failed: %v", err)
+	}
+
+	// Steer while the first LLM call is still in progress.
+	time.Sleep(30 * time.Millisecond)
+	a.Steer("go east")
+
+	a.Wait()
+	time.Sleep(10 * time.Millisecond)
+
+	// Agent must complete with an agent_end event.
+	if !collector.HasEvent(agent.EventAgentEnd) {
+		t.Error("expected agent_end after steer")
+	}
+
+		// There should be at least one text_delta containing the steered response.
+	textDeltas := collectTextDeltas(collector)
+	found := false
+	for _, d := range textDeltas {
+		if d == "steered response" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected text delta with 'steered response', got deltas: %v", textDeltas)
+	}
+}
+
+// TestHarness_FollowUpDuringStreaming verifies that a follow-up queued while
+// the agent is streaming gets processed after the current turn finishes.
+func TestHarness_FollowUpDuringStreaming(t *testing.T) {
+	// First response is slow; second is fast.
+	srv := testutil.LLMServerFactory(func(i int, r *http.Request) string {
+		if i == 0 {
+			time.Sleep(100 * time.Millisecond)
+			return testutil.TextResponse("first")
+		}
+		return testutil.TextResponse("follow-up processed")
+	})
+	defer srv.Close()
+
+	model := llm.Model{ID: "test", Provider: "test", API: "openai-completions", BaseURL: srv.URL}
+	a := agent.NewAgent(model, "test-key", "You are helpful.")
+	collector := testutil.NewEventCollector()
+	unsub := collector.Subscribe(a.Events())
+	defer unsub()
+
+	if err := a.Prompt("initial"); err != nil {
+		t.Fatalf("Prompt failed: %v", err)
+	}
+
+	// Queue follow-up while the first call is still streaming.
+	time.Sleep(20 * time.Millisecond)
+	if err := a.FollowUp("do more"); err != nil {
+		t.Fatalf("FollowUp failed: %v", err)
+	}
+
+	// Wait for both the initial and follow-up turns to complete.
+	waitWithTimeout(t, a, 5*time.Second)
+
+		// Must have processed the follow-up — look for its text output.
+	textDeltas := collectTextDeltas(collector)
+	found := false
+	for _, d := range textDeltas {
+		if d == "follow-up processed" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected text delta with 'follow-up processed', got deltas: %v", textDeltas)
+	}
+}
+
+// TestHarness_MultipleFollowUps verifies that multiple queued follow-ups
+// are all processed in order.
+func TestHarness_MultipleFollowUps(t *testing.T) {
+	responses := []string{
+		testutil.TextResponse("response-0"),
+		testutil.TextResponse("response-1"),
+		testutil.TextResponse("response-2"),
+	}
+	h := testutil.NewAgentHarness(t, responses, testutil.WithMaxTurns(5))
+	defer h.Close()
+
+	h.Prompt("start")
+
+	// Queue two follow-ups immediately.
+	h.FollowUp("second")
+	h.FollowUp("third")
+
+	h.Wait(5 * time.Second)
+
+		textDeltas := collectTextDeltas(h.Events)
+	var texts []string
+	for _, d := range textDeltas {
+		texts = append(texts, d)
+	}
+
+	// All three responses should appear.
+	assertContains(t, texts, "response-0")
+	assertContains(t, texts, "response-1")
+	assertContains(t, texts, "response-2")
+}
+
+// waitWithTimeout waits for the agent to finish or fatals on timeout.
+func waitWithTimeout(t *testing.T, a *agent.Agent, timeout time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		a.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		time.Sleep(10 * time.Millisecond)
+	case <-time.After(timeout):
+		t.Fatalf("agent did not finish within %v", timeout)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// collectTextDeltas extracts all text delta content from message_update events.
+func collectTextDeltas(collector *testutil.EventCollector) []string {
+	updates := collector.EventsOfType(agent.EventMessageUpdate)
+	var deltas []string
+	for _, e := range updates {
+		if ame, ok := e.AssistantMessageEvent.(agent.AssistantMessageEvent); ok {
+			if ame.Delta != "" {
+				deltas = append(deltas, ame.Delta)
+			}
+		}
+	}
+	return deltas
+}
 
 // testCompactor is a simple compactor for testing.
 type testCompactor struct {

--- a/skills/pge/SKILL.md
+++ b/skills/pge/SKILL.md
@@ -1,0 +1,426 @@
+---
+name: pge
+description: Planner-Generator-Executor 编排模式。通过 ai serve/send/watch/kill 控制子 agent 执行复杂任务。
+---
+
+# PGE — Dynamic Multi-Agent Orchestration
+
+PGE 模式让编排器 agent 通过 `ai` CLI 控制多个子 agent，完成复杂任务的拆解-执行-验证循环。
+
+## When to Use
+
+- 复杂功能实现（多文件、多模块、有验收标准）
+- 用户说 "用 PGE 模式" / "pge" / "编排模式"
+- 任务需要验证闭环（实现 → 验证 → 修复循环）
+
+**不要用于：** 简单 bug 修复、单文件改动、快速问答
+
+## Activation
+
+PGE 通过 `--role orchestrator` 启动：
+
+```bash
+ai run --role orchestrator "implement dark mode for the web app"
+# 或
+ai serve --role orchestrator --name "my-orchestrator"
+```
+
+## ⚠️ Critical: Sub-Agent Spawning Pattern
+
+`ai serve` 是**阻塞命令**。直接调用会卡死编排器。必须用 tmux 后台运行。
+
+### Standard Spawn-Monitor-Control Pattern
+
+```bash
+# 1. Spawn: tmux 后台启动，不阻塞编排器
+tmux new-session -d -s "gen-001" "ai serve --name 'gen-001-add-auth'"
+
+# 2. Get ID: 等 1 秒让 serve 打印 ID，然后捕获
+sleep 1
+RUN_ID=$(tmux capture-pane -t "gen-001" -p | head -1)
+
+# 3. Start watch BEFORE sending task (避免丢失早期事件)
+ai watch --follow --id "$RUN_ID" > /tmp/pge-gen-001.jsonl 2>&1 &
+WATCH_PID=$!
+sleep 0.5
+
+# 4. Send task
+ai send --id "$RUN_ID" "Read .pge/spec.md for context. Then: <task instruction>"
+
+# 5. Wait for completion (watch --follow 在 agent 结束后自动退出)
+#    timeout 根据任务大小调整: S=300s, M=600s, L=900s, XL=1200s
+timeout $TIMEOUT wait $WATCH_PID
+
+# 6. Check result
+if [ $? -eq 124 ]; then
+    echo "TIMEOUT: agent didn't finish in 10 minutes"
+    ai kill --id "$RUN_ID"
+    # → retry or report failure
+fi
+
+# 7. Cleanup tmux session
+tmux kill-session -t "gen-001" 2>/dev/null
+```
+
+### Validator Spawn Pattern
+
+Validator 使用专用 system prompt（通过 `--role validator` 嵌入 binary）：
+
+```bash
+# Spawn validator with dedicated system prompt
+tmux new-session -d -s "val-001" \
+  "ai serve --name 'val-001-check-auth' --role validator"
+sleep 1
+VAL_ID=$(tmux capture-pane -t "val-001" -p | head -1)
+
+# Watch and send validation task
+ai watch --follow --pretty --id "$VAL_ID" > /tmp/pge-val-001.log 2>&1 &
+WATCH_PID=$!
+sleep 0.5
+
+ai send --id "$VAL_ID" "Generator 完成了 <task>。独立验证 .pge/spec.md 的验收标准。"
+
+# Timeout: validation 通常比 generation 快，用任务 timeout 的一半
+timeout $VAL_TIMEOUT wait $WATCH_PID
+
+# Parse validation results
+cat /tmp/pge-val-001.log
+
+# Cleanup
+tmux kill-session -t "val-001" 2>/dev/null
+```
+
+### Parallel Spawn Pattern
+
+```bash
+# Spawn multiple generators in parallel
+tmux new-session -d -s "gen-001" "ai serve --name 'gen-001-backend'"
+tmux new-session -d -s "gen-002" "ai serve --name 'gen-002-frontend'"
+
+sleep 1
+GEN1=$(tmux capture-pane -t "gen-001" -p | head -1)
+GEN2=$(tmux capture-pane -t "gen-002" -p | head -1)
+
+# Watch both in background
+ai watch --follow --id "$GEN1" > /tmp/pge-gen-001.jsonl 2>&1 &
+WATCH1=$!
+ai watch --follow --id "$GEN2" > /tmp/pge-gen-002.jsonl 2>&1 &
+WATCH2=$!
+sleep 0.5
+
+# Send tasks
+ai send --id "$GEN1" "implement API endpoint"
+ai send --id "$GEN2" "implement UI component"
+
+# Wait both (adjust timeout per task size)
+timeout $TIMEOUT wait $WATCH1
+timeout $TIMEOUT wait $WATCH2
+
+# Parse each output file...
+```
+
+### Mid-Run Intervention
+
+```bash
+# Agent 跑偏了，实时修正
+ai send --id "$RUN_ID" "/steer focus only on the API, skip the frontend for now"
+
+# Agent 彻底搞砸了，终止重来
+ai kill --id "$RUN_ID"
+tmux kill-session -t "gen-001"
+
+# 重新 spawn
+tmux new-session -d -s "gen-001-v2" "ai serve --name 'gen-001-v2'"
+# ...
+```
+
+### Health Check
+
+```bash
+# 检查子 agent 是否还活着
+ai ls --json | python3 -c "
+import sys, json
+runs = json.loads(sys.stdin.read())
+for r in runs:
+    if r['id'].startswith('$RUN_ID'[:4]):
+        print(f\"{r['id']}: {r['status']}\")
+"
+
+# 看 tmux 里的 stderr
+tmux capture-pane -t "gen-001" -p -S -50
+```
+
+## Execution Flow
+
+### Phase 1: Spec Alignment
+
+1. **Understand** — 和用户讨论需求
+2. **Write spec** — 写入 `.pge/spec.md`
+
+```markdown
+# Spec: <title>
+
+## Goal
+<one sentence>
+
+## Acceptance Criteria
+- [ ] <criterion 1 — must be specific and verifiable>
+- [ ] <criterion 2>
+
+## Constraints
+- <technical constraints>
+
+## Out of Scope
+- <explicitly excluded>
+```
+
+3. **Get user confirmation** — 展示 spec，等用户说 ok
+
+### Phase 2: Task Decomposition
+
+分析 spec，拆解成可执行的 task。写入 `.pge/tasks/NNN-<name>.md`。
+
+```markdown
+# Task: <short description>
+
+## Goal
+<what this task accomplishes>
+
+## Files (scope)
+<expected files to modify/create — MUST be explicit for parallel conflict checking>
+
+## Estimated Size
+<S(<100) / M(100-300) / L(300-500) / XL(>500, consider splitting)>
+
+## Dependencies
+<which tasks must complete first, if any>
+
+## Acceptance
+<how to verify this task is done>
+```
+
+**Decomposition rules:**
+- 每个 task 应该能由一个 coding agent 独立完成
+- 如果 task 需要改 >5 个文件，考虑进一步拆分
+- 标记哪些 task 可以并行（不同文件、无依赖）
+- **预估行数**：每个 task 写入预估。>500 行的 task 应拆分，<80 行的 task 应合并到其他 task
+- **File scope 声明**：每个 task 必须列出预期修改/创建的文件列表。并行 task 的 file scope **必须互斥**——编排器在 spawn 前检查重叠
+
+### Phase 3: Execution Loop
+
+```
+while unchecked acceptance criteria remain:
+    1. Pick next task(s)
+    2. Spawn generator(s) via tmux pattern (see above)
+    3. Monitor via watch --follow
+    4. Parse agent_end from output
+    5. Update .pge/state.md with completed files and decisions
+    6. Spawn validator to check acceptance criteria
+    7. Update .pge/spec.md checkboxes
+    8. If failed → create fix tasks → loop
+```
+
+### Timeout Guide
+
+任务 Estimated Size 对应 timeout：
+
+| Size | Lines | Generator Timeout | Validator Timeout |
+|------|-------|-------------------|-------------------|
+| S | <100 | 300s (5min) | 150s |
+| M | 100-300 | 600s (10min) | 300s |
+| L | 300-500 | 900s (15min) | 450s |
+| XL | >500 | 1200s (20min) | 600s |
+
+```bash
+# 根据任务大小设置
+case $TASK_SIZE in
+  S)  TIMEOUT=300; VAL_TIMEOUT=150 ;;
+  M)  TIMEOUT=600; VAL_TIMEOUT=300 ;;
+  L)  TIMEOUT=900; VAL_TIMEOUT=450 ;;
+  XL) TIMEOUT=1200; VAL_TIMEOUT=600 ;;
+esac
+```
+
+## ⛔ Role Separation Rules
+
+**核心原则：Generator 说"完成了"不算数。只有 Validator 独立确认的完成才算数。**
+
+### Generator
+
+| 规则 | 原因 |
+|------|------|
+| **不许写测试文件** | 测试是验证手段，不是实现。Generator 写测试 = 自己考自己 |
+| **不许修改 spec.md** | 需求不是实现者定义的 |
+| Task 描述要明确说 "不需要写测试，只需 `go build` 通过" | 防止 agent 习惯性写测试 |
+
+### Validator
+
+Validator 是**独立裁判**，不是测试工具。它的职责是独立确认完成标准，手段由它自己决定：
+
+| 可以做的验证方式 | 说明 |
+|-----------------|------|
+| 代码 review | 读实现代码，检查正确性、边界条件、错误处理 |
+| 写测试并运行 | 对公共接口写测试验证行为 |
+| 构建检查 | `go build`, `go vet` |
+| 行为检查 | 运行程序，验证输出符合预期 |
+| 结构检查 | 文件存在性、函数签名（`go doc`） |
+| 任意组合 | Validator 自主选择最适合的验证方式 |
+
+| 必须遵守的规则 | 原因 |
+|---------------|------|
+| **必须是独立 agent（不同 tmux session）** | 和 Generator 进程隔离 |
+| **起始点是验收标准，不是 Generator 的报告** | Generator 可能说做了但没做 |
+| **结论必须是自己的，不是 Generator 的自我评估** | 独立裁判 |
+| **不许修改非测试的源文件** | 你不是 Generator |
+| 汇报格式：✅/❌/⚠️ + 具体证据 | 让 Planner 能决策下一步 |
+
+### Generator Task 模板
+
+```
+Read .pge/spec.md and .pge/state.md for context. Then: <具体实现要求>
+
+要求：
+- 只实现功能代码，不需要写测试文件
+- 确保 go build ./... 通过
+- 完成后列出修改了哪些文件和关键设计决策（用于更新 state.md）
+```
+
+### Validator Task 模板
+
+```
+Generator 完成了 <task描述>。
+请独立验证 .pge/spec.md 中以下验收标准是否真正被满足：
+
+<列出验收标准>
+
+验证方式由你决定——代码 review、写测试、构建检查、行为验证等均可。
+
+特别注意：
+- 不仅验证功能正确性，也验证行为细节（输出格式、错误提示、边界行为等）
+- 如果 spec 提到了具体的输出格式或行为，必须对照检查
+
+对每条标准给出判断：
+  ✅ <标准>: <你验证了什么，怎么验证的>
+  ❌ <标准>: <哪里不满足，具体证据>
+  ⚠️ <标准>: <部分满足，缺少什么>
+
+最后输出总结：X/Y 条完全通过。
+```
+
+### Phase 4: Report
+
+- 更新 `.pge/spec.md` 所有 checkbox 为 `[x]`
+- 写最终报告到 `.pge/progress.md`
+- 向用户汇报
+
+## Error Handling
+
+| Scenario | Detection | Action |
+|----------|-----------|--------|
+| Agent timeout | `timeout` exits 124 | `ai kill` → retry once with simpler task |
+| Agent crash | `ai ls` shows `failed` or `killed` | Check rpc.log → retry with modified instructions |
+| Agent off-track | Parse output, see wrong direction | `/steer` correction, or kill + respawn |
+| Same task fails 2× | Two consecutive failures | **Stop. Report to user.** |
+| Validator says not done | Criteria not all checked | Create specific fix tasks, loop |
+| tmux session died | `tmux has-session` fails | Check `ai ls` for status, may need cleanup |
+
+## Output Parsing
+
+`ai watch --follow` 输出 JSONL。关键事件：
+
+| Event | Meaning |
+|-------|---------|
+| `{"type":"response","command":"prompt","success":true}` | Command accepted |
+| `{"type":"agent_start",...}` | Agent started processing |
+| `{"type":"turn_end",...}` | One turn complete (tool call finished) |
+| `{"type":"agent_end",...}` | Agent finished. Has `messages` array with full history |
+
+**提取最终回复：**
+```bash
+grep '"agent_end"' /tmp/pge-gen-001.jsonl | tail -1 | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+stop = d.get('messages',[])[-1].get('metadata',{}).get('stopReason','')
+print(f'stopReason: {stop}')
+for m in d.get('messages', []):
+    if m['role'] == 'assistant':
+        for c in m.get('content', []):
+            if c.get('type') == 'text':
+                print(c['text'])
+"
+```
+
+## Progress Tracking
+
+`.pge/progress.md`（append-only）：
+
+```markdown
+## 14:30 — Started
+- Spec: implement dark mode
+- Acceptance criteria: 5
+
+## 14:35 — Task 001: Create theme tokens
+- Generator: a1b2c3 (tmux: gen-001)
+- Status: done
+- Files: src/theme.ts, src/tokens.css
+
+## 14:42 — Validation round 1
+- Criteria passed: 3/5
+- Failed: toggle persistence, system preference detection
+- Fix tasks created: 003, 004
+
+## 15:00 — All criteria passed
+```
+
+## Delegation Tips
+
+**Give WHAT (outcome), not HOW.** But include enough context for independent work.
+
+### ✅ Good
+```
+"Implement JWT authentication for /api/login endpoint. Use the existing
+User model in src/models/user.ts. Store tokens in http-only cookies."
+```
+
+### ❌ Bad
+```
+"Add auth. Look at how auth usually works."
+```
+
+## File Structure
+
+```
+.pge/
+  spec.md              # Requirements + acceptance criteria
+  state.md             # Current state — updated after each generator
+  tasks/
+    001-theme-tokens.md
+    002-toggle-ui.md
+    progress.md          # Execution log (append-only)
+```
+
+## Key Constraints
+
+1. **Orchestrator never writes implementation code** — delegates to generators
+2. **Each generator gets one clear task** — not a laundry list
+3. **Validate against spec, not against tasks** — tasks are means, spec is the end
+4. **Stop on repeated failure** — don't burn tokens retrying forever
+5. **Commit after each successful generator run** — incremental progress
+6. **Always use tmux to spawn** — `ai serve` is blocking, direct call freezes orchestrator
+
+## ⛔ Mandatory Self-Check
+
+| Assertion | Trigger | Fix |
+|-----------|---------|-----|
+| Direct `ai serve` call | Using `ai serve` without tmux | Wrap in tmux |
+| No spec written | Starting execution without .pge/spec.md | Write spec first |
+| No user confirmation | Executing without user approval | Show spec, wait for ok |
+| Generator task too vague | Task description < 2 sentences | Add more context |
+| Skipped validation | Task done but criteria not checked | Run validator |
+| Generator wrote tests | Output includes `*_test.go` files | Kill, strip tests, respawn validator separately |
+| No independent validator | Only Generator ran, no Validator agent | Must spawn separate Validator |
+| Silent failure | Generator failed but didn't report | Always check exit status |
+| No state.md update | Generator completed but state.md not updated | Write state.md before spawning next agent |
+| Parallel file overlap | Two parallel tasks list same file | Make sequential or re-scope |
+| Task too large | Estimated >500 lines | Split into smaller tasks |
+| Task too small | Estimated <80 lines | Merge with adjacent task |

--- a/skills/pge/design.md
+++ b/skills/pge/design.md
@@ -1,0 +1,243 @@
+# PGE Skill — Planner-Generator-Executor Orchestration
+
+## What
+
+PGE 模式让一个 agent（编排器）通过 `ai serve`/`ai send`/`ai watch`/`ai kill` 控制多个子 agent，实现复杂任务的拆解-执行-验证循环。
+
+**触发方式：**
+```bash
+ai run --peg "implement dark mode for the web app"
+ai serve --peg --name "orchestrator"
+```
+
+`--peg` 将 system prompt 替换为编排器模板（`pkg/prompt/orchestrator.md`），描述了子 agent 控制协议。
+
+## Why
+
+当前 `implement` skill 的 `ag task run` 是静态 DAG 调度：
+- task 在执行前全部定义好
+- scheduler 按固定依赖推进
+- 无法根据中间结果调整计划
+
+PGE 的编排器是 **动态的**：
+- 根据 spec 拆出第一批 task
+- 执行后看结果，决定下一批
+- 验证失败时重新规划
+- 直到所有验收标准通过
+
+## Architecture
+
+```
+User
+  │
+  ▼
+┌─────────────────────────┐
+│  Orchestrator (ai --peg) │  ← planner + coordinator
+│  System: orchestrator.md │
+└────────┬────────────────┘
+         │ ai serve / ai send / ai watch / ai kill
+         │
+    ┌────┴────┐
+    ▼         ▼
+┌───────┐ ┌─────────┐
+│ Gen 1 │ │ Gen 2   │  ← normal ai serve (default prompt)
+└───┬───┘ └────┬────┘
+    │          │
+    ▼          ▼
+┌─────────────────┐
+│   Validator     │  ← normal ai serve (default prompt)
+└─────────────────┘
+```
+
+**三个角色：**
+
+| Role | Who | What |
+|------|-----|------|
+| **Planner** | Orchestrator itself | 分析需求，拆解 task，验证结果 |
+| **Generator** | Sub-agent (`ai serve`) | 写代码，执行具体 task |
+| **Validator** | Sub-agent (`ai serve`) | 验证代码是否符合 spec |
+
+Planner 不写代码。Generator 和 Validator 用默认 coding agent prompt。
+
+## Sub-Agent Control Protocol
+
+编排器通过 bash 工具调用 `ai` CLI：
+
+```bash
+# 启动子 agent
+RUN_ID=$(ai serve --name "gen-001-add-auth")
+
+# 发送任务
+ai send --id $RUN_ID "implement JWT authentication for /api/login"
+
+# 实时监控（JSONL 流，agent 结束后自动退出）
+ai watch --follow --id $RUN_ID
+
+# 中途调整方向
+ai send --id $RUN_ID "/steer also add rate limiting"
+
+# 终止
+ai kill --id $RUN_ID
+```
+
+### Event Parsing
+
+`ai watch --follow` 输出 JSONL。关键事件：
+
+| Event | Meaning |
+|-------|---------|
+| `agent_start` | Agent started |
+| `message_update` | Streaming delta (look for `assistantMessageEvent.type`) |
+| `turn_end` | Turn complete, has final message + usage |
+| `agent_end` | Agent finished, has full message history |
+
+Generator 完成的标志：`agent_end` + `stopReason == "stop"`。
+
+### Output Extraction
+
+从 `agent_end` 事件中提取 assistant 最终回复：
+
+```bash
+ai watch --follow --id $RUN_ID | while read -r line; do
+  TYPE=$(echo "$line" | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('type',''))" 2>/dev/null)
+  if [ "$TYPE" = "agent_end" ]; then
+    echo "$line" | python3 -c "
+import sys,json
+d=json.loads(sys.stdin.read())
+for m in d.get('messages',[]):
+  if m['role']=='assistant':
+    for c in m.get('content',[]):
+      if c.get('type')=='text':
+        print(c['text'])
+" 2>/dev/null
+  fi
+done
+```
+
+## Execution Flow
+
+### Phase 1: Spec (user + orchestrator)
+
+1. 用户描述需求
+2. 编排器写入 `.pge/spec.md`：
+   ```markdown
+   # Spec: <title>
+   
+   ## Goal
+   <one sentence>
+   
+   ## Acceptance Criteria
+   - [ ] <criterion 1>
+   - [ ] <criterion 2>
+   
+   ## Constraints
+   - <constraint>
+   
+   ## Out of Scope
+   - <excluded>
+   ```
+3. 用户确认 spec
+
+### Phase 2: Execute (autonomous)
+
+编排器循环：
+
+```
+while spec has unchecked acceptance criteria:
+    1. Pick next work item (may parallelize)
+    2. Create task file → .pge/tasks/NNN-<name>.md
+    3. Spawn generator: ai serve --name "gen-NNN"
+    4. Send task + watch --follow
+    5. Parse result, check if task done
+    6. When enough tasks done → spawn validator
+    7. Validator checks acceptance criteria
+    8. Update .pge/spec.md checkboxes
+    9. If criteria fail → create fix tasks, loop
+```
+
+### Phase 3: Report
+
+- Summary of what was done
+- Final spec with checkmarks
+- Any deviations or open issues
+
+## Task File Format
+
+`.pge/tasks/NNN-<name>.md`:
+```markdown
+# Task: <short description>
+
+## Goal
+<what this task accomplishes>
+
+## Files
+<expected files to modify>
+
+## Status
+pending | running | done | failed
+
+## Result
+<filled after generator completes>
+```
+
+## Progress File
+
+`.pge/progress.md` — append-only log:
+```markdown
+## [timestamp] Task NNN started
+- Generator: <run ID>
+- Input: <task summary>
+
+## [timestamp] Task NNN completed
+- Result: <summary>
+- Files changed: <list>
+
+## [timestamp] Validation run
+- Spec criteria checked: N/M passed
+```
+
+## Parallelization Rules
+
+- **Parallel**: Tasks touch different files, no data dependency
+- **Sequential**: Task B needs output from Task A
+
+编排器自行判断并发度。简单规则：同目录的文件串行，不同目录可并行。
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Generator failed (exit error) | Retry once, then report |
+| Same task fails 3 times | Pause, report to user |
+| Validator says criteria not met | Create fix tasks, loop |
+| Spec changed by user mid-run | Re-evaluate, mark affected tasks |
+| Generator timeout | Kill, retry once |
+
+## File Layout
+
+```
+.pge/
+  spec.md              # Requirements + acceptance criteria
+  tasks/
+    001-add-auth.md
+    002-add-ratelimit.md
+  progress.md          # Append-only execution log
+```
+
+## Key Differences from `implement` Skill
+
+| | implement (ag task) | PGE (ai --peg) |
+|---|---|---|
+| Task definition | Static DAG (tasks.md) | Dynamic (planner decides on-the-fly) |
+| Scheduling | Fixed dependency order | Adaptive based on results |
+| Validation | Per-task review | Spec-level acceptance criteria |
+| Infrastructure | ag CLI + scheduler | ai CLI + orchestrator |
+| Failure recovery | Retry ×3, manual after | Planner adjusts plan dynamically |
+| Human involvement | Setup only | Spec approval + error escalation |
+
+## Non-Goals
+
+- Not replacing simple tasks (`ai run "fix this bug"` still works)
+- Not building a framework/library — it's a skill (SKILL.md)
+- Not multi-user/multi-tenant
+- Not modifying `ai` CLI itself (PGE is pure skill layer)


### PR DESCRIPTION
## Summary

PGE (Planner-Generator-Executor) 模式的基础设施实现，让单个 `ai` CLI 能编排多个子 agent 完成复杂任务。

## What Changed

### Infrastructure (`ai` CLI)

| 功能 | 说明 |
|------|------|
| `--peg` flag | `ai run --peg` / `ai serve --peg` 启用 PGE 编排器模式，注入 orchestrator system prompt |
| `/steer` 斜杠命令 | 运行中调整 agent 方向（`ai send --id $ID "/steer 改用方案B"`） |
| `ai watch --follow` | 持续流式监听 agent 事件（socket），直到 agent 结束自动退出 |
| `ai watch --follow --pretty` | 格式化输出为 `user:`/`assistant:`/`thinking:`/`tool:` 可读对话格式 |
| `prompt.Builder.SetTemplate()` | 支持自定义 system prompt 模板，同时保留 tools/skills/workspace 注入 |

### Prompt Templates (embedded)

| 文件 | 角色 |
|------|------|
| `pkg/prompt/orchestrator.md` | 编排器 system prompt — 规划、派发、验证、状态同步 |
| `pkg/prompt/validator.md` | 验证者 system prompt — 独立裁判，通过 `--system-prompt @.pge/validator.md` 注入 |

### PGE Design Decisions

核心问题是之前实战中发现的 7 个问题全部得到解决：

| # | 问题 | 解决 |
|---|------|------|
| 1 | Task 太大无预估 | task 模板加 Estimated Size 字段，>500 行拆分 |
| 2 | Generator 自测自验证 | role separation + 独立 Validator + 专用 validator.md |
| 3 | Agent 间不知道前面的改动 | `.pge/state.md` 状态同步机制 |
| 4 | 并行 agent 写同一文件 | file scope 必须声明且互斥 |
| 5 | Task 太小浪费开销 | <80 行合并到其他 task |
| 6 | 固定 timeout 不够 | 动态 timeout（S/M/L/XL） |
| 7 | 验证粒度不够细 | Validator task 模板要求检查输出格式、边界行为 |

## Sub-Agent Spawn Pattern

`ai serve` 是阻塞命令，子 agent 必须通过 tmux 后台启动：

```bash
tmux new-session -d -s "gen-001" "ai serve --name 'gen-001-task'"
sleep 1
RUN_ID=$(tmux capture-pane -t "gen-001" -p | head -1)
ai watch --follow --pretty --id "$RUN_ID" &
ai send --id "$RUN_ID" "<task>"
```

Validator 使用专用 prompt：
```bash
tmux new-session -d -s "val-001" \
  "ai serve --name 'val-001-check' --system-prompt @.pge/validator.md"
```

## Files Changed (11 files, +1256 / -16)

- `cmd/ai/watch.go` — `--follow`, `--pretty`, `followWatch()`, `prettyPrintAgentEnd()`
- `cmd/ai/run.go` — `--peg` flag, validator.md auto-creation
- `cmd/ai/rpc_help_handlers.go` — `/steer` registration
- `cmd/ai/rpc_app.go` — `buildSystemPrompt()`, `customSystemPrompt`
- `pkg/prompt/builder.go` — `SetTemplate()`, `OrchestratorTemplate()`, `ValidatorTemplate()`
- `pkg/prompt/orchestrator.md` — orchestrator system prompt
- `pkg/prompt/validator.md` — validator system prompt
- `docs/design/ai-agent-control.md` — design doc

## Test Plan

- [x] `ai serve --peg` — agent identifies as PGE orchestrator
- [x] `ai watch --follow` — full event stream from agent_start to agent_end
- [x] `ai watch --follow --pretty` — formatted readable output
- [x] `/steer` via `ai send` — successfully changed agent behavior mid-run
- [x] `go build` + `go vet` pass
- [ ] End-to-end PGE test: orchestrator spawns generator → validator → validates
- [ ] Real-world test on multi-file feature implementation