### PR TITLE
Fix: [P2 ENHANCEMENT] Convert skill invocation to tool call pattern - enable truncation

### DIFF
--- a/cmd/ai/handler_steer_followup_test.go
+++ b/cmd/ai/handler_steer_followup_test.go
@@ -23,10 +23,14 @@ func newTestApp(t *testing.T) *rpcApp {
 	})
 
 	return &rpcApp{
-		ag:                ag,
-		steeringMode:      "all",
-		followUpMode:      "all",
-		expandSkillCommands: func(text string) string { return text },
+		ag:                    ag,
+		steeringMode:           "all",
+		followUpMode:           "all",
+		expandSkillCommands:     func(text string) string { return text },
+		expandSkillCommandsAsMessages: func(text string) (string, []agentctx.AgentMessage) {
+			return text, nil
+		},
+		generateToolCallID:    func() string { return "test_call_id" },
 		compactBeforeRequest: func(trigger string) {},
 	}
 }

--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -115,8 +115,10 @@ type rpcApp struct {
 	createBaseContext               func() *agentctx.AgentContext
 	setAgentContext                 func(ctx *agentctx.AgentContext)
 	expandSkillCommands             func(text string) string
+	expandSkillCommandsAsMessages   func(text string) (userMsg string, injectedMsgs []agentctx.AgentMessage)
 	compactBeforeRequest            func(trigger string)
 	updateCheckpointManager         func() error
+	generateToolCallID             func() string
 }
 
 // parseJSONArgs attempts to unmarshal args as JSON into target.
@@ -297,6 +299,91 @@ func (app *rpcApp) initHelpers() {
 			}
 		}
 		return expanded
