### PR TITLE
feat: watch --follow --timeout, llm_retry events, server timeout fix

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -82,20 +82,11 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	}
 	app.loopCfg = loopCfg
 
-	// Create agent with LoopConfig
+		// Create agent with LoopConfig
 	ag := agent.NewAgentFromConfigWithContext(app.model, app.apiKey, agentCtx, loopCfg)
 	defer ag.Shutdown()
 	ag.SetThinkingLevel("high")
 	app.ag = ag
-
-	// Start timeout watchdog if timeout is set
-	if timeout > 0 {
-		go func() {
-			<-time.After(timeout)
-			slog.Warn("[RPC] Timeout reached, aborting agent", "timeout", timeout)
-			ag.Abort()
-		}()
-	}
 
 	// Initialize checkpoint manager for persistent state
 	if app.sess != nil {
@@ -117,10 +108,23 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	slog.Info("Concurrency control enabled", "maxConcurrentTools", concurrencyConfig.MaxConcurrentTools, "toolTimeout", concurrencyConfig.ToolTimeout)
 	slog.Info("Tool output truncation", "maxChars", toolOutputConfig.MaxChars)
 
-	// --- Create RPC server ---
+		// --- Create RPC server ---
 	server := rpc.NewServer()
 	server.SetOutput(output)
 	app.server = server
+
+	// Start timeout watchdog if timeout is set.
+	// Must be after server creation so server.Cancel() is available.
+	if timeout > 0 {
+		go func() {
+			<-time.After(timeout)
+			slog.Warn("[RPC] Timeout reached, aborting agent", "timeout", timeout)
+			ag.Abort()
+			// Cancel the RPC server so RunWithIO unblocks and the process exits.
+			// Without this, the process lingers forever waiting for stdin.
+			server.Cancel()
+		}()
+	}
 
 	// --- Register all handlers ---
 		validToolSummaryStrategies := map[string]bool{"llm": true, "heuristic": true, "off": true}

--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -667,7 +667,8 @@ func watchSubcommand() {
 	fs := flag.NewFlagSet("watch", flag.ExitOnError)
 	idFlag := fs.String("id", "", "run ID or prefix (auto-selects by cwd if omitted)")
 	sinceFlag := fs.Int64("since", -1, "start reading from byte offset (machine-readable mode). Use 0 for beginning.")
-	followFlag := fs.Bool("follow", false, "follow mode: continuously stream events until agent exits (machine-readable)")
+				followFlag := fs.Bool("follow", false, "follow mode: continuously stream events until agent exits (machine-readable)")
+	watchTimeoutFlag := fs.Duration("timeout", -1, "with --follow: max duration to wait (0 = until agent process exits; default without this flag: exit on agent_end)")
 	prettyFlag := fs.Bool("pretty", false, "with --follow: format output as readable conversation instead of raw JSONL")
 	fs.Parse(os.Args[1:])
 
@@ -696,7 +697,7 @@ func watchSubcommand() {
 			fmt.Fprintf(os.Stderr, "error: run %s is not running (status: %s), --follow requires a live agent\n", meta.ID, meta.Status)
 			os.Exit(1)
 		}
-		followWatch(meta, 0, *prettyFlag)
+								followWatch(meta, 0, *prettyFlag, *watchTimeoutFlag)
 		return
 	}
 
@@ -761,7 +762,7 @@ func machineWatch(eventsPath string, offset int64) {
 // followWatch continuously streams events from the agent via socket.
 // It connects to the Unix domain socket and subscribes to the event stream,
 // printing each event line to stdout until the connection closes (agent exits).
-func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
+func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool, watchTimeout time.Duration) {
 	sockPath := run.SocketPath("", meta.ID)
 
 	client := run.NewSocketClient(sockPath)
@@ -771,6 +772,13 @@ func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
 		os.Exit(1)
 	}
 	defer conn.Close()
+
+	// watchTimeout == -1: flag not set → default behavior (exit on agent_end)
+	// watchTimeout == 0: wait forever (until agent process exits)
+	// watchTimeout > 0: wait up to this duration
+	if watchTimeout > 0 {
+		conn.SetDeadline(time.Now().Add(watchTimeout))
+	}
 
 	scanner := bufio.NewScanner(conn)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -829,11 +837,18 @@ func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool) {
 			lastKind = evt.Kind
 		}
 
