### PR TITLE
Fix: /rewind slash command always returns entry not found

### DIFF
--- a/cmd/ai/rpc_session_handlers.go
+++ b/cmd/ai/rpc_session_handlers.go
@@ -165,6 +165,11 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 	if entryID == "root" {
 		app.sess.ResetLeaf()
 	} else {
+		// Lazy loading may not have all entries in byID (e.g., pre-compaction).
+		// Ensure the full session is loaded so Branch can find the entry.
+		if err := app.sess.EnsureFullyLoaded(); err != nil {
+			return nil, err
+		}
 		if err := app.sess.Branch(entryID); err != nil {
 			return nil, err
 		}
@@ -188,6 +193,11 @@ func (app *rpcApp) handleFork(args string) (any, error) {
 		entryID = jsonData.EntryID
 	}
 	slog.Info("Received fork: entryId=", "value", entryID)
+	// Lazy loading may not have all entries in byID (e.g., pre-compaction).
+	// Ensure the full session is loaded so GetEntry can find the entry.
+	if err := app.sess.EnsureFullyLoaded(); err != nil {
+		return nil, err
+	}
 	entry, ok := app.sess.GetEntry(entryID)
 	if !ok || entry.Type != session.EntryTypeMessage || entry.Message == nil || entry.Message.Role != "user" {
 		return nil, fmt.Errorf("invalid entryId: %s", entryID)

--- a/cmd/ai/rpc_session_handlers.go
+++ b/cmd/ai/rpc_session_handlers.go
@@ -150,7 +150,7 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 	if app.parseJSONArgs(args, &jsonData) && jsonData.EntryID != "" {
 		entryID = jsonData.EntryID
 	}
-		if entryID == "" {
+	if entryID == "" {
 		return nil, fmt.Errorf("usage: /rewind <index|entryId|root>  (use /messages to see indices)")
 	}
 
@@ -188,7 +188,7 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 	if err := app.sessionMgr.SaveCurrent(); err != nil {
 		slog.Info("Failed to update session metadata:", "value", err)
 	}
-		return map[string]any{"switched": true, "entryId": entryID}, nil
+	return map[string]any{"switched": true, "entryId": entryID}, nil
 }
 
 // resolveMessageIndex maps a numeric string (from /messages index) to the corresponding

--- a/cmd/ai/rpc_session_handlers.go
+++ b/cmd/ai/rpc_session_handlers.go
@@ -150,6 +150,10 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 	if app.parseJSONArgs(args, &jsonData) && jsonData.EntryID != "" {
 		entryID = jsonData.EntryID
 	}
+		if entryID == "" {
+		return nil, fmt.Errorf("usage: /rewind <index|entryId|root>  (use /messages to see indices)")
+	}
+
 	slog.Info("Received rewind", "entryId", entryID)
 	app.stateMu.Lock()
 	streaming := app.isStreaming
@@ -158,8 +162,11 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 		return nil, fmt.Errorf("agent is busy")
 	}
 
-	if entryID == "" {
-		return nil, fmt.Errorf("entryId is required")
+	// Resolve index-based reference (e.g. "/rewind 5" → message at index 5 in /messages).
+	if entryID != "root" {
+		if resolved, ok := resolveMessageIndex(app.sess, entryID); ok {
+			entryID = resolved
+		}
 	}
 
 	if entryID == "root" {
@@ -181,7 +188,31 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 	if err := app.sessionMgr.SaveCurrent(); err != nil {
 		slog.Info("Failed to update session metadata:", "value", err)
 	}
-	return map[string]any{"switched": true}, nil
+		return map[string]any{"switched": true, "entryId": entryID}, nil
+}
+
+// resolveMessageIndex maps a numeric string (from /messages index) to the corresponding
+// session entry ID. Uses GetBranch (same path as /messages) and counts only EntryTypeMessage
+// entries, which is the same set /messages shows (compaction/branch_summary messages are
+// generated dynamically and have no rewind target).
+func resolveMessageIndex(sess *session.Session, arg string) (string, bool) {
+	idx, err := strconv.Atoi(arg)
+	if err != nil {
+		return "", false // not a number — caller should treat as entryId string
+	}
+	branch := sess.GetBranch("")
+	msgIdx := 0
+	for _, entry := range branch {
+		if entry.Type != session.EntryTypeMessage {
+			continue
+		}
+		if msgIdx == idx {
+			return entry.ID, true
+		}
+		msgIdx++
+	}
+	// Index out of range — return empty so caller falls through to entryId lookup.
+	return "", false
 }
 
 func (app *rpcApp) handleFork(args string) (any, error) {

--- a/pkg/session/lazy_test.go
+++ b/pkg/session/lazy_test.go
@@ -377,6 +377,201 @@ func TestLoadSessionLazyMessageChainWithCompaction(t *testing.T) {
 	assert.Len(t, messages, 11, "Should return compaction summary + 10 recent messages")
 }
 
+// TestRewindPreCompactionEntry tests that rewind works for pre-compaction entries
+// after lazy loading via EnsureFullyLoaded.
+func TestRewindPreCompactionEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "session")
+	err := os.MkdirAll(sessionDir, 0755)
+	require.NoError(t, err)
+
+	sess := &Session{
+		sessionDir: sessionDir,
+		entries:    make([]*SessionEntry, 0),
+		byID:       make(map[string]*SessionEntry),
+		persist:    true,
+	}
+	sess.header = newSessionHeader("test-session", "/test", "")
+
+	// Add 10 old messages (pre-compaction)
+	for i := 0; i < 10; i++ {
+		msg := agentctx.AgentMessage{
+			Role: "user",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "old message"},
+			},
+		}
+		err := sess.AddMessages(msg)
+		require.NoError(t, err)
+	}
+
+	// Record the ID of the 5th entry (a pre-compaction entry)
+	preCompactionID := sess.entries[4].ID
+	require.NotEmpty(t, preCompactionID)
+
+	// Add compaction entry
+	compaction := &SessionEntry{
+		Type:      EntryTypeCompaction,
+		ID:        "compaction-1",
+		Timestamp: "2024-01-01T00:00:00Z",
+		Summary:   "Previous conversation summary",
+	}
+	sess.addEntry(compaction)
+
+	// Add 10 recent messages (post-compaction)
+	for i := 0; i < 10; i++ {
+		msg := agentctx.AgentMessage{
+			Role: "user",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "recent message"},
+			},
+		}
+		err := sess.AddMessages(msg)
+		require.NoError(t, err)
+	}
+
+	// Persist to file
+	filePath := filepath.Join(sessionDir, "messages.jsonl")
+	data := serializeSessionForTest(sess)
+	err = os.WriteFile(filePath, data, 0644)
+	require.NoError(t, err)
+
+	// Load lazily — pre-compaction entries should NOT be in byID
+	loaded, err := LoadSessionLazy(sessionDir, DefaultLoadOptions())
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	// Confirm the pre-compaction entry is NOT directly accessible via GetEntry
+	// (this is the bug: lazy load doesn't include it)
+	_, found := loaded.GetEntry(preCompactionID)
+	assert.False(t, found, "Pre-compaction entry should not be in byID after lazy load")
+
+	// Now call EnsureFullyLoaded (what the rewind handler will do)
+	err = loaded.EnsureFullyLoaded()
+	require.NoError(t, err)
+
+	// After full load, the pre-compaction entry should be accessible
+	entry, found := loaded.GetEntry(preCompactionID)
+	require.True(t, found, "Pre-compaction entry should be found after EnsureFullyLoaded")
+	require.NotNil(t, entry)
+	assert.Equal(t, preCompactionID, entry.ID)
+
+	// Branch (rewind) to the pre-compaction entry should succeed
+	err = loaded.Branch(preCompactionID)
+	require.NoError(t, err, "Branch to pre-compaction entry should succeed")
+}
+
+// TestRewindPostCompactionEntry tests that rewind still works for post-compaction entries.
+func TestRewindPostCompactionEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "session")
+	err := os.MkdirAll(sessionDir, 0755)
+	require.NoError(t, err)
+
+	sess := &Session{
+		sessionDir: sessionDir,
+		entries:    make([]*SessionEntry, 0),
+		byID:       make(map[string]*SessionEntry),
+		persist:    true,
+	}
+	sess.header = newSessionHeader("test-session", "/test", "")
+
+	// Add old messages
+	for i := 0; i < 10; i++ {
+		msg := agentctx.AgentMessage{
+			Role: "user",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "old message"},
+			},
+		}
+		err := sess.AddMessages(msg)
+		require.NoError(t, err)
+	}
+
+	// Add compaction entry
+	compaction := &SessionEntry{
+		Type:      EntryTypeCompaction,
+		ID:        "compaction-1",
+		Timestamp: "2024-01-01T00:00:00Z",
+		Summary:   "Previous conversation summary",
+	}
+	sess.addEntry(compaction)
+
+	// Add recent messages
+	for i := 0; i < 10; i++ {
+		msg := agentctx.AgentMessage{
+			Role: "user",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "recent message"},
+			},
+		}
+		err := sess.AddMessages(msg)
+		require.NoError(t, err)
+	}
+
+	// Record the ID of the 5th post-compaction entry
+	postCompactionID := sess.entries[12].ID
+	require.NotEmpty(t, postCompactionID)
+
+	// Persist to file
+	filePath := filepath.Join(sessionDir, "messages.jsonl")
+	data := serializeSessionForTest(sess)
+	err = os.WriteFile(filePath, data, 0644)
+	require.NoError(t, err)
+
+	// Load lazily
+	loaded, err := LoadSessionLazy(sessionDir, DefaultLoadOptions())
+	require.NoError(t, err)
+
+	// EnsureFullyLoaded + Branch should work for post-compaction too
+	err = loaded.EnsureFullyLoaded()
+	require.NoError(t, err)
+	err = loaded.Branch(postCompactionID)
+	require.NoError(t, err, "Branch to post-compaction entry should succeed")
+}
+
+// TestRewindRoot tests that rewind "root" (ResetLeaf) still works.
+func TestRewindRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "session")
+	err := os.MkdirAll(sessionDir, 0755)
+	require.NoError(t, err)
+
+	sess := &Session{
+		sessionDir: sessionDir,
+		entries:    make([]*SessionEntry, 0),
+		byID:       make(map[string]*SessionEntry),
+		persist:    true,
+	}
+	sess.header = newSessionHeader("test-session", "/test", "")
+
+	// Add some messages
+	for i := 0; i < 5; i++ {
+		msg := agentctx.AgentMessage{
+			Role: "user",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "message"},
+			},
+		}
+		err := sess.AddMessages(msg)
+		require.NoError(t, err)
+	}
+
+	// Persist to file
+	filePath := filepath.Join(sessionDir, "messages.jsonl")
+	data := serializeSessionForTest(sess)
+	err = os.WriteFile(filePath, data, 0644)
+	require.NoError(t, err)
+
+	// Load lazily
+	loaded, err := LoadSessionLazy(sessionDir, DefaultLoadOptions())
+	require.NoError(t, err)
+
+	// ResetLeaf should work (this is what "root" rewind does)
+	loaded.ResetLeaf()
+	assert.Nil(t, loaded.leafID)
+}
+
 // Helper to serialize session to bytes (matches actual file format)
 func serializeSessionForTest(s *Session) []byte {
 	var data []byte

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -241,6 +241,36 @@ func (s *Session) ResetLeaf() {
 	s.leafID = nil
 }
 
+// EnsureFullyLoaded reloads all entries from disk, replacing in-memory state.
+// This is needed when operations (like rewind or fork) need access to entries
+// that were not loaded during lazy loading (e.g., pre-compaction entries).
+// If the session is not persisted or has no directory, this is a no-op.
+func (s *Session) EnsureFullyLoaded() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.persist || s.sessionDir == "" {
+		return nil
+	}
+
+	// Load full session from disk
+	full, err := LoadSession(s.sessionDir)
+	if err != nil {
+		return fmt.Errorf("failed to fully load session: %w", err)
+	}
+
+	// Replace in-memory state with full data
+	full.mu.Lock()
+	s.entries = full.entries
+	s.byID = full.byID
+	// Preserve leafID — it may have been changed by the caller
+	// Preserve header — should be the same
+	s.flushed = true
+	full.mu.Unlock()
+
+	return nil
+}
+
 // AppendMessage appends a message entry and persists it.
 func (s *Session) AppendMessage(message agentctx.AgentMessage) (string, error) {
 	s.mu.Lock()

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -259,14 +259,13 @@ func (s *Session) EnsureFullyLoaded() error {
 		return fmt.Errorf("failed to fully load session: %w", err)
 	}
 
-	// Replace in-memory state with full data
-	full.mu.Lock()
+	// Replace in-memory state with full data.
+	// No lock needed on full — it's a local variable not shared with other goroutines.
 	s.entries = full.entries
 	s.byID = full.byID
-	// Preserve leafID — it may have been changed by the caller
-	// Preserve header — should be the same
+	// Preserve leafID — it may have been changed by the caller.
+	// Preserve header — should be the same.
 	s.flushed = true
-	full.mu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
## Workpad

```text
macOS:/Users/genius/.symphony/workspaces/299f8ff4-fdb6-4025-8d33-f5df38a29d06@003b52c
```

### Plan

- [x] 1. Investigate root cause
  - [x] 1.1 Read `loadFromEnd()` in `pkg/session/lazy.go` — confirmed it only loads post-compaction entries into `byID`
  - [x] 1.2 Read `Branch()` in `pkg/session/session.go` — confirmed it does `s.byID[id]` with no fallback
  - [x] 1.3 Read `handleRewind()` in `cmd/ai/rpc_session_handlers.go` — confirmed it calls `app.sess.Branch(entryID)`
- [ ] 2. Implement fix
  - [ ] 2.1 Add `EnsureFullyLoaded()` method to `Session` that reloads from disk using `LoadSession`
  - [ ] 2.2 Call `EnsureFullyLoaded()` in `handleRewind()` before `Branch()` 
  - [ ] 2.3 Also call it in `handleFork()` before `GetEntry()` (same issue)
- [ ] 3. Write tests
  - [ ] 3.1 Test rewind to pre-compaction entry
  - [ ] 3.2 Test rewind to post-compaction entry (regression)
  - [ ] 3.3 Test rewind "root" still works
- [ ] 4. Verify all existing tests pass
- [ ] 5. Commit, push, create PR
- [ ] 6. Self review

### Root Cause

`loadFromEnd()` (lazy.go) scans backwards and stops at the first compaction entry. Only entries after compaction are added to `byID`. When `Branch(id)` is called with a pre-compaction entry ID, it fails because that ID is not in `byID`.

### Fix Strategy

**Option B: Full load for rewind** — Add `EnsureFullyLoaded()` to `Session` that re-reads the entire file from disk, replacing in-memory state. Call this from `handleRewind()` (and `handleFork()`) before looking up entries.

This preserves lazy loading for normal operation and only does a full load when the user explicitly requests rewind/fork.

### Acceptance Criteria

- [ ] `/rewind <entryId>` works for entries anywhere in the session (not just post-compaction)
- [ ] `/rewind root` continues to work
- [ ] Lazy loading performance is preserved for normal operation
- [ ] Existing session tests pass
- [ ] New test case covers rewinding to pre-compaction entries

### Validation

- [ ] targeted tests: `go test ./pkg/session/... -v -run TestRewind`
- [ ] all session tests: `go test ./pkg/session/... -v`
- [ ] format check: `make fmt-check`

### Notes

- (2025-05-25) Investigation complete, root cause confirmed in `loadFromEnd()`
- (2025-05-25) Also affects `handleFork()` which calls `GetEntry()` with same byID limitation