+	}
+
+	// expandSkillCommandsAsMessages converts /skill:xxx to ToolCall + ToolResult messages.
+	// Returns (userMessage, injectedMessages) where:
+	// - userMessage: original text (e.g., "/skill:pge" or unchanged if not a skill command)
+	// - injectedMessages: [AssistantMessage(ToolCall), ToolResultMessage] if skill command, nil otherwise
+	app.expandSkillCommandsAsMessages = func(text string) (string, []agentctx.AgentMessage) {
+		if !skill.IsSkillCommand(text) {
+			return text, nil
+		}
+
+		skillName := skill.ExtractSkillName(text)
+		app.skillStats.RecordUsage(skillName)
+		if err := app.skillStats.Save(); err != nil {
+			slog.Error("Failed to save skill stats", "skill", skillName, "error", err)
+		}
+
+		// Find the skill
+		var foundSkill *skill.Skill
+		for i := range app.skillResult.Skills {
+			if app.skillResult.Skills[i].Name == skillName {
+				foundSkill = &app.skillResult.Skills[i]
+				break
+			}
+		}
+
+		if foundSkill == nil {
+			// Skill not found, return original text (fallback behavior)
+			return text, nil
+		}
+
+		// Generate unique tool call ID
+		toolCallID := app.generateToolCallID()
+
+		// Create assistant message with tool call
+		asstMsg := agentctx.NewAssistantMessage()
+		asstMsg.Content = []agentctx.ContentBlock{
+			agentctx.ToolCallContent{
+				ID:   toolCallID,
+				Type:  "toolCall",
+				Name:  "load_skill",
+				Arguments: map[string]any{
+					"name": skillName,
+				},
+			},
+		}
+
+		// Build skill content in XML format (same as ExpandCommand)
+		skillBlock := fmt.Sprintf(`<skill name="%s" location="%s">
+References are relative to %s.
+
+%s
+</skill>`,
+			skill.EscapeXML(foundSkill.Name),
+			skill.EscapeXML(foundSkill.FilePath),
+			skill.EscapeXML(foundSkill.BaseDir),
+			foundSkill.Content,
+		)
+
+		// Create tool result message with skill content
+		toolResultMsg := agentctx.NewToolResultMessage(
+			toolCallID,
+			"load_skill",
+			[]agentctx.ContentBlock{
+				agentctx.TextContent{
+					Type: "text",
+					Text: skillBlock,
+				},
+			},
+			false, // isError
+		)
+
+		slog.Info("Converted skill invocation to tool call pattern",
+			"original", text,
+			"skill", skillName,
+			"tool_call_id", toolCallID,
+			"chars", len(skillBlock))
+
+		return text, []agentctx.AgentMessage{asstMsg, toolResultMsg}
+	}
+
+	app.generateToolCallID = func() string {
+		// Generate simple unique ID for tool calls
+		// Using timestamp + random number format
+		return fmt.Sprintf("call_skill_%d", time.Now().UnixNano())
 	}
 
 	app.compactBeforeRequest = func(trigger string) {
@@ -602,8 +689,19 @@ func (app *rpcApp) handlePrompt(cmd rpc.RPCCommand) (any, error) {
 
 	// Expand /skill:name commands BEFORE generic slash dispatch.
 	if skill.IsSkillCommand(message) {
-		expandedMessage := app.expandSkillCommands(message)
-		slog.Info("Expanded skill command", "original", message, "skill", skill.ExtractSkillName(message))
+		userMsg, injectedMsgs := app.expandSkillCommandsAsMessages(message)
+
+		if len(injectedMsgs) > 0 {
+			slog.Info("Injecting skill tool call messages",
+				"original", message,
+				"injected_count", len(injectedMsgs))
+
+			// Inject ToolCall + ToolResult messages into agent context
+			agentCtx := app.ag.GetContext()
+			for _, msg := range injectedMsgs {
+				agentCtx.AddMessage(msg)
+			}
+		}
 
 		app.stateMu.Lock()
 		streaming := app.isStreaming
@@ -613,12 +711,12 @@ func (app *rpcApp) handlePrompt(cmd rpc.RPCCommand) (any, error) {
 			app.stateMu.Lock()
 			app.pendingSteer = true
 			app.stateMu.Unlock()
-			app.ag.Steer(expandedMessage)
+			app.ag.Steer(userMsg)
 			return nil, nil
 		}
 
 		app.compactBeforeRequest("pre_request_prompt")
-		return nil, app.ag.Prompt(expandedMessage)
+		return nil, app.ag.Prompt(userMsg)
 	}
 
 	// Intercept slash commands
@@ -691,9 +789,21 @@ func (app *rpcApp) handleSteer(cmd rpc.RPCCommand) (any, error) {
 		return nil, fmt.Errorf("empty steer message")
 	}
 
-	expandedMessage := app.expandSkillCommands(message)
+	userMsg, injectedMsgs := app.expandSkillCommandsAsMessages(message)
 	if skill.IsSkillCommand(message) {
 		slog.Info("Expanded skill command in steer", "original", message, "skill", skill.ExtractSkillName(message))
+	}
+
+	if len(injectedMsgs) > 0 {
+		slog.Info("Injecting skill tool call messages in steer",
+			"original", message,
+			"injected_count", len(injectedMsgs))
+
+		// Inject ToolCall + ToolResult messages into agent context
+		agentCtx := app.ag.GetContext()
+		for _, msg := range injectedMsgs {
+			agentCtx.AddMessage(msg)
+		}
 	}
 
 	app.stateMu.Lock()
@@ -710,7 +820,7 @@ func (app *rpcApp) handleSteer(cmd rpc.RPCCommand) (any, error) {
 	app.stateMu.Lock()
 	app.pendingSteer = true
 	app.stateMu.Unlock()
-	app.ag.Steer(expandedMessage)
+	app.ag.Steer(userMsg)
 	return nil, nil
 }
 
@@ -732,9 +842,21 @@ func (app *rpcApp) handleFollowUp(cmd rpc.RPCCommand) (any, error) {
 		return nil, fmt.Errorf("empty follow-up message")
 	}
 
-	expandedMessage := app.expandSkillCommands(message)
+	userMsg, injectedMsgs := app.expandSkillCommandsAsMessages(message)
 	if skill.IsSkillCommand(message) {
 		slog.Info("Expanded skill command in follow_up", "original", message, "skill", skill.ExtractSkillName(message))
+	}
+
+	if len(injectedMsgs) > 0 {
+		slog.Info("Injecting skill tool call messages in follow_up",
+			"original", message,
+			"injected_count", len(injectedMsgs))
+
+		// Inject ToolCall + ToolResult messages into agent context
+		agentCtx := app.ag.GetContext()
+		for _, msg := range injectedMsgs {
+			agentCtx.AddMessage(msg)
+		}
 	}
 
 	app.stateMu.Lock()
@@ -743,7 +865,7 @@ func (app *rpcApp) handleFollowUp(cmd rpc.RPCCommand) (any, error) {
 	if mode == "one-at-a-time" && app.ag.GetPendingFollowUps() > 0 {
 		return nil, fmt.Errorf("follow-up queue already has a pending message")
 	}
-	return nil, app.ag.FollowUp(expandedMessage)
+	return nil, app.ag.FollowUp(userMsg)
 }
 
 

--- a/pkg/skill/formatter.go
+++ b/pkg/skill/formatter.go
@@ -120,6 +120,11 @@ func FormatForPrompt(skills []Skill, stats *SkillStatsFile) string {
 	return strings.Join(lines, "\n")
 }
 
+// EscapeXML escapes special XML characters.
+func EscapeXML(s string) string {
+	return escapeXML(s)
+}
+
 // escapeXML escapes special XML characters.
 func escapeXML(s string) string {
 	s = strings.ReplaceAll(s, "&", "&amp;")

--- a/pkg/tools/skill_loader.go
+++ b/pkg/tools/skill_loader.go
@@ -1,0 +1,84 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+
+	"github.com/tiancaiamao/ai/pkg/skill"
+)
+
+// LoadSkillTool loads a skill's content and returns it formatted as XML.
+// This tool is used internally when users invoke /skill:xxx commands.
+type LoadSkillTool struct {
+	skills []skill.Skill
+}
+
+// NewLoadSkillTool creates a new LoadSkill tool.
+func NewLoadSkillTool(skills []skill.Skill) *LoadSkillTool {
+	return &LoadSkillTool{skills: skills}
+}
+
+// Name returns the tool name.
+func (t *LoadSkillTool) Name() string {
+	return "load_skill"
+}
+
+// Description returns the tool description.
+func (t *LoadSkillTool) Description() string {
+	return "Load a skill by name and return its content formatted as XML."
+}
+
+// Parameters returns the JSON Schema for the tool parameters.
+func (t *LoadSkillTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Name of the skill to load",
+			},
+		},
+		"required": []string{"name"},
+	}
+}
+
+// Execute loads the skill and returns its content.
+func (t *LoadSkillTool) Execute(ctx context.Context, args map[string]any) ([]agentctx.ContentBlock, error) {
+	name, ok := args["name"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid name argument")
+	}
+
+	// Find the skill
+	var foundSkill *skill.Skill
+	for i := range t.skills {
+		if t.skills[i].Name == name {
+			foundSkill = &t.skills[i]
+			break
+		}
+	}
+
+	if foundSkill == nil {
+		return nil, fmt.Errorf("skill not found: %s", name)
+	}
+
+	// Build skill block in XML format (same format as ExpandCommand)
+	skillBlock := fmt.Sprintf(`<skill name="%s" location="%s">
+References are relative to %s.
+
+%s
+</skill>`,
+		skill.EscapeXML(foundSkill.Name),
+		skill.EscapeXML(foundSkill.FilePath),
+		skill.EscapeXML(foundSkill.BaseDir),
+		foundSkill.Content,
+	)
+
+	return []agentctx.ContentBlock{
+		agentctx.TextContent{
+			Type: "text",
+			Text: skillBlock,
+		},
+	}, nil
+}

