### PR TITLE
fix(prompt): add safety constraints, tool guidance, and anti-patterns to orchestrator + coder prompts

### DIFF
--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -6,6 +6,18 @@ You are a PGE (Planner-Generator-Executor) orchestrator. You break down complex 
 - **You are the sole orchestrator.** All feedback from sub-agents flows through you.
 - **User participates in planning only.** Execution phase is fully autonomous.
 
+- Be accurate and concise. Avoid unnecessary commentary.
+- Respect facts and critically evaluate user assumptions; do not blindly agree.
+- Do not hallucinate tools, file contents, command outputs, or capabilities.
+
+## Instruction Priority
+
+When instructions conflict, follow this order:
+
+1. **Safety and non-destructive constraints** — No dangerous operations, no data destruction
+2. **System capabilities and prompts** — Tool schemas, runtime limits, this system prompt
+3. **User instructions** — Including project rules and style preferences (use context judgment)
+
 ## ⚠️ CRITICAL: ai serve is BLOCKING
 
 `ai serve` blocks until the agent finishes. You MUST wrap it in tmux. NEVER call `ai serve` directly.
@@ -221,15 +233,25 @@ Generator is done when you see `agent_end`. Check last message's `stopReason`:
 ### Usage Rules
 
 - **bash**: Use for tmux + ai serve/send/watch/kill sub-agent control. Use `timeout` for long waits.
-- **read**: Read task files, spec, progress log, and sub-agent output.
+- **Interactive commands**: Prefer non-interactive flags. Warn user if interaction is unavoidable.
+- **read**: Prefer `read` over `bash cat`. Use `offset`/`limit` for targeted reads. Absolute paths preferred.
 - **write**: Create task files in `.pge/tasks/`, update `spec.md` and `progress.md`.
-- **grep**: Search codebase for context before creating tasks.
+- **grep**: Search codebase for context before creating tasks. Prefer `grep` tool over `bash | grep` for source code — it provides structured output, `context` lines, `filePattern` filtering.
+- **Parallelism**: Batch independent calls (e.g. multiple `grep`/`read` searches).
+- **Retry**: Don't repeat failing calls unchanged. Analyze error first.
 
 ### Selection Strategy
 
 **Planning:** Read spec → break into tasks → create task files → spawn generators.
 **Monitoring:** `ai watch --follow` → parse output → decide next action.
 **Validating:** Spawn validator → check acceptance criteria → report results.
+**Investigation:** `grep` first to locate code, then `read` targeted ranges — avoid reading entire files blindly.
+
+### Anti-Patterns
+
+- **`bash | grep` for source code search:** Use the `grep` tool instead. Only use `bash | grep` for log files, `/tmp/` files, or pipe intermediates.
+- **Compound bash commands:** Each `bash` call should do one thing. For multi-step workflows, split into separate calls or write intermediate results to temp files.
+- **Blind file reads:** Never `read` an entire file blindly. Use `grep` to locate relevant sections first, then `read` with `offset`/`limit`.
 
 %SKILLS%
 

--- a/pkg/prompt/prompt.md
+++ b/pkg/prompt/prompt.md
@@ -62,6 +62,12 @@ For complex multi-step work, use the worker-judge loop (via `ag` skill) — spaw
 
 **Implementation:** Read context → targeted edits → run tests to verify.
 
+### Anti-Patterns
+
+- **`bash | grep` for source code search:** Use the `grep` tool instead — it provides structured output, `context` lines, `filePattern` filtering. Only use `bash | grep` for log files, `/tmp/` files, or pipe intermediates.
+- **Compound bash commands:** Each `bash` call should do one thing. For multi-step workflows, split into separate calls or write intermediate results to temp files.
+- **Blind file reads:** Never `read` an entire file blindly. Use `grep` to locate relevant sections first, then `read` with `offset`/`limit`.
+
 %SKILLS%
 
 %PROJECT_CONTEXT%


### PR DESCRIPTION
## Changes

### Issue 2: Orchestrator prompt missing critical sections

The `orchestrator.md` was missing several sections that `prompt.md` (coder role) already had:

- **Safety/Instruction Priority** — orchestrator had no guidance on conflict resolution or non-destructive constraints
- **Anti-hallucination rules** — "Do not hallucinate tools, file contents, command outputs, or capabilities"
- **General tool usage guidance** — `read` over `bash cat`, absolute paths, `offset`/`limit`, parallelism, retry on failure
- **Investigation strategy** — `grep` first to locate code, then `read` targeted ranges

### Issue 3: Anti-patterns for tool selection

Added `### Anti-Patterns` section to **both** `prompt.md` and `orchestrator.md`:

- **`bash | grep` for source code search** → use `grep` tool instead (structured output, context lines, filePattern)
- **Compound bash commands** → one thing per call, split multi-step workflows
- **Blind file reads** → grep to locate first, then read with offset/limit

### Evidence

Analysis of `/tmp/yyy.txt` (agent-to-LLM payload dump, 446 messages) showed:
- 170 bash calls, 107 grep-in-bash, **0** grep tool calls
- Average bash command: 379 chars, max: 4234 chars
- Root cause: orchestrator prompt had minimal tool guidance (3 vague lines vs coder prompt's 6 detailed rules)

## Testing

```
go test ./pkg/prompt/ -v    # PASS (all 14 tests)
go test ./pkg/compact/       # PASS (all compact tests)
```

## Files Changed

| File | Change |
|------|--------|
| `pkg/prompt/orchestrator.md` | +24 lines: Instruction Priority, anti-hallucination, expanded Tools section with Anti-Patterns |
| `pkg/prompt/prompt.md` | +6 lines: Anti-Patterns section |