### PR TITLE
Fix: [BUG] /follow-up slash command writes to dead-end queue, never consumed by Agent

### DIFF
--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -102,7 +102,6 @@ type rpcApp struct {
 	steeringMode       string
 	followUpMode       string
 	pendingSteer       bool
-	followUpQueue      []string
 	showThinking       bool
 	showTools          bool
 	showPrefix         bool

--- a/cmd/ai/rpc_help_handlers.go
+++ b/cmd/ai/rpc_help_handlers.go
@@ -63,13 +63,12 @@ func (app *rpcApp) handleFollowUpSlash(args string) (any, error) {
 		return nil, fmt.Errorf("follow-up mode is '%s', not enabled", app.followUpMode)
 	}
 
-	if len(app.followUpQueue) > 0 && app.followUpMode == "one-at-a-time" {
+	if app.followUpMode == "one-at-a-time" && app.ag.GetPendingFollowUps() > 0 {
 		return nil, fmt.Errorf("follow-up queue already has a pending message")
 	}
 
 	expandedMessage := app.expandSkillCommands(message)
-	app.followUpQueue = append(app.followUpQueue, expandedMessage)
-	return map[string]any{"status": "queued", "message": expandedMessage}, nil
+	return nil, app.ag.FollowUp(expandedMessage)
 }
 
 func (app *rpcApp) handleAbortSlash(args string) (any, error) {


### PR DESCRIPTION
## Workpad

```text
genius:/Users/genius/.symphony/workspaces/9c5655ec-7f4a-4747-972e-1b3cc45233ed@c90b146
```

### Plan

- [x] 1. Reproduce and confirm the bug
  - [x] 1.1 Verify `handleFollowUpSlash()` writes to `app.followUpQueue` (dead-end `[]string` slice)
  - [x] 1.2 Verify no code drains `app.followUpQueue`
  - [x] 1.3 Verify `handleFollowUp` RPC handler uses `app.ag.FollowUp()` correctly
- [ ] 2. Implement fix
  - [ ] 2.1 Change `handleFollowUpSlash()` to call `app.ag.FollowUp()` instead of appending to slice
  - [ ] 2.2 Remove dead `app.followUpQueue` field from `rpcApp` struct
  - [ ] 2.3 Search for any other references to `app.followUpQueue` and clean up
- [ ] 3. Validate
  - [ ] 3.1 Run targeted tests: `go test ./cmd/ai/... ./pkg/agent/... -v`
  - [ ] 3.2 Build succeeds: `go build ./cmd/ai`

### Acceptance Criteria

- [ ] `/follow-up <message>` slash command delivers the message to the Agent for execution
- [ ] Multiple `/follow-up` calls work without `follow-up queue already has a pending message` error
- [ ] The dead-end `app.followUpQueue` slice is removed
- [ ] Existing RPC follow-up path (`ai send --streaming-behavior followUp`) continues to work
- [ ] Tests pass: `go test ./cmd/ai/... ./pkg/agent/... -v`

### Validation

- [ ] targeted tests: `go test ./cmd/ai/... ./pkg/agent/... -v`
- [ ] build: `go build ./cmd/ai`

### Notes

- Confirmed: `handleFollowUpSlash()` at rpc_help_handlers.go appends to `app.followUpQueue []string` which is never read
- Confirmed: `handleFollowUp` RPC handler correctly calls `app.ag.FollowUp()` which writes to Agent's `chan string`
- Fix: Align slash command path with RPC path by calling `app.ag.FollowUp()` directly