### PR TITLE
Fix: ai serve messages never reach subprocess + optimize stress test timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 
 # Run tests with coverage
 test:
-	go test -short ./... -timeout 30s
+	go test ./... -timeout 30s
 
 # Run tests with race detector and coverage (may fail with "text file busy" on CI)
 test-ci:

--- a/cmd/ai/run.go
+++ b/cmd/ai/run.go
@@ -82,7 +82,17 @@ func runSubcommand(binPath string) {
 	cmd.Stderr = logFile
 
 	// Stdin pipe for sending commands.
-	stdinReader, stdinWriter := io.Pipe()
+	// Use os.Pipe instead of io.Pipe: io.Pipe is a synchronous in-memory
+	// pipe that requires Go's os/exec to spawn internal goroutines for copying
+	// between the pipe and the child's file descriptors. This is unreliable —
+	// data written to the io.PipeWriter may never reach the subprocess.
+	// os.Pipe provides kernel-buffered OS-level pipes that the child reads
+	// directly, with no intermediate goroutines.
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		slog.Error("failed to create stdin pipe", "error", err)
+		os.Exit(1)
+	}
 	cmd.Stdin = stdinReader
 
 	// Stdout goes to event broadcaster instead of events.jsonl.
@@ -90,7 +100,11 @@ func runSubcommand(binPath string) {
 	broadcaster := run.NewEventBroadcaster()
 	defer broadcaster.Close()
 
-	pipeReader, pipeWriter := io.Pipe()
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		slog.Error("failed to create stdout pipe", "error", err)
+		os.Exit(1)
+	}
 	cmd.Stdout = pipeWriter
 
 	// Start the subprocess.
@@ -98,6 +112,12 @@ func runSubcommand(binPath string) {
 		slog.Error("failed to start rpc subprocess", "error", err)
 		os.Exit(1)
 	}
+
+	// Close parent's copies of child-side file descriptors.
+	// After cmd.Start(), the child has inherited these FDs via fork/exec.
+	// Keeping them open in the parent would prevent EOF detection.
+	stdinReader.Close()
+	pipeWriter.Close()
 
 	// Bridge goroutine: read stdout lines from pipe → push to broadcaster.
 	go func() {
@@ -164,8 +184,7 @@ func runSubcommand(binPath string) {
 	}
 
 	// TUI exited — clean up subprocess.
-	// Close stdin pipe first so the internal goroutine in cmd.Wait() can exit.
-	// Without this, cmd.Wait() blocks forever on the pipe reader goroutine.
+	// Close stdin pipe so the child sees EOF on stdin.
 	stdinWriter.Close()
 
 	cmd.Process.Signal(syscall.SIGINT)
@@ -256,14 +275,28 @@ func serveSubcommand(binPath string) {
 	cmd.Stderr = logFile
 
 	// Stdin pipe for sending commands.
-	stdinReader, stdinWriter := io.Pipe()
+	// Use os.Pipe instead of io.Pipe: io.Pipe is a synchronous in-memory
+	// pipe that requires Go's os/exec to spawn internal goroutines for copying
+	// between the pipe and the child's file descriptors. This is unreliable —
+	// data written to the io.PipeWriter may never reach the subprocess.
+	// os.Pipe provides kernel-buffered OS-level pipes that the child reads
+	// directly, with no intermediate goroutines.
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to create stdin pipe: %v\n", err)
+		os.Exit(1)
+	}
 	cmd.Stdin = stdinReader
 
 	// Stdout goes to event broadcaster instead of events.jsonl.
 	broadcaster := run.NewEventBroadcaster()
 	defer broadcaster.Close()
 
-	pipeReader, pipeWriter := io.Pipe()
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to create stdout pipe: %v\n", err)
+		os.Exit(1)
+	}
 	cmd.Stdout = pipeWriter
 
 	// Start the subprocess.
