### PR TITLE
Fix: [BUG] compaction ensureToolCallPairing 产生空壳 assistant 消息

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -806,6 +806,11 @@ func ensureToolCallPairing(oldMessages, recentMessages []agentctx.AgentMessage) 
 			}
 
 			if hasOldToolCalls {
+				if len(filteredContent) == 0 {
+					// Empty shell! Hide the entire assistant message
+					keptMessages = append(keptMessages, msg.WithVisibility(false, msg.IsUserVisible()))
+					continue
+				}
 				// Create a new message with filtered content
 				filteredMsg := msg
 				filteredMsg.Content = filteredContent
@@ -910,6 +915,11 @@ func (c *Compactor) ensureToolCallPairingWithGrace(oldMessages, recentMessages [
 			}
 
 			if hasOldToolCalls {
+				if len(filteredContent) == 0 {
+					// Empty shell! Hide the entire assistant message
+					keptMessages = append(keptMessages, msg.WithVisibility(false, msg.IsUserVisible()))
+					continue
+				}
 				// Create a new message with filtered content
 				filteredMsg := msg
 				filteredMsg.Content = filteredContent

--- a/pkg/compact/compact_empty_shell_grace_test.go
+++ b/pkg/compact/compact_empty_shell_grace_test.go
@@ -1,0 +1,145 @@
+package compact
+
+import (
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"testing"
+
+	"github.com/tiancaiamao/ai/pkg/llm"
+)
+
+// TestEnsureToolCallPairingWithGrace_EmptyShell tests the empty shell bug fix
+// in the grace period variant of the function
+func TestEnsureToolCallPairingWithGrace_EmptyShell(t *testing.T) {
+	config := &Config{
+		GracePeriod: 1, // Protect 1 most recent tool result
+	}
+
+	compactor := NewCompactor(config, llm.Model{}, "", "", 0)
+
+	oldMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call-1",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file1.txt"},
+				},
+				agentctx.ToolCallContent{
+					ID:   "call-2",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file2.txt"},
+				},
+			},
+		},
+	}
+
+	// Assistant message has tool calls that are in oldMessages
+	recentMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				// Only tool calls, no text content - becomes empty shell
+				agentctx.ToolCallContent{
+					ID:   "call-1",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file1.txt"},
+				},
+			},
+		},
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-1",
+			ToolName:   "read",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "file1 content"},
+			},
+		},
+		agentctx.NewUserMessage("next user message"),
+	}
+
+	result := compactor.ensureToolCallPairingWithGrace(oldMessages, recentMessages)
+
+	// Find the assistant message
+	foundHiddenAssistant := false
+	for _, msg := range result {
+		if msg.Role == "assistant" {
+			// Check if this message has any text content
+			hasText := false
+			for _, block := range msg.Content {
+				if _, ok := block.(agentctx.TextContent); ok {
+					hasText = true
+					break
+				}
+			}
+			if !hasText {
+				// This is the assistant with only tool calls - should be hidden
+				if msg.IsAgentVisible() {
+					t.Error("BUG: Assistant message should be hidden when all tool calls are filtered and no text content remains")
+				}
+				foundHiddenAssistant = true
+			}
+		}
+	}
+
+	if !foundHiddenAssistant {
+		t.Error("Assistant message should still exist (hidden, not deleted)")
+	}
+}
+
+// TestEnsureToolCallPairingWithGrace_EmptyShellWithGraceProtected tests that
+// tool results within grace period are protected even when their tool calls
+// are in oldMessages
+func TestEnsureToolCallPairingWithGrace_EmptyShellWithGraceProtected(t *testing.T) {
+	config := &Config{
+		GracePeriod: 1, // Protect 1 most recent tool result
+	}
+
+	compactor := NewCompactor(config, llm.Model{}, "", "", 0)
+
+	oldMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call-1",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file1.txt"},
+				},
+			},
+		},
+	}
+
+	// Tool result is within grace period (most recent), so it should be protected
+	recentMessages := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("recent turn"),
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-1",
+			ToolName:   "read",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "file1 content"},
+			},
+		},
+	}
+
+	result := compactor.ensureToolCallPairingWithGrace(oldMessages, recentMessages)
+
+	// Tool result should be visible due to grace period
+	toolResultVisible := false
+	for _, msg := range result {
+		if msg.Role == "toolResult" && msg.ToolCallID == "call-1" {
+			if msg.IsAgentVisible() {
+				toolResultVisible = true
+			}
+		}
+	}
+
+	if !toolResultVisible {
+		t.Error("Tool result within grace period should be visible")
+	}
+}