-		// On agent_end, flush and exit.
+								// On agent_end:
+		// - Default (no --timeout flag): exit immediately. One-shot task complete.
+		// - With --timeout 0 or --timeout N: continue waiting for more events.
 		if strings.Contains(line, `"agent_end"`) {
 			fmt.Println()
 			fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
-			return
+			if watchTimeout < 0 {
+				// No --timeout flag → one-shot mode, exit.
+				return
+			}
+			// --timeout set (0 or positive) → keep going.
+			continue
 		}
 	}
 	fmt.Fprintf(os.Stderr, "--- agent stream ended without agent_end event ---\n")

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -109,7 +109,11 @@ func (s *Server) Run() error {
 // RunWithIO starts the RPC server using the provided reader and writer.
 // This method blocks until an error occurs or the reader is closed.
 func (s *Server) RunWithIO(reader io.Reader, writer io.Writer) error {
-	scanner := bufio.NewScanner(reader)
+	// Wrap reader so reads are cancellable via server context.
+	// Without this, scanner.Scan() blocks forever and timeout watchdog
+	// cannot cause the server to exit.
+	cr := &contextReader{reader: reader, ctx: s.ctx}
+	scanner := bufio.NewScanner(cr)
 	// Set larger buffer: 4MB initial, 16MB max to handle large JSON commands (>64KB)
 	buf := make([]byte, 0, 4*1024*1024) // 4MB
 	scanner.Buffer(buf, 16*1024*1024)   // 16MB max
@@ -261,4 +265,44 @@ func (s *Server) writeJSON(data []byte) {
 // Context returns the server's context.
 func (s *Server) Context() context.Context {
 	return s.ctx
+}
+
+// Cancel shuts down the server by canceling its context.
+// This causes RunWithIO to unblock and return, allowing the process to exit.
+func (s *Server) Cancel() {
+	s.cancel()
+}
+
+// contextReader wraps an io.Reader so that Read calls are cancellable via context.
+// When the context is canceled, ongoing and future Read calls return an error,
+// unblocking any scanner that is waiting for input.
+type contextReader struct {
+	reader io.Reader
+	ctx    context.Context
+}
+
+func (cr *contextReader) Read(p []byte) (int, error) {
+	// Fast path: context already done.
+	if err := cr.ctx.Err(); err != nil {
+		return 0, err
+	}
+	// If the underlying reader is a file/pipe, we can't interrupt a blocking
+	// Read directly. Use a goroutine with a race between the read and context
+	// cancellation.
+	done := make(chan readResult, 1)
+	go func() {
+		n, err := cr.reader.Read(p)
+		done <- readResult{n: n, err: err}
+	}()
+	select {
+	case r := <-done:
+		return r.n, r.err
+	case <-cr.ctx.Done():
+		return 0, cr.ctx.Err()
+	}
+}
+
+type readResult struct {
+	n   int
+	err error
 }

--- a/pkg/rpc/server_test.go
+++ b/pkg/rpc/server_test.go
@@ -336,3 +336,58 @@ var (
 	_ io.Reader
 	_ context.Context
 )
+func TestContextReader_Cancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Use a pipe that nobody writes to — Read will block forever.
+	r, _ := io.Pipe()
+	cr := &contextReader{reader: r, ctx: ctx}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := cr.Read(make([]byte, 64))
+		done <- err
+	}()
+
+	// Give the goroutine time to enter Read.
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel context — Read should unblock with context error.
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected error after cancel, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read did not unblock after context cancel")
+	}
+}
+
+func TestContextReader_Normal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cr := &contextReader{reader: strings.NewReader("hello"), ctx: ctx}
+	buf := make([]byte, 10)
+	n, err := cr.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(buf[:n]) != "hello" {
+		t.Fatalf("expected 'hello', got '%s'", string(buf[:n]))
+	}
+}
+
+func TestContextReader_AlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cr := &contextReader{reader: strings.NewReader("hello"), ctx: ctx}
+	_, err := cr.Read(make([]byte, 10))
+	if err == nil {
+		t.Error("expected error from already-canceled context")
+	}
+}

--- a/pkg/run/conv.go
+++ b/pkg/run/conv.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/tiancaiamao/ai/pkg/rpc"
 )
