### PR TITLE
Fix: [BUG] Fix ai serve: status always failed, bridge goroutine leak, process never exits

### DIFF
--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -273,7 +273,9 @@ func serveSubcommand(binPath string) {
 	}
 
 	// Bridge goroutine: read stdout lines from pipe → push to broadcaster.
+	bridgeDone := make(chan struct{})
 	go func() {
+		defer close(bridgeDone)
 		defer pipeReader.Close()
 		scanner := bufio.NewScanner(pipeReader)
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -338,12 +340,13 @@ func serveSubcommand(binPath string) {
 		}
 	}
 
-	// Watch for subprocess exit and close stdinWriter so cmd.Wait() can return.
-	// Without this, Go's internal pipe-reader goroutine blocks forever when
-	// the subprocess exits (e.g. on --timeout), preventing cmd.Wait() from
-	// returning and leaving a zombie ai serve process.
+	// Capture process exit state to avoid the double-wait race with cmd.Wait().
+	// When the subprocess exits, close stdinWriter to unblock Go's internal
+	// stdin-copy goroutine, allowing cmd.Wait() to return.
+	processStateCh := make(chan *os.ProcessState, 1)
 	go func() {
-		cmd.Process.Wait() // blocks until subprocess exits
+		state, _ := cmd.Process.Wait()
+		processStateCh <- state
 		stdinWriter.Close()
 	}()
 
@@ -351,18 +354,24 @@ func serveSubcommand(binPath string) {
 	fmt.Println(id)
 
 	// Wait for subprocess to exit.
-	waitErr := cmd.Wait()
+	// cmd.Wait() may return an error due to the double Process.Wait() call,
+	// but goroutines are still properly cleaned up.
+	_ = cmd.Wait()
 
-	// Determine final status.
+	// Close pipeWriter so the bridge goroutine can finish.
+	pipeWriter.Close()
+	<-bridgeDone
+
+	// Determine final status using the captured process state (not cmd.Wait()
+	// error, which is unreliable due to the double-wait).
+	processState := <-processStateCh
 	status := run.StatusFailed
-	if waitErr == nil {
+	if processState.Success() {
 		status = run.StatusDone
 	} else {
-		if exitErr, ok := waitErr.(*exec.ExitError); ok {
-			if state, ok := exitErr.ProcessState.Sys().(syscall.WaitStatus); ok {
-				if state.Signaled() {
-					status = run.StatusKilled
-				}
+		if ws, ok := processState.Sys().(syscall.WaitStatus); ok {
+			if ws.Signaled() {
+				status = run.StatusKilled
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes three bugs in `serveSubcommand()` in `cmd/ai/run.go`:

### Bug 1: cmd.Process.Wait() called twice → status always "failed"
A goroutine called `cmd.Process.Wait()` to detect subprocess exit, then `cmd.Wait()` internally called `Process.Wait()` again. On Unix, a PID can only be waited once — the second call returns "wait: no child processes", causing status to always be "failed".

**Fix**: Capture the `ProcessState` from our `Process.Wait()` goroutine and use it for status determination. Ignore `cmd.Wait()`'s error (which is unreliable due to double-wait) and use `processState.Success()` instead.

### Bug 2: pipeWriter never closed → bridge goroutine leaks
After `cmd.Wait()` returns, `pipeWriter` was never closed, so the bridge goroutine blocks on `scanner.Scan()` forever. Without `--timeout`, the `ai serve` process never exits.

**Fix**: Close `pipeWriter` after `cmd.Wait()` returns. Add `bridgeDone` channel to wait for clean bridge goroutine shutdown.

### Bug 3: run.json never updated with correct status
Because of Bug 1, status was always "failed" even when the agent completed successfully.

**Fix**: Using the captured `ProcessState` (instead of `cmd.Wait()` error) correctly reports status as "done" on clean exit.

## Approach Notes

The `Process.Wait()` goroutine is still needed (not removed as the original plan suggested) because `cmd.Stdout` uses `io.Pipe` which does not auto-propagate EOF when the subprocess exits. The goroutine detects process exit, closes `stdinWriter` (unblocking Go's internal stdin-copy goroutine), and captures the exit state for status determination.

## Testing

- `make fmt-check` ✅
- `go test ./cmd/ai/... -v` — all 34 tests pass ✅
- `go test ./pkg/... -timeout 120s` — all pass ✅