--- a/pkg/compact/compact_empty_shell_test.go
+++ b/pkg/compact/compact_empty_shell_test.go
@@ -1,0 +1,193 @@
+package compact
+
+import (
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"testing"
+)
+
+// TestEnsureToolCallPairing_EmptyShell demonstrates the bug where an assistant message
+// becomes an empty shell when all its tool calls are filtered out and it has no text content
+func TestEnsureToolCallPairing_EmptyShell(t *testing.T) {
+	// Scenario: assistant in recentMessages has tool_calls whose IDs are in oldMessages
+	// All tool_calls get filtered out, leaving empty content (empty shell bug)
+	// Expected: entire message should be hidden instead of leaving empty shell
+
+	oldMessages := []agentctx.AgentMessage{
+		{
+			Role: "user",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "old user message"},
+			},
+		},
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call-1",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file1.txt"},
+				},
+				agentctx.ToolCallContent{
+					ID:   "call-2",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file2.txt"},
+				},
+			},
+		},
+	}
+
+	// Assistant message in recentMessages has same tool_calls as oldMessages
+	// They will be filtered out, leaving empty content
+	recentMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				// Only tool calls, no text content - becomes empty shell
+				agentctx.ToolCallContent{
+					ID:   "call-1",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file1.txt"},
+				},
+				agentctx.ToolCallContent{
+					ID:   "call-2",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file2.txt"},
+				},
+			},
+		},
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-1",
+			ToolName:   "read",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "file1 content"},
+			},
+		},
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-2",
+			ToolName:   "read",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "file2 content"},
+			},
+		},
+		agentctx.NewUserMessage("next user message"),
+	}
+
+	result := ensureToolCallPairing(oldMessages, recentMessages)
+
+	// Find the assistant message that should be hidden
+	// It should be the only assistant message with only tool calls (no text)
+	foundHiddenAssistant := false
+	for _, msg := range result {
+		if msg.Role == "assistant" {
+			// Check if this message has any text content
+			hasText := false
+			for _, block := range msg.Content {
+				if _, ok := block.(agentctx.TextContent); ok {
+					hasText = true
+					break
+				}
+			}
+			if !hasText {
+				// This is the assistant with only tool calls - should be hidden
+				if msg.IsAgentVisible() {
+					t.Error("BUG: Assistant message should be hidden when all tool calls are filtered and no text content remains")
+				}
+				foundHiddenAssistant = true
+			}
+		}
+	}
+
+	if !foundHiddenAssistant {
+		t.Error("Assistant message should still exist (hidden, not deleted)")
+	}
+
+	// Verify tool_results are also hidden
+	hiddenToolResults := 0
+	for _, msg := range result {
+		if msg.Role == "toolResult" && (msg.ToolCallID == "call-1" || msg.ToolCallID == "call-2") {
+			if !msg.IsAgentVisible() {
+				hiddenToolResults++
+			}
+		}
+	}
+
+	if hiddenToolResults != 2 {
+		t.Errorf("Expected 2 hidden tool_results, got %d", hiddenToolResults)
+	}
+}
+
+// TestEnsureToolCallPairing_EmptyShellWithMixedContent tests that when assistant
+// has both text content and old tool calls, only tool calls are filtered
+func TestEnsureToolCallPairing_EmptyShellWithMixedContent(t *testing.T) {
+	// Scenario: assistant has both text content and tool calls in oldMessages
+	// Only tool calls should be filtered, text content should remain
+
+	oldMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:   "call-1",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file.txt"},
+				},
+			},
+		},
+	}
+
+	recentMessages := []agentctx.AgentMessage{
+		{
+			Role: "assistant",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "Here's what I found:"},
+				agentctx.ToolCallContent{
+					ID:   "call-1",
+					Type: "toolCall",
+					Name: "read",
+					Arguments: map[string]any{"path": "/file.txt"},
+				},
+			},
+		},
+		{
+			Role:       "toolResult",
+			ToolCallID: "call-1",
+			ToolName:   "read",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "file content"},
+			},
+		},
+	}
+
+	result := ensureToolCallPairing(oldMessages, recentMessages)
+
+	// Find assistant message
+	foundAssistant := false
+	for _, msg := range result {
+		if msg.Role == "assistant" {
+			foundAssistant = true
+			// Assistant should still be visible (has text content)
+			if !msg.IsAgentVisible() {
+				t.Error("Assistant should remain visible when it has text content")
+			}
+			// Content should have 1 text block (tool call filtered)
+			if len(msg.Content) != 1 {
+				t.Errorf("Expected 1 content block (text), got %d", len(msg.Content))
+			}
+			// Verify it's text content
+			if _, ok := msg.Content[0].(agentctx.TextContent); !ok {
+				t.Error("Expected TextContent, got something else")
+			}
+		}
+	}
+
+	if !foundAssistant {
+		t.Error("Assistant message should still exist")
+	}
+}


### PR DESCRIPTION
## Workpad

```
hostname:macbook.local:/Users/genius/.symphony/workspaces/589bf992-93a2-47c7-a014-44ef3ec35528@origin/main
```

### Plan

- [x] 1. Reproduce the bug
  - [x] 1.1. Create test case demonstrating empty shell assistant messages
  - [x] 1.2. Run test to confirm bug exists
- [x] 2. Fix `ensureToolCallPairing`
  - [x] 2.1. Check if filtered content is empty after filtering tool calls
  - [x] 2.2. If empty, hide entire message (agentVisible=false) instead of keeping empty shell
- [x] 3. Fix `ensureToolCallPairingWithGrace`
  - [x] 3.1. Apply same fix as ensureToolCallPairing
- [x] 4. Run tests
  - [x] 4.1. Run pkg/compact tests
  - [x] 4.2. Verify new test case passes
- [ ] 5. Commit and push
- [ ] 6. Create PR
- [ ] 7. Self-review PR

### Acceptance Criteria

- [x] Assistant messages with all tool calls filtered and no text content are hidden (agentVisible=false)
- [x] No empty shell assistant messages (content: []) remain after compaction
- [x] All existing tests still pass
- [x] New test case validates the fix

### Validation

- [x] Run existing tests: `go test ./pkg/compact -v -run TestEnsureToolCallPairing`
- [x] Run all compact tests: `go test ./pkg/compact -v`

### Notes

- Bug location: pkg/compact/compact.go lines 807-823 and 872-888
- Root cause: `splitMessagesByTokenBudget` splits messages by token budget, can separate assistant from tool_result
- When assistant in recentMessages but all its tool_calls in oldMessages, all ToolCallContent is filtered
- If no TextContent, message becomes empty shell with `content: []`
- Fix: hide entire message (agentVisible=false) when filtered content is empty
- Fix applied to both `ensureToolCallPairing` and `ensureToolCallPairingWithGrace`
- All tests pass (28 tests in pkg/compact)

### Confusions

- None