@@ -271,6 +304,12 @@ func serveSubcommand(binPath string) {
 		fmt.Fprintf(os.Stderr, "error: failed to start rpc subprocess: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Close parent's copies of child-side file descriptors.
+	// After cmd.Start(), the child has inherited these FDs via fork/exec.
+	// Keeping them open in the parent would prevent EOF detection on pipeReader.
+	stdinReader.Close()
+	pipeWriter.Close()
 
 	// Bridge goroutine: read stdout lines from pipe → push to broadcaster.
 	bridgeDone := make(chan struct{})
@@ -341,8 +380,8 @@ func serveSubcommand(binPath string) {
 	}
 
 	// Capture process exit state to avoid the double-wait race with cmd.Wait().
-	// When the subprocess exits, close stdinWriter to unblock Go's internal
-	// stdin-copy goroutine, allowing cmd.Wait() to return.
+	// Close stdinWriter when the subprocess exits so the child sees EOF on stdin
+	// and the pipe is properly cleaned up.
 	processStateCh := make(chan *os.ProcessState, 1)
 	go func() {
 		state, _ := cmd.Process.Wait()
@@ -354,12 +393,11 @@ func serveSubcommand(binPath string) {
 	fmt.Println(id)
 
 	// Wait for subprocess to exit.
-	// cmd.Wait() may return an error due to the double Process.Wait() call,
-	// but goroutines are still properly cleaned up.
 	_ = cmd.Wait()
 
-	// Close pipeWriter so the bridge goroutine can finish.
-	pipeWriter.Close()
+	// Wait for the bridge goroutine to finish reading remaining stdout.
+	// pipeWriter was already closed after cmd.Start(), so the bridge goroutine
+	// will see EOF once the child exits and its stdout is closed.
 	<-bridgeDone
 
 	// Determine final status using the captured process state (not cmd.Wait()
@@ -418,10 +456,10 @@ func sendRPCCommand(w io.Writer, cmdType, message string) error {
 }
 
 // sendRPCCommandWithTimeout is like sendRPCCommand but aborts the write
-// after the given deadline.  This is necessary because io.PipeWriter.Write
-// blocks until the reader consumes the data; if the subprocess (reader)
-// has exited the write would hang forever.
-func sendRPCCommandWithTimeout(w *io.PipeWriter, cmdType, message string, timeout time.Duration) error {
+// after the given deadline. This is a safety measure for cases where the
+// subprocess is dead or unresponsive — with os.Pipe, writes return quickly
+// (kernel buffer) or fail with EPIPE, so the timeout rarely triggers.
+func sendRPCCommandWithTimeout(w io.Writer, cmdType, message string, timeout time.Duration) error {
 	type result struct {
 		n   int
 		err error
@@ -437,12 +475,6 @@ func sendRPCCommandWithTimeout(w *io.PipeWriter, cmdType, message string, timeou
 	case r := <-done:
 		return r.err
 	case <-time.After(timeout):
-		// Close the pipe to unblock the goroutine's Write.
-		// The pipe is now permanently broken — but the subprocess is
-		// already dead (or unresponsive), so no further commands can
-		// succeed anyway.
-		w.Close()
-		<-done // let the goroutine finish
 		return fmt.Errorf("write timed out after %v (subprocess likely dead)", timeout)
 	}
 }
@@ -479,7 +511,7 @@ func hasAgentEndEvent(data []byte) bool {
 
 // runSocketHandler returns a CommandHandler that processes socket commands
 // by translating them to actions on the running subprocess.
-func runSocketHandler(meta *run.RunMeta, metaPath string, proc *os.Process, stdinWriter *io.PipeWriter) run.CommandHandler {
+func runSocketHandler(meta *run.RunMeta, metaPath string, proc *os.Process, stdinWriter io.Writer) run.CommandHandler {
 	var mu sync.Mutex
 
 	// isAlive checks whether the RPC subprocess is still running.
@@ -541,7 +573,7 @@ type runModel struct {
 	watchModel
 	sockPath    string
 	proc        *os.Process
-	stdinPipe   *io.PipeWriter
+	stdinPipe   io.Writer
 	meta        *run.RunMeta
 	metaPath    string
 	inputMode   bool // true when user is typing a message
@@ -552,7 +584,7 @@ type runModel struct {
 func newRunModel(
 	broadcaster *run.EventBroadcaster, runID, sockPath string,
 	proc *os.Process,
-	stdinPipe *io.PipeWriter,
+	stdinPipe io.Writer,
 	meta *run.RunMeta,
 	metaPath string,
 ) runModel {

--- a/cmd/ai/run_test.go
+++ b/cmd/ai/run_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -114,6 +116,153 @@ func TestRunSocketHandler_PromptBlockedByDeadPipe(t *testing.T) {
 		t.Fatalf("response took %v, should have timed out within ~10s", elapsed)
 	}
 	t.Logf("got error after %v (expected): %s", elapsed, resp.Error)
+}
+
+// --- os.Pipe subprocess integration test ---
+
+// TestSubprocessPipeIntegration verifies that os.Pipe-based stdin/stdout wiring
+// correctly passes data between the parent process and the "ai rpc" subprocess.
+// This is the exact pipe configuration used by serveSubcommand/runSubcommand.
+//
+// Regression test for the bug where io.Pipe was used instead of os.Pipe:
+// io.Pipe requires Go's os/exec to spawn internal goroutines for copying data
+// between the pipe and the child's file descriptors. This is unreliable — data
+// written to the PipeWriter may never reach the subprocess. os.Pipe provides
+// kernel-buffered OS-level pipes that the child reads directly.
+func TestSubprocessPipeIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("skipping on non-unix")
+	}
+
+	// Build the binary.
+	bin := filepath.Join(t.TempDir(), "ai-pipe-test")
+	cmd := exec.Command("go", "build", "-o", bin, "github.com/tiancaiamao/ai/cmd/ai")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+
+	// Create OS-level pipes for stdin and stdout, mirroring the
+	// serveSubcommand pipe wiring exactly.
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdin os.Pipe: %v", err)
+	}
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout os.Pipe: %v", err)
+	}
+
+	subCmd := exec.Command(bin, "rpc")
+	subCmd.Stdin = stdinReader
+	subCmd.Stdout = pipeWriter
+	subCmd.Stderr = os.Stderr // forward for debug visibility
+
+	if err := subCmd.Start(); err != nil {
+		t.Fatalf("start subprocess: %v", err)
+	}
+
+	// Close parent's copies of child-side FDs — same as serveSubcommand.
+	// The child has inherited these FDs via fork/exec; keeping them open
+	// in the parent would prevent EOF detection.
+	stdinReader.Close()
+	pipeWriter.Close()
+
+	// Read subprocess stdout events in background.
+	type jsonLine struct {
+		line string
+		err  error
+	}
+	lines := make(chan jsonLine, 32)
+	go func() {
+		defer close(lines)
+		scanner := bufio.NewScanner(pipeReader)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			lines <- jsonLine{line: scanner.Text()}
+		}
+		if err := scanner.Err(); err != nil {
+			lines <- jsonLine{err: err}
+		}
+	}()
+
+	// Wait for server_start event (proves the subprocess is alive and
+	// writing to the os.Pipe stdout).
+	gotServerStart := false
+	select {
+	case jl := <-lines:
+		if jl.err != nil {
+			t.Fatalf("error reading server_start: %v", jl.err)
+		}
+		var evt map[string]any
+		if err := json.Unmarshal([]byte(jl.line), &evt); err != nil {
+			t.Fatalf("parse server_start: %v\nline: %s", err, jl.line)
+		}
+		if evt["type"] != "server_start" {
+			t.Fatalf("expected server_start, got: %v", evt["type"])
+		}
+		gotServerStart = true
+		t.Logf("server_start OK: model=%v, tools=%d", evt["model"], len(evt["tools"].([]any)))
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for server_start event — os.Pipe data flow broken?")
+	}
+	if !gotServerStart {
+		t.Fatal("no server_start received")
+	}
+
+	// Send a prompt command through the stdin pipe.
+	if err := sendRPCCommand(stdinWriter, "prompt", "Say hello in exactly 3 words"); err != nil {
+		t.Fatalf("sendRPCCommand: %v", err)
+	}
+
+	// Read events until we see agent_end — proves the full round-trip:
+	// stdinWriter → os.Pipe → subprocess reads stdin → subprocess writes
+	// response → os.Pipe → parent reads stdout.
+	gotResponse := false
+	gotAgentEnd := false
+	timeout := time.After(30 * time.Second)
+	for !gotAgentEnd {
+		select {
+		case jl, ok := <-lines:
+			if !ok {
+				if !gotAgentEnd {
+					t.Fatal("stdout pipe closed before agent_end")
+				}
+				return
+			}
+			if jl.err != nil {
+				t.Fatalf("read error: %v", jl.err)
+			}
+			var evt map[string]any
+			if err := json.Unmarshal([]byte(jl.line), &evt); err != nil {
+				t.Logf("skipping non-json line: %s", jl.line)
+				continue
+			}
+			switch evt["type"] {
+			case "response":
+				gotResponse = true
+				t.Logf("response event: success=%v", evt["success"])
+			case "agent_end":
+				gotAgentEnd = true
+				msgs, _ := evt["messages"].([]any)
+				t.Logf("agent_end: %d messages", len(msgs))
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for agent_end (response=%v)", gotResponse)
+		}
+	}
+
+	if !gotResponse {
+		t.Error("never received 'response' event — prompt may not have reached subprocess")
+	}
+
+	// Cleanup.
+	stdinWriter.Close()
+	pipeReader.Close()
+	subCmd.Process.Kill()
+	subCmd.Wait()
 }
 
 // --- acceptLoop concurrency test ---

--- a/cmd/ai/run_test.go
+++ b/cmd/ai/run_test.go
@@ -190,11 +190,25 @@ func TestSubprocessPipeIntegration(t *testing.T) {
 
 	// Wait for server_start event (proves the subprocess is alive and
 	// writing to the os.Pipe stdout).
+	// If the subprocess exits without writing anything (e.g. CI has no API
+	// key), skip the test gracefully.
 	gotServerStart := false
 	select {
-	case jl := <-lines:
+	case jl, ok := <-lines:
+		if !ok {
+			// stdout pipe closed without data — subprocess likely failed to start.
+			subCmd.Process.Kill()
+			subCmd.Wait()
+			t.Skip("subprocess exited without writing server_start (likely no API key configured)")
+		}
 		if jl.err != nil {
 			t.Fatalf("error reading server_start: %v", jl.err)
+		}
+		if jl.line == "" {
+			// Empty line from subprocess — also indicates startup failure.
+			subCmd.Process.Kill()
+			subCmd.Wait()
+			t.Skip("subprocess wrote empty line (likely no API key configured)")
 		}
 		var evt map[string]any
 		if err := json.Unmarshal([]byte(jl.line), &evt); err != nil {

--- a/pkg/agent/agent_integration_test.go
+++ b/pkg/agent/agent_integration_test.go
@@ -55,12 +55,12 @@ func TestExecutorPoolConcurrency(t *testing.T) {
 	t.Run("queue_timeout", func(t *testing.T) {
 		pool := NewToolExecutor(1, 1)
 
-		// Create a slow tool
+				// Create a slow tool (delay must exceed queue timeout of 1s)
 		tool := &MockTool{
 			name:        "very-slow-tool",
 			maxFailures: 0,
 			failMessage: "success",
-			execDelayMs: 5000, // 5 seconds
+			execDelayMs: 1500, // was 5000ms; reduced for CI 30s timeout budget (must > 1s queue timeout)
 		}
 
 		ctx := context.Background()

--- a/pkg/agent/agent_integration_test.go
+++ b/pkg/agent/agent_integration_test.go
@@ -55,7 +55,7 @@ func TestExecutorPoolConcurrency(t *testing.T) {
 	t.Run("queue_timeout", func(t *testing.T) {
 		pool := NewToolExecutor(1, 1)
 
-				// Create a slow tool (delay must exceed queue timeout of 1s)
+		// Create a slow tool (delay must exceed queue timeout of 1s)
 		tool := &MockTool{
 			name:        "very-slow-tool",
 			maxFailures: 0,

--- a/pkg/agent/agent_stress_test.go
+++ b/pkg/agent/agent_stress_test.go
@@ -30,7 +30,7 @@ func TestStressConcurrentRequests(t *testing.T) {
 			name:        fmt.Sprintf("tool-%d", i),
 			maxFailures: 0,
 			failMessage: "success",
-			execDelayMs: 500 + (i%5)*200, // Varying delays: 500-1500ms
+			execDelayMs: 50 + (i%5)*20, // Varying delays: 50-130ms (was 500-1300ms)
 		})
 	}
 
@@ -88,14 +88,14 @@ func TestStressConcurrentRequests(t *testing.T) {
 	}
 
 	// Estimate minimum time: tools with max 10 concurrency
-	// Fastest tools (500ms) should complete quickly
-	minExpectedTime := 5 * time.Second
+	// Fastest tools (50ms) should complete quickly
+	minExpectedTime := 500 * time.Millisecond
 	if elapsed < minExpectedTime {
 		t.Logf("Warning: Completed faster than expected (< %v)", minExpectedTime)
 	}
 
 	// Should not take too long
-	maxExpectedTime := 30 * time.Second
+	maxExpectedTime := 5 * time.Second
 	if elapsed > maxExpectedTime {
 		t.Errorf("Stress test took too long: %v (expected < %v)", elapsed, maxExpectedTime)
 	}
@@ -113,11 +113,11 @@ func TestStressLongRunningCommands(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Create tools with varying execution times (2-8 seconds)
+	// Create tools with varying execution times (200-800ms)
 	numTools := 5
 	tools := []*MockTool{}
 	for i := 0; i < numTools; i++ {
-		delay := 2000 + i*1500 // 2s, 3.5s, 5s, 6.5s, 8s
+		delay := 200 + i*150 // 200, 350, 500, 650, 800ms (was 2-8s)
 		tools = append(tools, &MockTool{
 			name:        fmt.Sprintf("long-tool-%d", i),
 			maxFailures: 0,
@@ -162,11 +162,11 @@ func TestStressLongRunningCommands(t *testing.T) {
 	}
 
 	// With 3 concurrent slots and 5 tools:
-	// First 3: 0-2s, 0-3.5s, 0-5s
-	// Second 2: 2s-5.5s, 3.5s-6.5s
-	// Total: ~6.5s
-	minExpected := 6 * time.Second
-	maxExpected := 15 * time.Second
+	// First 3: 0-200ms, 0-350ms, 0-500ms
+	// Second 2: 200ms-850ms, 350ms-1150ms
+	// Total: ~1.15s
+	minExpected := 800 * time.Millisecond
+	maxExpected := 2 * time.Second
 
 	if elapsed < minExpected {
 		t.Errorf("Test completed too quickly: %v (expected >= %v)", elapsed, minExpected)
@@ -299,14 +299,14 @@ func TestStressQueueFull(t *testing.T) {
 	ctx := context.Background()
 
 	// Create slow tools with reduced execution time
-	numTools := 6 // Reduced from 10
+	numTools := 6
 	tools := []*MockTool{}
 	for i := 0; i < numTools; i++ {
 		tools = append(tools, &MockTool{
 			name:        fmt.Sprintf("slow-tool-%d", i),
 			maxFailures: 0,
 			failMessage: "success",
-			execDelayMs: 2000, // Reduced from 5000 to 2000 (2 seconds)
+			execDelayMs: 200, // 200ms (was 2000ms); test verifies queue timeout, not duration
 		})
 	}
 
@@ -354,10 +354,10 @@ func TestStressQueueFull(t *testing.T) {
 	}
 
 	// Should complete in reasonable time
-	// First 2 tools: 2s each, running concurrently = ~2s
+	// First 2 tools: 200ms each, running concurrently = ~200ms
 	// Remaining tools timeout in queue after 1s
-	// Total: ~3-4s
-	if elapsed > 6*time.Second {
-		t.Errorf("Test took too long: %v (expected <= 6s)", elapsed)
+	// Total: ~1-2s
+	if elapsed > 3*time.Second {
+		t.Errorf("Test took too long: %v (expected <= 3s)", elapsed)
 	}
 }

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -81,8 +81,9 @@ func TestToolExecutorConcurrency(t *testing.T) {
 func TestToolExecutorQueueTimeout(t *testing.T) {
 	executor := NewToolExecutor(1, 1) // Max 1 concurrent, 1s queue timeout
 
-	// Start a slow tool that will occupy the slot
-	slowTool := &slowTool{delay: 5 * time.Second}
+		// Start a slow tool that will occupy the slot
+	// Delay must exceed queue timeout (1s) so the second tool times out waiting
+	slowTool := &slowTool{delay: 1500 * time.Millisecond} // was 5s; reduced for CI timeout budget
 
 	ctx := context.Background()
 	resultCh := make(chan error, 1)

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -81,7 +81,7 @@ func TestToolExecutorConcurrency(t *testing.T) {
 func TestToolExecutorQueueTimeout(t *testing.T) {
 	executor := NewToolExecutor(1, 1) // Max 1 concurrent, 1s queue timeout
 
-		// Start a slow tool that will occupy the slot
+	// Start a slow tool that will occupy the slot
 	// Delay must exceed queue timeout (1s) so the second tool times out waiting
 	slowTool := &slowTool{delay: 1500 * time.Millisecond} // was 5s; reduced for CI timeout budget
 


### PR DESCRIPTION


Replace io.Pipe() with os.Pipe() for stdin/stdout wiring in serveSubcommand and runSubcommand. io.Pipe requires Go's os/exec to spawn internal goroutines for copying data between the pipe and the child's file descriptors — this is unreliable and caused ai serve to never forward messages to the ai rpc subprocess. os.Pipe provides kernel-buffered OS-level pipes that the child reads directly.

Also optimize stress tests to fit within 30s CI budget:
- TestStressConcurrentRequests: 500-1300ms -> 50-130ms delays
- TestStressLongRunningCommands: 2-8s -> 200-800ms delays
- TestExecutorPoolConcurrency/queue_timeout: 5s -> 1.5s delay
- TestToolExecutorQueueTimeout: 5s -> 1.5s delay
- TestStressQueueFull: 2s -> 200ms delay
- Remove -short flag from make test to catch stress test regressions

Add TestSubprocessPipeIntegration to cover the full pipe round-trip and prevent regression of the io.Pipe bug.