### PR TITLE
bench: remove ag dependency, fix io.Pipe deadlock

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -40,11 +40,11 @@ help:
 	@echo "  make ab-report           输出历史 A/B 报告"
 	@echo ""
 	@echo "Options:"
-	@echo "  AGENT=ai                 指定 agent 二进制 (默认: /Users/genius/go/bin/ai)"
+			@echo "  AGENT=ai                 指定 agent 二进制 (默认: /Users/genius/go/bin/ai)"
 	@echo "  AGENTS=\"a b\"            A/B 对比的 agent 列表"
 	@echo "  MODEL=minimax            A/B 运行模型名（会透传到 ab_test.py）"
 	@echo "  TASK=task_id             A/B 或 bench 运行单任务"
-	@echo "  TIMEOUT=0                单任务超时 (默认: 0=不限制)"
+		@echo "  TIMEOUT=0                单任务超时 (默认: 10m)"
 	@echo "  MAX_STEPS_MODE=soft      max_steps 判分模式: soft|hard (可选，不传则使用 runner/manifest 默认)"
 	@echo "  MANIFEST=tasks/xxx.json  指定 manifest (默认: tasks/fast-manifest.json, 63个快任务)"
 	@echo "                          使用 MANIFEST=tasks/all.json 可运行全部任务"
@@ -82,19 +82,19 @@ bench: bench-run
 bench-run: bench-build
 	@if [ -n "$(TASK)" ]; then \
 		echo "Running task: $(TASK)"; \
-				../../bin/benchmark --task $(TASK) --agent $(or $(AGENT),/Users/genius/go/bin/ai) --ag $(or $(AG),/Users/genius/go/bin/ag) --timeout $(or $(TIMEOUT),0) $(MAX_STEPS_MODE_FLAG) $(ASSERT_INIT_FAIL_FLAG); \
+				../../bin/benchmark --task $(TASK) --agent $(or $(AGENT),/Users/genius/go/bin/ai) --timeout $(or $(TIMEOUT),10m) $(MAX_STEPS_MODE_FLAG) $(ASSERT_INIT_FAIL_FLAG); \
 	else \
-		../../bin/benchmark --agent $(or $(AGENT),/Users/genius/go/bin/ai) --ag $(or $(AG),/Users/genius/go/bin/ag) --timeout $(or $(TIMEOUT),0) $(MAX_STEPS_MODE_FLAG) $(MANIFEST_FLAG) $(ASSERT_INIT_FAIL_FLAG) --clean; \
+		../../bin/benchmark --agent $(or $(AGENT),/Users/genius/go/bin/ai) --timeout $(or $(TIMEOUT),10m) $(MAX_STEPS_MODE_FLAG) $(MANIFEST_FLAG) $(ASSERT_INIT_FAIL_FLAG) --clean; \
 	fi
 
 # Verify all selected tasks fail before agent modifications
 bench-precheck: bench-build
 	@echo "Precheck manifest: $(PRECHECK_MANIFEST)"
-	../../bin/benchmark --precheck-only --ag $(or $(AG),/Users/genius/go/bin/ag) $(PRECHECK_MANIFEST_FLAG)
+	../../bin/benchmark --precheck-only $(PRECHECK_MANIFEST_FLAG)
 
 # Resume from previous progress
 bench-resume: bench-build
-		../../bin/benchmark --agent $(or $(AGENT),/Users/genius/go/bin/ai) --ag $(or $(AG),/Users/genius/go/bin/ag) --timeout $(or $(TIMEOUT),0) $(MAX_STEPS_MODE_FLAG) $(MANIFEST_FLAG) --resume $(or $(RESUME),results/progress.json)
+		../../bin/benchmark --agent $(or $(AGENT),/Users/genius/go/bin/ai) --timeout $(or $(TIMEOUT),10m) $(MAX_STEPS_MODE_FLAG) $(MANIFEST_FLAG) --resume $(or $(RESUME),results/progress.json)
 
 # List available benchmark tasks
 bench-list: bench-build
@@ -104,7 +104,7 @@ bench-list: bench-build
 bench-task: bench-build
 	@echo "Usage: make bench-task TASK=tbench/chess-best-move"
 	@echo "Or use: make bench-run TASK=tbench/chess-best-move"