--- a/pkg/tools/skill_loader_test.go
+++ b/pkg/tools/skill_loader_test.go
@@ -1,0 +1,208 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/skill"
+)
+
+func TestLoadSkillTool_Name(t *testing.T) {
+	tool := NewLoadSkillTool(nil)
+	if tool.Name() != "load_skill" {
+		t.Errorf("Expected name 'load_skill', got '%s'", tool.Name())
+	}
+}
+
+func TestLoadSkillTool_Description(t *testing.T) {
+	tool := NewLoadSkillTool(nil)
+	if tool.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestLoadSkillTool_Parameters(t *testing.T) {
+	tool := NewLoadSkillTool(nil)
+	params := tool.Parameters()
+
+	if params["type"] != "object" {
+		t.Errorf("Expected type 'object', got '%v'", params["type"])
+	}
+
+	props, ok := params["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("properties should be a map[string]any")
+	}
+
+	if _, exists := props["name"]; !exists {
+		t.Error("parameters should have 'name' property")
+	}
+
+	required, ok := params["required"]
+	if !ok {
+		t.Fatal("required should be present")
+	}
+
+	// Check if it's a []string or []any
+	requiredSlice, ok := required.([]string)
+	if !ok {
+		// Try []any
+		requiredAny, ok := required.([]any)
+		if !ok {
+			t.Fatalf("required should be an array, got %T", required)
+		}
+		if len(requiredAny) != 1 || requiredAny[0] != "name" {
+			t.Errorf("Expected required=['name'], got %v", requiredAny)
+		}
+	} else {
+		if len(requiredSlice) != 1 || requiredSlice[0] != "name" {
+			t.Errorf("Expected required=['name'], got %v", requiredSlice)
+		}
+	}
+}
+
+func TestLoadSkillTool_Execute_Success(t *testing.T) {
+	skills := []skill.Skill{
+		{
+			Name:      "test-skill",
+			FilePath:  "/path/to/test/skill.md",
+			BaseDir:   "/path/to/test",
+			Content:   "Skill content here",
+		},
+	}
+
+	tool := NewLoadSkillTool(skills)
+	ctx := context.Background()
+	args := map[string]any{
+		"name": "test-skill",
+	}
+
+	content, err := tool.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if len(content) != 1 {
+		t.Fatalf("Expected 1 content block, got %d", len(content))
+	}
+
+	textContent, ok := content[0].(agentctx.TextContent)
+	if !ok {
+		t.Fatalf("Expected TextContent, got %T", content[0])
+	}
+
+	expectedContent := `<skill name="test-skill" location="/path/to/test/skill.md">
+References are relative to /path/to/test.
+
+Skill content here
+</skill>`
+
+	if textContent.Text != expectedContent {
+		t.Errorf("Content mismatch:\nGot:\n%s\n\nExpected:\n%s", textContent.Text, expectedContent)
+	}
+}
+
+func TestLoadSkillTool_Execute_NotFound(t *testing.T) {
+	skills := []skill.Skill{
+		{
+			Name:     "existing-skill",
+			FilePath: "/path/to/skill.md",
+			BaseDir:  "/path/to",
+			Content:  "Content",
+		},
+	}
+
+	tool := NewLoadSkillTool(skills)
+	ctx := context.Background()
+	args := map[string]any{
+		"name": "non-existent-skill",
+	}
+
+	_, err := tool.Execute(ctx, args)
+	if err == nil {
+		t.Error("Expected error for non-existent skill")
+	}
+
+	expectedError := "skill not found: non-existent-skill"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error '%s', got '%s'", expectedError, err.Error())
+	}
+}
+
+func TestLoadSkillTool_Execute_MissingName(t *testing.T) {
+	tool := NewLoadSkillTool(nil)
+	ctx := context.Background()
+	args := map[string]any{}
+
+	_, err := tool.Execute(ctx, args)
+	if err == nil {
+		t.Error("Expected error for missing name")
+	}
+
+	expectedError := "invalid name argument"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error '%s', got '%s'", expectedError, err.Error())
+	}
+}
+
+func TestLoadSkillTool_Execute_InvalidNameType(t *testing.T) {
+	tool := NewLoadSkillTool(nil)
+	ctx := context.Background()
+	args := map[string]any{
+		"name": 123, // Invalid type
+	}
+
+	_, err := tool.Execute(ctx, args)
+	if err == nil {
+		t.Error("Expected error for invalid name type")
+	}
+
+	expectedError := "invalid name argument"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error '%s', got '%s'", expectedError, err.Error())
+	}
+}
+
+func TestLoadSkillTool_XMLEscaping(t *testing.T) {
+	skills := []skill.Skill{
+		{
+			Name:      "skill<script>",
+			FilePath:  "/path/to/\"file\".md",
+			BaseDir:   "/base&dir",
+			Content:   "Content with <tags> and &ampersands;",
+		},
+	}
+
+	tool := NewLoadSkillTool(skills)
+	ctx := context.Background()
+	args := map[string]any{
+		"name": "skill<script>",
+	}
+
+	content, err := tool.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	textContent, ok := content[0].(agentctx.TextContent)
+	if !ok {
+		t.Fatalf("Expected TextContent, got %T", content[0])
+	}
+
+	// Verify XML escaping - skill name should be escaped
+	if !strings.Contains(textContent.Text, "skill&lt;script&gt;") {
+		t.Errorf("Expected escaped skill name in output, got: %s", textContent.Text)
+	}
+
+	// File path should be escaped
+	if !strings.Contains(textContent.Text, "&quot;file&quot;.md") {
+		t.Errorf("Expected escaped file path in output, got: %s", textContent.Text)
+	}
+
+	// Base dir should be escaped
+	if !strings.Contains(textContent.Text, "base&amp;dir") {
+		t.Errorf("Expected escaped base dir in output, got: %s", textContent.Text)
+	}
+}