@@ -84,6 +85,8 @@ func ParseEvent(line string) *FormattedEvent {
 		return parseResponseEvent(evt)
 	case "session_switch":
 		return parseSessionSwitch(evt)
+		case "llm_retry":
+		return parseLLMRetry(evt)
 	case "loop_guard_triggered":
 		return parseLoopGuard(evt)
 	case "tool_call_recovery":
@@ -417,8 +420,46 @@ func parseToolCallRecovery(evt map[string]any) *FormattedEvent {
 	if attempt > 0 {
 		return &FormattedEvent{Kind: KindMeta, Role: "ai", Text: fmt.Sprintf("ai: recovered malformed tool call (attempt %d): %s", attempt, truncate(reason, 220))}
 	}
-	return &FormattedEvent{Kind: KindMeta, Role: "ai", Text: "ai: recovered malformed tool call: " + truncate(reason, 220)}
+		return &FormattedEvent{Kind: KindMeta, Role: "ai", Text: "ai: recovered malformed tool call: " + truncate(reason, 220)}
 }
+
+// parseLLMRetry handles llm_retry events, making rate-limit and other
+// transient LLM errors visible to watchers.
+func parseLLMRetry(evt map[string]any) *FormattedEvent {
+	info, _ := evt["llmRetry"].(map[string]any)
+	if info == nil {
+		return nil
+	}
+	attempt := intFromMap(info, "attempt")
+	maxRetries := intFromMap(info, "maxRetries")
+	delayNs := intFromMap(info, "delay")
+	errorType, _ := info["errorType"].(string)
+	errMsg, _ := info["error"].(string)
+
+	if attempt <= 0 {
+		return nil
+	}
+
+	delay := time.Duration(delayNs) * time.Nanosecond
+	delayStr := delay.Round(time.Millisecond).String()
+	if delay >= time.Second {
+		delayStr = fmt.Sprintf("%.1fs", delay.Seconds())
+	}
+
+	label := errorType
+	if label == "" {
+		label = "unknown"
+	}
+
+	text := fmt.Sprintf("ai: LLM retry %d/%d (%s, waiting %s)",
+		attempt, maxRetries, label, delayStr)
+	if errMsg != "" {
+		text += ": " + truncate(errMsg, 120)
+	}
+
+	return &FormattedEvent{Kind: KindMeta, Role: "ai", Text: text}
+}
+
 
 // formatToolDetail tries to extract a short summary of tool arguments.
 func formatToolDetail(evt map[string]any, toolName string) string {

--- a/pkg/run/conv_test.go
+++ b/pkg/run/conv_test.go
@@ -735,3 +735,48 @@ func containsSubstr(s, sub string) bool {
 	}
 	return false
 }
+
+func TestParseEvent_LLMRetry(t *testing.T) {
+	raw := `{"type":"llm_retry","llmRetry":{"attempt":3,"maxRetries":8,"delay":12000000000,"errorType":"rate_limit","error":"rate limit exceeded"}}`
+	evt := ParseEvent(raw)
+	if evt == nil {
+		t.Fatal("expected non-nil event for llm_retry")
+	}
+	if evt.Kind != KindMeta {
+		t.Fatalf("expected KindMeta, got %s", evt.Kind)
+	}
+	if !contains(evt.Text, "retry 3/8") {
+		t.Fatalf("expected attempt info, got: %s", evt.Text)
+	}
+	if !contains(evt.Text, "rate_limit") {
+		t.Fatalf("expected error type, got: %s", evt.Text)
+	}
+	if !contains(evt.Text, "12.0s") {
+		t.Fatalf("expected delay, got: %s", evt.Text)
+	}
+	if !contains(evt.Text, "rate limit exceeded") {
+		t.Fatalf("expected error message, got: %s", evt.Text)
+	}
+}
+
+func TestParseEvent_LLMRetry_NoInfo(t *testing.T) {
+	raw := `{"type":"llm_retry"}`
+	evt := ParseEvent(raw)
+	if evt != nil {
+		t.Fatalf("expected nil for llm_retry without llmRetry field, got: %v", evt)
+	}
+}
+
+func TestParseEvent_LLMRetry_ServerError(t *testing.T) {
+	raw := `{"type":"llm_retry","llmRetry":{"attempt":1,"maxRetries":3,"delay":1000000000,"errorType":"server"}}`
+	evt := ParseEvent(raw)
+	if evt == nil {
+		t.Fatal("expected non-nil event for llm_retry")
+	}
+	if !contains(evt.Text, "retry 1/3") {
+		t.Fatalf("expected attempt info, got: %s", evt.Text)
+	}
+	if !contains(evt.Text, "server") {
+		t.Fatalf("expected error type, got: %s", evt.Text)
+	}
+}


### PR DESCRIPTION
## Summary

Three related improvements for subagent observability and control:

### 1. `ai watch --follow --timeout` flag
- **No flag** (default): exit on `agent_end` — one-shot task complete
- **`--timeout 0`**: wait forever (until process exits or killed)
- **`--timeout 20m`**: wait up to 20 minutes

Covers 90% of subagent use cases with default one-shot behavior.

### 2. `llm_retry` event rendering
Rate-limit retries were invisible to watchers, causing apparent ~165s "freezes". Now renders as:
```
ai: LLM retry 3/8 (rate_limit, waiting 12.0s): ...
```

### 3. RPC server timeout fix
`ai serve --timeout` was not actually causing process exit because `RunWithIO` blocked on stdin. Fixed by:
- `contextReader`: wraps `io.Reader` with `context.Context` for cancellable reads
- `server.Cancel()`: unblocks `RunWithIO` from watchdog goroutine

## Files Changed

| File | Change |
|------|--------|
| `cmd/ai/watch.go` | `--timeout` flag + timeout-based agent_end logic |
| `pkg/run/conv.go` | `parseLLMRetry()` + `time` import |
| `pkg/run/conv_test.go` | 3 tests for llm_retry parsing |
| `pkg/rpc/server.go` | `contextReader` + `server.Cancel()` |
| `pkg/rpc/server_test.go` | 3 tests for contextReader |
| `cmd/ai/rpc_handlers.go` | Watchdog moved after server creation + Cancel() call |

## Testing

All existing + new tests pass:
- `TestParseEvent_LLMRetry*` (3 tests)
- `TestContextReader*` (3 tests)
- Full `go test ./...`