### PR TITLE
fix: ai watch exits on agent_end regardless of --timeout

### DIFF
--- a/cmd/ai/watch.go
+++ b/cmd/ai/watch.go
@@ -844,18 +844,13 @@ func followWatch(meta *run.RunMeta, fromSeq uint64, pretty bool, summary bool, w
 			lastKind = evt.Kind
 		}
 
-								// On agent_end:
-		// - Default (no --timeout flag): exit immediately. One-shot task complete.
-		// - With --timeout 0 or --timeout N: continue waiting for more events.
+										// On agent_end: always exit — the task is complete.
+		// The --timeout flag controls maximum wait time for the agent to finish,
+		// not how long to wait after it finishes.
 		if strings.Contains(line, `"agent_end"`) {
 			fmt.Println()
 			fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
-			if watchTimeout < 0 {
-				// No --timeout flag set → one-shot mode, exit.
-				return
-			}
-			// --timeout set (0 or positive) → keep going.
-			continue
+			return
 		}
 	}
 	fmt.Fprintf(os.Stderr, "--- agent stream ended without agent_end event ---\n")
@@ -877,7 +872,7 @@ func followWatchSummary(scanner *bufio.Scanner, fromSeq uint64, watchTimeout tim
 		}
 		seq++
 
-		// Check for agent_end
+				// Check for agent_end — always exit when task is complete.
 		if strings.Contains(line, `"agent_end"`) {
 			// Save current assistant text as the "last" one.
 			if currentAssistantText.Len() > 0 {
@@ -887,16 +882,12 @@ func followWatchSummary(scanner *bufio.Scanner, fromSeq uint64, watchTimeout tim
 			}
 
 			fmt.Fprintf(os.Stderr, "__seq:%d\n", seq)
-			if watchTimeout < 0 {
-				// One-shot mode: print the final assistant text and exit.
-				text := strings.TrimSpace(lastAssistantText.String())
-				if text != "" {
-					fmt.Println(text)
-				}
-				return
+			// Print the final assistant text and exit.
+			text := strings.TrimSpace(lastAssistantText.String())
+			if text != "" {
+				fmt.Println(text)
 			}
-			// With --timeout: keep accumulating for next prompt cycle.
-			continue
+			return
 		}
 
 		// Parse and accumulate assistant text only.

--- a/cmd/ai/watch_test.go
+++ b/cmd/ai/watch_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tiancaiamao/ai/pkg/run"
 )
@@ -124,6 +129,174 @@ func TestProcessEvent_LiveThinkingDelta_RendersImmediately(t *testing.T) {
 	}
 	if !strings.Contains(out, "abc") {
 		t.Fatalf("expected delta content rendered immediately, got %q", out)
+	}
+}
+
+func TestFollowWatchSummary_ExitsOnAgentEnd_WithTimeout(t *testing.T) {
+	// Regression test: followWatchSummary must exit on agent_end
+	// regardless of the watchTimeout value.
+	// Previously, a positive watchTimeout caused it to skip agent_end
+	// and keep waiting (wasting the full timeout duration).
+		events := strings.Join([]string{
+		`{"type":"text_delta","delta":"hello "}`,
+		`{"type":"text_delta","delta":"world"}`,
+		`{"type":"agent_end"}`,
+		// Extra lines after agent_end — should never be reached.
+		`{"type":"text_delta","delta":"should not appear"}`,
+	}, "\n")
+
+	scanner := bufio.NewScanner(strings.NewReader(events))
+
+	// Capture stdout and stderr via pipes.
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	// Read captured output in background.
+		var stdout, stderrBuf bytes.Buffer
+	outDone := make(chan struct{})
+	go func() {
+		io.Copy(&stdout, rOut)
+		close(outDone)
+	}()
+	errDone := make(chan struct{})
+	go func() {
+		io.Copy(&stderrBuf, rErr)
+		close(errDone)
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		// Use a positive timeout — the bug was that this prevented exit on agent_end.
+		followWatchSummary(scanner, 0, 15*time.Minute)
+		close(done)
+	}()
+
+	// Should exit quickly, not wait 15 minutes.
+	select {
+	case <-done:
+		// Good — exited on agent_end.
+	case <-time.After(5 * time.Second):
+		t.Fatal("followWatchSummary did not exit on agent_end within 5s (would have waited full timeout)")
+	}
+
+	// Close write ends and restore before reading.
+	wOut.Close()
+	wErr.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	<-outDone
+	<-errDone
+
+	// Should have printed the accumulated assistant text.
+	if !strings.Contains(stdout.String(), "hello world") {
+		t.Errorf("expected stdout to contain 'hello world', got %q", stdout.String())
+	}
+	// Should NOT contain text that comes after agent_end.
+	if strings.Contains(stdout.String(), "should not appear") {
+		t.Error("should not have processed events after agent_end")
+	}
+	// Stderr should contain __seq marker.
+	if !strings.Contains(stderrBuf.String(), "__seq:3") {
+		t.Errorf("expected stderr to contain '__seq:3', got %q", stderrBuf.String())
+	}
+}
+
+func TestFollowWatchSummary_ExitsOnAgentEnd_WithoutTimeout(t *testing.T) {
+	// When watchTimeout is -1 (not set), should also exit on agent_end.
+		events := strings.Join([]string{
+		`{"type":"text_delta","delta":"done"}`,
+		`{"type":"agent_end"}`,
+	}, "\n")
+
+	scanner := bufio.NewScanner(strings.NewReader(events))
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	var stdout, stderrBuf bytes.Buffer
+	outDone := make(chan struct{})
+	go func() { io.Copy(&stdout, rOut); close(outDone) }()
+	errDone := make(chan struct{})
+	go func() { io.Copy(&stderrBuf, rErr); close(errDone) }()
+
+	done := make(chan struct{})
+	go func() {
+		followWatchSummary(scanner, 0, -1)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("followWatchSummary did not exit on agent_end")
+	}
+
+	wOut.Close()
+	wErr.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	<-outDone
+	<-errDone
+
+	if !strings.Contains(stdout.String(), "done") {
+		t.Errorf("expected stdout to contain 'done', got %q", stdout.String())
+	}
+	if !strings.Contains(stderrBuf.String(), "__seq:2") {
+		t.Errorf("expected stderr to contain '__seq:2', got %q", stderrBuf.String())
+	}
+}
+
+func TestFollowWatchSummary_StreamEndsWithoutAgentEnd(t *testing.T) {
+	// If stream ends without agent_end, should print whatever text was accumulated.
+		events := strings.Join([]string{
+		`{"type":"text_delta","delta":"partial"}`,
+	}, "\n")
+
+	scanner := bufio.NewScanner(strings.NewReader(events))
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	var stdout bytes.Buffer
+	outDone := make(chan struct{})
+	go func() { io.Copy(&stdout, rOut); close(outDone) }()
+	errDone := make(chan struct{})
+	var stderrBuf bytes.Buffer
+	go func() { io.Copy(&stderrBuf, rErr); close(errDone) }()
+
+	done := make(chan struct{})
+	go func() {
+		followWatchSummary(scanner, 0, 0)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("followWatchSummary did not exit when stream ended")
+	}
+
+	wOut.Close()
+	wErr.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	<-outDone
+	<-errDone
+
+	if !strings.Contains(stdout.String(), "partial") {
+		t.Errorf("expected stdout to contain 'partial', got %q", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Bug

`ai watch --follow --pretty --timeout 15m` does not exit when the sub-agent finishes. Instead it waits the full 15-minute timeout.

## Root Cause

In `followWatch()` and `followWatchSummary()`, the `agent_end` handler checked `watchTimeout < 0` to decide whether to exit:

```go
// Before (buggy)
if strings.Contains(line, "\"agent_end\"") {
    if watchTimeout < 0 {
        return
    }
    continue  // ← stuck here for full timeout duration
}
```

When `--timeout 15m` is set, `watchTimeout` is positive → `continue` → `scanner.Scan()` blocks → waits until deadline expires.

## Fix

Always `return` on `agent_end`. The `--timeout` flag controls max wait time for the agent to finish, not how long to wait *after* it finishes.

## Test Coverage

3 new regression tests for `followWatchSummary`:
- `TestFollowWatchSummary_ExitsOnAgentEnd_WithTimeout` — verifies immediate exit with 15-minute timeout
- `TestFollowWatchSummary_ExitsOnAgentEnd_WithoutTimeout` — verifies exit with no timeout
- `TestFollowWatchSummary_StreamEndsWithoutAgentEnd` — verifies graceful fallback when stream ends without agent_end