### PR DESCRIPTION
## Summary

Convert skill invocation (/skill:xxx) from inline text insertion to ToolCall + ToolResult pattern. This enables truncation of skill documents via context management.

## Problem
When users invoke skills via /skill:xxx (e.g., /skill:pge), the entire skill document is inserted as a user message into RecentMessages:
1. Cannot be truncated (user messages are protected)
2. Accumulates across sessions (static docs pile up in history)
3. Wastes context window (8K+ chars per skill invocation)

## Solution
Convert skill invocation to match tool execution pattern:
- User: "/skill:xxx"
- AgentContext receives:
  - UserMessage("/skill:xxx")
  - AssistantMessage([ToolCall(load_skill, {name:"xxx"})])
  - ToolResultMessage(id="call_xxx", tool="load_skill", content="<skill>...</skill>")

## Implementation
- Created LoadSkillTool in pkg/tools/skill_loader.go
- Modified handlePrompt/handleSteer/handleFollowUp to inject ToolCall + ToolResult messages when /skill:xxx detected
- Added expandSkillCommandsAsMessages helper to create tool call messages with valid ToolCallID
- Exported skill.EscapeXML for use in skill_loader

## Benefits
1. Skill documents become truncatable (as tool results)
2. Context management can remove old skill invocations
3. Follows existing tool execution pattern
4. Semantic clarity: skill loading = loading external resource (like read/bash)

## Testing
- Unit tests for LoadSkillTool
- Integration tests for handlePrompt/handleSteer/handleFollowUp
- All existing tests pass