-		../../bin/benchmark --task $(TASK) --agent $(or $(AGENT),../../bin/ai) --ag $(or $(AG),/Users/genius/go/bin/ag) --timeout $(or $(TIMEOUT),0) $(MAX_STEPS_MODE_FLAG) $(ASSERT_INIT_FAIL_FLAG)
+		../../bin/benchmark --task $(TASK) --agent $(or $(AGENT),../../bin/ai) --timeout $(or $(TIMEOUT),10m) $(MAX_STEPS_MODE_FLAG) $(ASSERT_INIT_FAIL_FLAG)
 
 # Import Terminal Bench 2.0 tasks
 bench-import:

--- a/benchmark/cmd/benchmark/main.go
+++ b/benchmark/cmd/benchmark/main.go
@@ -7,8 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-		"io"
-	"io/fs"
+			"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -170,10 +169,9 @@ type AgentRunner interface {
 	Name() string
 }
 
-// AIAgentRunner runs the ai agent via rpc mode with ag conv for output
+// AIAgentRunner runs the ai agent via rpc mode, parsing JSON events directly
 type AIAgentRunner struct {
 	BinaryPath string
-	AgBinary   string
 	MaxTurns   int
 	Timeout    time.Duration
 }
@@ -183,7 +181,7 @@ func (r *AIAgentRunner) Name() string {
 }
 
 func (r *AIAgentRunner) Run(taskDir string, prompt string) (string, error) {
-	var ctx context.Context
+		var ctx context.Context
 	var cancel context.CancelFunc
 
 	// Only set timeout if Timeout > 0
@@ -194,12 +192,8 @@ func (r *AIAgentRunner) Run(taskDir string, prompt string) (string, error) {
 		ctx = context.Background()
 	}
 
-			// Build the RPC prompt as JSON
+	// Build the RPC prompt as JSON
 	rpcPrompt := fmt.Sprintf(`{"type":"prompt","message":%q}`, prompt)
-
-	// Use ai --mode rpc piped through ag conv for full event output.
-	// NOTE: Do NOT use --only text here — analyzeAgentOutput() needs tool
-	// execution events to evaluate must_use_capabilities and success_criteria.
 
 	// Build RPC command with optional --max-turns and --timeout
 	aiArgs := []string{r.BinaryPath, "--mode", "rpc"}
@@ -209,50 +203,24 @@ func (r *AIAgentRunner) Run(taskDir string, prompt string) (string, error) {
 	if r.Timeout > 0 {
 		aiArgs = append(aiArgs, "--timeout", r.Timeout.String())
 	}
-	agArgs := []string{r.AgBinary, "conv"}
 
-	// Build a three-process pipeline: stdin(rpcPrompt) -> ai -> ag -> stdout+stderr
-	// We use direct exec.Command pipe instead of sh -c to avoid shell interpreting
-	// backticks and other special characters in the JSON payload.
+	// Run ai --mode rpc directly, capturing its JSON event stream on stdout.
+	// No longer pipes through ag conv — analyzeAgentOutput() parses raw JSON events.
 	aiCmd := exec.CommandContext(ctx, aiArgs[0], aiArgs[1:]...)
-	agCmd := exec.CommandContext(ctx, agArgs[0], agArgs[1:]...)
 
-		// Wire: stdin(rpcPrompt) -> ai -> ag -> stdout+stderr
 	var stdout, stderr bytes.Buffer
 	aiCmd.Stdin = bytes.NewBufferString(rpcPrompt)
-	agCmd.Stdout = &stdout
-	agCmd.Stderr = &stderr
+	aiCmd.Stdout = &stdout
+	aiCmd.Stderr = &stderr
 
-	// Pipe ai stdout -> ag stdin
-	aiAgPipe, aiAgWriter := io.Pipe()
-	aiCmd.Stdout = aiAgWriter
-	agCmd.Stdin = aiAgPipe
-
-	// Set working directory to task dir
 	aiCmd.Dir = taskDir
-	agCmd.Dir = taskDir
 	aiCmd.Env = nonInteractiveCommandEnv()
-	agCmd.Env = nonInteractiveCommandEnv()
 
-	// Start all processes
 	if err := aiCmd.Start(); err != nil {
 		return "", fmt.Errorf("failed to start ai: %w", err)
 	}
-	if err := agCmd.Start(); err != nil {
-		aiCmd.Process.Kill()
-		return "", fmt.Errorf("failed to start ag: %w", err)
-	}
 
-		// Wait for ai to finish, then close pipe writer
-	aiDone := make(chan error, 1)
-	go func() {
-		aiDone <- aiCmd.Wait()
-		aiAgWriter.Close()
-	}()
-
-	// Wait for ag to finish
-	agErr := agCmd.Wait()
-	aiErr := <-aiDone
+		aiErr := aiCmd.Wait()
 
 	output := stdout.String()
 	if stderr.Len() > 0 {
@@ -261,9 +229,6 @@ func (r *AIAgentRunner) Run(taskDir string, prompt string) (string, error) {
 
 	if aiErr != nil {
 		return output, aiErr
-	}
-	if agErr != nil {
-		return output, agErr
 	}
 	return output, nil
 }
@@ -708,29 +673,10 @@ func analyzeAgentOutput(output string) ProcessMetrics {
 
 	lines := strings.Split(output, "\n")
 	for _, line := range lines {
-		if events := parseCodexEvents(line); len(events) > 0 {
-			for _, ev := range events {
-				applyEventSignals(&metrics, ev, seenTools, seenCapabilities, logFiles)
-			}
-			continue
+		events := parseRPCEvents(line)
+		for _, ev := range events {
+			applyEventSignals(&metrics, ev, seenTools, seenCapabilities, logFiles)
 		}
-
-		tool, payload, ok := parseToolLine(line)
-		if !ok {
-			continue
-		}
-
-		event := toolEvent{
-			Tool:    tool,
-			Payload: payload,
-			Command: extractArgValue(payload, "command"),
-		}
-		event.File = extractArgValue(payload, "file")
-		if event.File == "" {
-			event.File = extractArgValue(payload, "path")
-		}
-
-		applyEventSignals(&metrics, event, seenTools, seenCapabilities, logFiles)
 	}
 
 	if metrics.FirstEditIndex > 0 {
@@ -846,40 +792,14 @@ func eventHasReadSignal(event toolEvent) bool {
 	return tool == "bash" && isReadCommand(strings.ToLower(event.Command))
 }
 
-func parseToolLine(line string) (string, string, bool) {
-	// Format 1: ag conv output — "🔧 toolName key=val key2=val2"
-	if strings.Contains(line, "🔧") {
-		rest := strings.TrimSpace(strings.SplitN(line, "🔧", 2)[1])
-		parts := strings.SplitN(rest, " ", 2)
-		tool := parts[0]
-		payload := ""
-		if len(parts) > 1 {
-			payload = parts[1]
-		}
-		if tool != "" {
-			return tool, payload, true
-		}
-	}
-
-	// Format 2: legacy "• tool: payload"
-	bulletPos := strings.Index(line, "•")
-	if bulletPos == -1 {
-		return "", "", false
-	}
-	rest := strings.TrimSpace(line[bulletPos+len("•"):])
-	parts := strings.SplitN(rest, ":", 2)
-	if len(parts) != 2 {
-		return "", "", false
-	}
-
-	tool := strings.TrimSpace(parts[0])
-	if tool == "" {
-		return "", "", false
-	}
-	return tool, strings.TrimSpace(parts[1]), true
-}
-
-func parseCodexEvents(line string) []toolEvent {
+// parseRPCEvents parses a single line from ai --mode rpc JSON event stream.
+// It extracts tool calls from tool_execution_start and tool_execution_end events.
+//
+// Event formats produced by ai rpc:
+//
+//	{"type":"tool_execution_start","toolName":"read","args":{"path":"/foo/bar.go"},...}
+//	{"type":"tool_execution_end","toolName":"bash","result":{...},...}
+func parseRPCEvents(line string) []toolEvent {
 	line = strings.TrimSpace(line)
 	if !strings.HasPrefix(line, "{") {
 		return nil
@@ -891,66 +811,48 @@ func parseCodexEvents(line string) []toolEvent {
 	}
 
 	typ, _ := envelope["type"].(string)
-	item, ok := envelope["item"].(map[string]any)
-	if !ok {
-		return nil
-	}
-	itemType, _ := item["type"].(string)
 
-	if typ == "item.started" && itemType == "command_execution" {
-		command, _ := item["command"].(string)
-		if command == "" {
+	switch typ {
+	case "tool_execution_start":
+		toolName, _ := envelope["toolName"].(string)
+		if toolName == "" {
 			return nil
 		}
-		return []toolEvent{{
-			Tool:    "bash",
-			Payload: command,
-			Command: command,
-		}}
-	}
+		args, _ := envelope["args"].(map[string]any)
 
-	if typ == "item.completed" && itemType == "file_change" {
-		rawChanges, ok := item["changes"].([]any)
-		if !ok || len(rawChanges) == 0 {
-			return nil
+		event := toolEvent{Tool: toolName}
+
+		// Extract file path from args
+		if path, ok := args["path"].(string); ok {
+			event.File = path
+		} else if file, ok := args["file"].(string); ok {
+			event.File = file
 		}
 
-		events := make([]toolEvent, 0, len(rawChanges))
-		for _, raw := range rawChanges {
-			change, ok := raw.(map[string]any)
-			if !ok {
-				continue
+		// Extract command for bash tool
+		if cmd, ok := args["command"].(string); ok {
+			event.Command = cmd
+			event.Payload = cmd
+		}
+
+		// For tools with structured args, store a compact representation
+		if event.Payload == "" && len(args) > 0 {
+			if bs, err := json.Marshal(args); err == nil {
+				event.Payload = string(bs)
 			}
-			path, _ := change["path"].(string)
-			events = append(events, toolEvent{
-				Tool: "edit",
-				File: path,
-			})
 		}
-		if len(events) == 0 {
-			return nil
-		}
-		return events
+
+		return []toolEvent{event}
+
+		case "tool_execution_end":
+		// tool_execution_end events don't add new tool calls —
+		// tool_execution_start already captured the invocation.
+		// We may want to extract result text here in the future for
+		// detecting test output patterns.
+		return nil
 	}
 
 	return nil
-}
-
-func extractArgValue(payload, key string) string {
-	pat := key + "="
-	idx := strings.Index(payload, pat)
-	if idx == -1 {
-		return ""
-	}
-	s := payload[idx+len(pat):]
-	end := len(s)
-	for _, sep := range []string{",", "]"} {
-		if i := strings.Index(s, sep); i >= 0 && i < end {
-			end = i
-		}
-	}
-	value := strings.TrimSpace(s[:end])
-	return strings.Trim(value, `"'`)
 }
 
 func isSearchCommand(cmd string) bool {
@@ -1610,8 +1512,7 @@ func main() {
 	var (
 				tasksDir          = flag.String("tasks", "tasks", "Tasks directory")
 		resultsDir        = flag.String("results", "results", "Results directory")
-		agentBinary       = flag.String("agent", "/Users/genius/go/bin/ai", "Agent binary path (ai)")
-		agBinary          = flag.String("ag", "ag", "ag CLI binary path (for ag conv)")
+				agentBinary       = flag.String("agent", "/Users/genius/go/bin/ai", "Agent binary path (ai)")
 		maxTurns          = flag.Int("max-turns", 50, "Maximum agent turns")
 		timeout           = flag.Duration("timeout", 10*time.Minute, "Per-task timeout")
 		manifestPath      = flag.String("manifest", "", "Task manifest path (JSON)")
@@ -1638,14 +1539,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error resolving results dir: %v\n", err)
 		os.Exit(1)
 	}
-		absAgentBinary, err := filepath.Abs(*agentBinary)
+			absAgentBinary, err := filepath.Abs(*agentBinary)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error resolving agent binary: %v\n", err)
-		os.Exit(1)
-	}
-	absAgBinary, err := filepath.Abs(*agBinary)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error resolving ag binary: %v\n", err)
 		os.Exit(1)
 	}
 	absManifestPath := ""
@@ -1658,9 +1554,8 @@ func main() {
 	}
 
 	// Create agent runner
-		agent := &AIAgentRunner{
+			agent := &AIAgentRunner{
 		BinaryPath: absAgentBinary,
-		AgBinary:   absAgBinary,
 		MaxTurns:   *maxTurns,
 		Timeout:    *timeout,
 	}

--- a/benchmark/cmd/benchmark/main_test.go
+++ b/benchmark/cmd/benchmark/main_test.go
@@ -9,14 +9,24 @@ import (
 	"testing"
 )
 
+// rpcToolStart builds a tool_execution_start JSON line as produced by ai --mode rpc.
+func rpcToolStart(tool string, args map[string]any) string {
+	envelope := map[string]any{
+		"type":     "tool_execution_start",
+		"toolName": tool,
+		"args":     args,
+	}
+	b, _ := json.Marshal(envelope)
+	return string(b)
+}
+
 func TestAnalyzeAgentOutput(t *testing.T) {
-	output := `=== Turn 1 ===
-Tool calls:
-  • bash: [command=grep -n BUG app.py]
-  • read: [path=setup/app.py]
-  • edit: [file=setup/app.py]
-  • bash: [command=python3 -m pytest tests/test_app.py -v]
-`
+	output := strings.Join([]string{
+		rpcToolStart("bash", map[string]any{"command": "grep -n BUG app.py"}),
+		rpcToolStart("read", map[string]any{"path": "setup/app.py"}),
+		rpcToolStart("edit", map[string]any{"file": "setup/app.py"}),
+		rpcToolStart("bash", map[string]any{"command": "python3 -m pytest tests/test_app.py -v"}),
+	}, "\n")
 
 	metrics := analyzeAgentOutput(output)
 
@@ -55,12 +65,12 @@ func TestEvaluateTaskConstraints(t *testing.T) {
 		t.Fatalf("write constraints: %v", err)
 	}
 
-	output := `Tool calls:
-  • grep: [pattern=BUG path=app.py]
-  • read: [path=app.py]
-  • edit: [file=app.py]
-  • test: [command=pytest]
-`
+	output := strings.Join([]string{
+		rpcToolStart("bash", map[string]any{"command": "grep -n BUG app.py"}),
+		rpcToolStart("read", map[string]any{"path": "app.py"}),
+		rpcToolStart("edit", map[string]any{"file": "app.py"}),
+		rpcToolStart("bash", map[string]any{"command": "pytest"}),
+	}, "\n")
 	metrics := analyzeAgentOutput(output)
 
 	bench := &Benchmark{MaxStepsMode: "hard"}
@@ -82,9 +92,11 @@ func TestEvaluateTaskConstraints(t *testing.T) {
 	}
 }
 
-func TestAnalyzeAgentOutputWithCodexJSON(t *testing.T) {
-	output := `{"type":"item.started","item":{"id":"item_2","type":"command_execution","command":"/bin/zsh -lc 'grep -n BUG app.py'","status":"in_progress"}}
-{"type":"item.started","item":{"id":"item_3","type":"command_execution","command":"/bin/zsh -lc 'python3 -m pytest tests/test_app.py -v'","status":"in_progress"}}`
+func TestAnalyzeAgentOutputWithBashToolEvents(t *testing.T) {
+	output := strings.Join([]string{
+		rpcToolStart("bash", map[string]any{"command": "grep -n BUG app.py"}),
+		rpcToolStart("bash", map[string]any{"command": "python3 -m pytest tests/test_app.py -v"}),
+	}, "\n")
 
 	metrics := analyzeAgentOutput(output)
 	if metrics.TotalToolCalls != 2 {
@@ -101,17 +113,19 @@ func TestAnalyzeAgentOutputWithCodexJSON(t *testing.T) {
 	}
 }
 
-func TestAnalyzeAgentOutputWithCodexFileChangeAndReadSignals(t *testing.T) {
-	output := `{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc 'nl -ba stage1_load.py'","status":"in_progress"}}
-{"type":"item.started","item":{"id":"item_2","type":"command_execution","command":"/bin/zsh -lc 'bash ../verify.sh'","status":"in_progress"}}
-{"type":"item.completed","item":{"id":"item_3","type":"file_change","changes":[{"path":"/tmp/task/setup/stage5_save.py","kind":"update"}],"status":"completed"}}`
+func TestAnalyzeAgentOutputWithFileChangeAndReadSignals(t *testing.T) {
+	output := strings.Join([]string{
+		rpcToolStart("bash", map[string]any{"command": "nl -ba stage1_load.py"}),
+		rpcToolStart("bash", map[string]any{"command": "bash ../verify.sh"}),
+		rpcToolStart("edit", map[string]any{"file": "/tmp/task/setup/stage5_save.py"}),
+	}, "\n")
 
 	metrics := analyzeAgentOutput(output)
 	if metrics.ReadCalls < 1 {
 		t.Fatalf("expected read call inferred from bash command, got %d", metrics.ReadCalls)
 	}
 	if metrics.EditCalls < 1 {
-		t.Fatalf("expected edit call inferred from file_change, got %d", metrics.EditCalls)
+		t.Fatalf("expected edit call, got %d", metrics.EditCalls)
 	}
 	if !metrics.ReadStage1 {
 		t.Fatalf("expected stage1 read signal")
@@ -143,7 +157,7 @@ func TestEvaluateTaskConstraintsReadRequirementWithBashCommands(t *testing.T) {
 		t.Fatalf("write constraints: %v", err)
 	}
 
-	output := `{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc 'cat app.py'","status":"in_progress"}}`
+	output := rpcToolStart("bash", map[string]any{"command": "cat app.py"})
 	metrics := analyzeAgentOutput(output)
 
 	bench := &Benchmark{MaxStepsMode: "soft"}
@@ -181,12 +195,12 @@ func TestEvaluateTaskConstraintsSoftMaxSteps(t *testing.T) {
 		t.Fatalf("write constraints: %v", err)
 	}
 
-	output := `Tool calls:
-  • read: [path=app.py]
-  • edit: [file=app.py]
-  • test: [command=pytest]
-  • test: [command=pytest]
-`
+	output := strings.Join([]string{
+		rpcToolStart("read", map[string]any{"path": "app.py"}),
+		rpcToolStart("edit", map[string]any{"file": "app.py"}),
+		rpcToolStart("bash", map[string]any{"command": "pytest"}),
+		rpcToolStart("bash", map[string]any{"command": "pytest"}),
+	}, "\n")
 	metrics := analyzeAgentOutput(output)
 	bench := &Benchmark{MaxStepsMode: "soft"}
 	violations, softViolations, score, checked, err := bench.evaluateTaskConstraints(Task{Dir: taskDir}, metrics, true)
@@ -224,12 +238,12 @@ func TestEvaluateTaskConstraintsTaskHardOverride(t *testing.T) {
 		t.Fatalf("write constraints: %v", err)
 	}
 
-	output := `Tool calls:
-  • read: [path=app.py]
-  • edit: [file=app.py]
-  • test: [command=pytest]
-  • test: [command=pytest]
-`
+	output := strings.Join([]string{
+		rpcToolStart("read", map[string]any{"path": "app.py"}),
+		rpcToolStart("edit", map[string]any{"file": "app.py"}),
+		rpcToolStart("bash", map[string]any{"command": "pytest"}),
+		rpcToolStart("bash", map[string]any{"command": "pytest"}),
+	}, "\n")
 	metrics := analyzeAgentOutput(output)
 	bench := &Benchmark{MaxStepsMode: "soft"}
 	violations, softViolations, _, checked, err := bench.evaluateTaskConstraints(Task{Dir: taskDir}, metrics, true)


### PR DESCRIPTION
## Summary

The benchmark runner previously piped `ai --mode rpc` stdout through `ag conv` to convert JSON events into text format. This caused an **io.Pipe deadlock** when `ag conv` exited prematurely.

### Root Cause
```
ai rpc (stdout) → io.PipeWriter → [io.Pipe] → io.PipeReader → ag conv (stdin)
```
1. `ag conv` exits (stale binary, flag error, or normal completion)
2. Nobody reads from `io.PipeReader` anymore
3. `io.Pipe` is synchronous (no buffer) — `ai` blocks on stdout write forever
4. `--timeout 0` (Makefile default) → no timeout safety net → **permanent hang**

### Changes
- **Remove ag conv subprocess and io.Pipe pipeline** — run `ai --mode rpc` directly
- **Add `parseRPCEvents()`** — parses `tool_execution_start` JSON events directly
- **Remove `parseToolLine()`** (ag conv text format `🔧 toolName`) and `parseCodexEvents()`
- **Remove `--ag` flag** from CLI and Makefile
- **Change default timeout** from `0` (infinite) to `10m`
- **Update all tests** to use ai rpc JSON event format

### Testing
- `go test -short ./... -race` — all pass
- `go vet` — clean
- Live: `001_fix_off_by_one` passes in 14.5s (was hanging indefinitely)
- Live: `002_add_error_handling` passes in 18.1s
- Tool metrics correctly extracted: read, edit, bash counts verified

### Related
- PR #247 (fix/send-timeout) fixes a **different** deadlock in `ai run` socket handler (writing to dead subprocess stdin). Both fixes are needed.

### Stats
```
benchmark/Makefile                   |  14 +--
benchmark/cmd/benchmark/main.go      | 213 +++++----- (net -91 lines)
benchmark/cmd/benchmark/main_test.go |  84 ++---
3 files changed, 110 insertions(+), 201 deletions(-)
```