### PR TITLE
Fix: ai serve daemon hangs when rpc subprocess exits with --timeout

### DIFF
--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -338,14 +338,19 @@ func serveSubcommand(binPath string) {
 		}
 	}
 
+	// Watch for subprocess exit and close stdinWriter so cmd.Wait() can return.
+	// Without this, Go's internal pipe-reader goroutine blocks forever when
+	// the subprocess exits (e.g. on --timeout), preventing cmd.Wait() from
+	// returning and leaving a zombie ai serve process.
+	go func() {
+		cmd.Process.Wait() // blocks until subprocess exits
+		stdinWriter.Close()
+	}()
+
 	// Print run ID to stdout — caller can capture this.
 	fmt.Println(id)
 
 	// Wait for subprocess to exit.
-	// Note: we do NOT close stdin on agent_end — ai serve should remain alive
-	// to accept further ai send commands. The subprocess exits when:
-	// - stdin is explicitly closed (ai kill, or socket shutdown command)
-	// - the subprocess crashes
 	waitErr := cmd.Wait()
 
 	// Determine final status.


### PR DESCRIPTION
## Bug

When `ai serve` spawns `ai rpc` with `--timeout`, the subprocess exits when the timeout expires, but `ai serve` hangs forever on `cmd.Wait()` because the stdin pipe writer is never closed.

Go's `exec.Cmd.Wait()` has an internal goroutine that reads from the stdin pipe. When the pipe writer is not closed, this goroutine blocks forever, preventing `cmd.Wait()` from returning.

## Fix

Add a goroutine after `cmd.Start()` that watches for subprocess exit via `cmd.Process.Wait()` and closes `stdinWriter`. This unblocks the pipe goroutine in `exec.Cmd.Wait()`, allowing it to return.

This mirrors the pattern already used in `runSubcommand` (TUI mode) at line 167-169.

## Testing

- All existing tests pass (`go test ./cmd/ai/... -v`)
- Build succeeds (`go build ./cmd/ai`)

## Files Changed

- `cmd/ai/run.go` — Added goroutine to close stdinWriter on subprocess exit in `serveSubcommand`