### PR TITLE
Fix: prevent empty checkpoint from overwriting previous LLMContext

### DIFF
--- a/pkg/agent/checkpoint_manager.go
+++ b/pkg/agent/checkpoint_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 )
@@ -60,6 +61,22 @@ func (m *AgentContextCheckpointManager) CreateSnapshot(
 ) (int, error) {
 	if !m.enabled {
 		return totalTurns, nil
+	}
+
+	// Defense in depth: if the new LLMContext is empty, carry forward the
+	// content from the previous checkpoint. This prevents data loss when
+	// the caller passes an empty string (e.g. after truncate without
+	// update_llm_context).
+	if llmContext == "" {
+		if prev, err := agentctx.LoadLatestCheckpoint(m.sessionDir); err == nil {
+			if prevCtx, err := agentctx.LoadCheckpointLLMContext(
+				filepath.Join(m.sessionDir, prev.Path),
+			); err == nil && prevCtx != "" {
+				slog.Info("[Checkpoint] Carrying forward previous LLMContext (new context is empty)",
+					"previousTurn", prev.Turn, "previousChars", len(prevCtx))
+				llmContext = prevCtx
+			}
+		}
 	}
 
 	// Capture the full AgentState from the running context.

--- a/pkg/agent/checkpoint_manager_test.go
+++ b/pkg/agent/checkpoint_manager_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -154,6 +155,127 @@ func TestCheckpointManager_ShouldCheckpoint_Disabled(t *testing.T) {
 	}
 }
 
+func TestCheckpointManager_CreateSnapshot_EmptyLLMContext_CarriesForward(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewAgentContextCheckpointManager(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create checkpoint manager: %v", err)
+	}
+	defer mgr.Close()
+
+	// Step 1: Create initial checkpoint with non-empty LLMContext
+	initialContext := "# Current Task\nImportant context that must not be lost"
+	agentCtx := &agentctx.AgentContext{
+		RecentMessages: []agentctx.AgentMessage{agentctx.NewUserMessage("Hello")},
+		AgentState:     agentctx.NewAgentState("test-session", "/workspace"),
+	}
+
+	_, err = mgr.CreateSnapshot(agentCtx, initialContext, 5)
+	if err != nil {
+		t.Fatalf("Failed to create initial snapshot: %v", err)
+	}
+
+	// Step 2: Create snapshot with empty LLMContext (simulates truncate-without-update)
+	agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("More messages"))
+	_, err = mgr.CreateSnapshot(agentCtx, "", 8)
+	if err != nil {
+		t.Fatalf("Failed to create snapshot with empty context: %v", err)
+	}
+
+	// Step 3: Reconstruct and verify context was carried forward
+	recoveredLLMContext, _, _, err := mgr.Reconstruct()
+	if err != nil {
+		t.Fatalf("Failed to reconstruct: %v", err)
+	}
+
+	if recoveredLLMContext != initialContext {
+		t.Errorf("LLMContext should be carried forward from previous checkpoint.\nExpected: %q\nGot: %q", initialContext, recoveredLLMContext)
+	}
+
+	// Step 4: Verify the checkpoint file on disk has the carried-forward content
+	latestInfo, err := agentctx.LoadLatestCheckpoint(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to load latest checkpoint info: %v", err)
+	}
+	onDisk, err := agentctx.LoadCheckpointLLMContext(filepath.Join(tmpDir, latestInfo.Path))
+	if err != nil {
+		t.Fatalf("Failed to load LLM context from disk: %v", err)
+	}
+	if onDisk != initialContext {
+		t.Errorf("On-disk LLMContext should match carried-forward content.\nExpected: %q\nGot: %q", initialContext, onDisk)
+	}
+}
+
+func TestCheckpointManager_CreateSnapshot_NonEmptyContext_Unchanged(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewAgentContextCheckpointManager(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create checkpoint manager: %v", err)
+	}
+	defer mgr.Close()
+
+	// Create first checkpoint with content
+	firstContext := "First context"
+	agentCtx := &agentctx.AgentContext{
+		RecentMessages: []agentctx.AgentMessage{},
+		AgentState:     agentctx.NewAgentState("test-session", "/workspace"),
+	}
+	_, err = mgr.CreateSnapshot(agentCtx, firstContext, 1)
+	if err != nil {
+		t.Fatalf("Failed to create first snapshot: %v", err)
+	}
+
+	// Create second checkpoint with different content — should NOT carry forward
+	secondContext := "Second context (updated)"
+	_, err = mgr.CreateSnapshot(agentCtx, secondContext, 3)
+	if err != nil {
+		t.Fatalf("Failed to create second snapshot: %v", err)
+	}
+
+	// Reconstruct should return the second (latest) context
+	recoveredLLMContext, _, _, err := mgr.Reconstruct()
+	if err != nil {
+		t.Fatalf("Failed to reconstruct: %v", err)
+	}
+
+	if recoveredLLMContext != secondContext {
+		t.Errorf("LLMContext should be the latest non-empty value.\nExpected: %q\nGot: %q", secondContext, recoveredLLMContext)
+	}
+}
+
+func TestCheckpointManager_CreateSnapshot_EmptyFirst_NoPrevious(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewAgentContextCheckpointManager(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create checkpoint manager: %v", err)
+	}
+	defer mgr.Close()
+
+	// Create very first snapshot with empty context — no previous to carry forward from
+	agentCtx := &agentctx.AgentContext{
+		RecentMessages: []agentctx.AgentMessage{},
+		AgentState:     agentctx.NewAgentState("test-session", "/workspace"),
+	}
+
+	_, err = mgr.CreateSnapshot(agentCtx, "", 0)
+	if err != nil {
+		t.Fatalf("Failed to create snapshot: %v", err)
+	}
+
+	// Should succeed but context stays empty (no previous to carry forward from)
+	recoveredLLMContext, _, _, err := mgr.Reconstruct()
+	if err != nil {
+		t.Fatalf("Failed to reconstruct: %v", err)
+	}
+
+	if recoveredLLMContext != "" {
+		t.Errorf("LLMContext should remain empty when no previous checkpoint exists, got: %q", recoveredLLMContext)
+	}
+}
+
 func TestHasToolResultNamed(t *testing.T) {
 	results := []agentctx.AgentMessage{
 		agentctx.NewToolResultMessage("id1", "bash", []agentctx.ContentBlock{
@@ -182,4 +304,126 @@ func TestHasToolResultNamed(t *testing.T) {
 	if hasToolResultNamed([]agentctx.AgentMessage{}, "update_llm_context") {
 		t.Error("Should return false for empty results")
 	}
+}
+
+// TestSavePreCompactionCheckpoint_EmptyLLMContext_SkipsCheckpoint verifies
+// the first defense layer: savePreCompactionCheckpoint skips when LLMContext
+// is empty, preventing creation of checkpoints that would overwrite good data.
+func TestSavePreCompactionCheckpoint_EmptyLLMContext_SkipsCheckpoint(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewAgentContextCheckpointManager(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create checkpoint manager: %v", err)
+	}
+	defer mgr.Close()
+
+	// Create an initial checkpoint with real content
+	initialContext := "# Important context\nDo not lose this"
+	agentCtx := &agentctx.AgentContext{
+		LLMContext:     initialContext,
+		RecentMessages: []agentctx.AgentMessage{agentctx.NewUserMessage("Hello")},
+		AgentState:     agentctx.NewAgentState("test-session", "/workspace"),
+	}
+	_, err = mgr.CreateSnapshot(agentCtx, initialContext, 1)
+	if err != nil {
+		t.Fatalf("Failed to create initial snapshot: %v", err)
+	}
+
+	// Now simulate the bug scenario: LLMContext is empty (truncate-without-update)
+	agentCtx.LLMContext = ""
+
+	// Create a loopState with a compactor that would normally trigger
+	ls := &loopState{
+		config: &LoopConfig{
+			Compactors: []agentctx.Compactor{
+				&alwaysCompactCompactor{},
+			},
+		},
+		agentCtx:      agentCtx,
+		checkpointMgr: mgr,
+		turnCount:     5,
+	}
+
+	// Call savePreCompactionCheckpoint — it should skip because LLMContext is empty
+	ls.savePreCompactionCheckpoint("pre_llm_threshold")
+
+	// Verify no new checkpoint was created by checking the count
+	idx, err := agentctx.LoadCheckpointIndex(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to load checkpoint index: %v", err)
+	}
+	if len(idx.Checkpoints) != 1 {
+		t.Errorf("Expected 1 checkpoint (initial only), got %d", len(idx.Checkpoints))
+	}
+
+	// Verify the current symlink still points to the good checkpoint
+	recoveredLLMContext, _, _, err := mgr.Reconstruct()
+	if err != nil {
+		t.Fatalf("Failed to reconstruct: %v", err)
+	}
+	if recoveredLLMContext != initialContext {
+		t.Errorf("LLMContext should still be the initial value.\nExpected: %q\nGot: %q", initialContext, recoveredLLMContext)
+	}
+}
+
+// TestSavePreCompactionCheckpoint_NonEmptyLLMContext_CreatesCheckpoint verifies
+// that savePreCompactionCheckpoint still works correctly when LLMContext is non-empty.
+func TestSavePreCompactionCheckpoint_NonEmptyLLMContext_CreatesCheckpoint(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewAgentContextCheckpointManager(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create checkpoint manager: %v", err)
+	}
+	defer mgr.Close()
+
+	// Create initial checkpoint
+	agentCtx := &agentctx.AgentContext{
+		LLMContext:     "# Task context",
+		RecentMessages: []agentctx.AgentMessage{agentctx.NewUserMessage("Hello")},
+		AgentState:     agentctx.NewAgentState("test-session", "/workspace"),
+	}
+	_, err = mgr.CreateSnapshot(agentCtx, "# Task context", 1)
+	if err != nil {
+		t.Fatalf("Failed to create initial snapshot: %v", err)
+	}
+
+	// Now with non-empty LLMContext, savePreCompactionCheckpoint should create a new one
+	ls := &loopState{
+		config: &LoopConfig{
+			Compactors: []agentctx.Compactor{
+				&alwaysCompactCompactor{},
+			},
+		},
+		agentCtx:      agentCtx,
+		checkpointMgr: mgr,
+		turnCount:     3,
+	}
+
+	ls.savePreCompactionCheckpoint("pre_llm_threshold")
+
+	// Verify a new checkpoint was created
+	idx, err := agentctx.LoadCheckpointIndex(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to load checkpoint index: %v", err)
+	}
+	if len(idx.Checkpoints) != 2 {
+		t.Errorf("Expected 2 checkpoints, got %d", len(idx.Checkpoints))
+	}
+}
+
+// alwaysCompactCompactor is a test compactor that always reports ShouldCompact=true.
+type alwaysCompactCompactor struct{}
+
+func (a *alwaysCompactCompactor) ShouldCompact(_ context.Context, _ *agentctx.AgentContext) bool {
+	return true
+}
+
+func (a *alwaysCompactCompactor) Compact(_ *agentctx.AgentContext) (*agentctx.CompactionResult, error) {
+	return &agentctx.CompactionResult{Summary: "test compaction"}, nil
+}
+
+func (a *alwaysCompactCompactor) CalculateDynamicThreshold() int {
+	return 0
 }

--- a/pkg/agent/loop_state.go
+++ b/pkg/agent/loop_state.go
@@ -85,6 +85,13 @@ func (s *loopState) savePreCompactionCheckpoint(trigger string) {
 	if s.checkpointMgr == nil || !s.checkpointMgr.ShouldCheckpoint() {
 		return
 	}
+	// Guard: skip checkpoint when LLMContext is empty (e.g. after truncate
+	// without update_llm_context). Writing an empty checkpoint would
+	// overwrite the previous checkpoint that had content.
+	if s.agentCtx.LLMContext == "" {
+		slog.Info("[Loop] Skipping pre-compaction checkpoint (LLMContext is empty)", "trigger", trigger, "turn", s.turnCount)
+		return
+	}
 	// Check if any compactor would trigger before saving checkpoint.
 	shouldCompact := false
 	for _, c := range s.config.Compactors {

--- a/pkg/context/checkpoint_test.go
+++ b/pkg/context/checkpoint_test.go
@@ -490,3 +490,62 @@ func TestTruncateWithHeadTail_Long(t *testing.T) {
 	assert.Contains(t, result, "chars truncated")
 	assert.True(t, len(result) < len(longText))
 }
+
+// --- Empty LLMContext defense tests ---
+
+func TestCheckpoint_EmptyLLMContext_WritesEmptyFile(t *testing.T) {
+	// This test documents that SaveCheckpoint writes an empty llm_context.txt
+	// when snapshot.LLMContext is "". The defense against this is at the
+	// caller level (CreateSnapshot carry-forward) and loop_state guard.
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "session")
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+
+	snapshot := &ContextSnapshot{
+		LLMContext:     "",
+		RecentMessages: []AgentMessage{},
+		AgentState:     &AgentState{TotalTurns: 0},
+	}
+
+	info, err := SaveCheckpoint(sessionDir, snapshot, 0, 0)
+	require.NoError(t, err)
+
+	// Verify empty file is written (documenting current behavior)
+	llmContextPath := filepath.Join(sessionDir, info.Path, "llm_context.txt")
+	data, err := os.ReadFile(llmContextPath)
+	require.NoError(t, err)
+	assert.Equal(t, "", string(data))
+}
+
+func TestCheckpoint_SecondSaveWithEmptyContext_OverwritesPrevious(t *testing.T) {
+	// Documents the bug scenario: a second SaveCheckpoint with empty context
+	// overwrites the good data from the first save. This is why the defense
+	// layers in CreateSnapshot and savePreCompactionCheckpoint are needed.
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "session")
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+
+	// First save: good content
+	snapshot1 := &ContextSnapshot{
+		LLMContext:     "Important context that should be preserved",
+		RecentMessages: []AgentMessage{},
+		AgentState:     &AgentState{TotalTurns: 1},
+	}
+	_, err := SaveCheckpoint(sessionDir, snapshot1, 1, 0)
+	require.NoError(t, err)
+
+	// Second save: empty content (the bug scenario)
+	snapshot2 := &ContextSnapshot{
+		LLMContext:     "",
+		RecentMessages: []AgentMessage{},
+		AgentState:     &AgentState{TotalTurns: 2},
+	}
+	info2, err := SaveCheckpoint(sessionDir, snapshot2, 2, 0)
+	require.NoError(t, err)
+
+	// Verify the latest checkpoint has empty context (bug behavior documented)
+	llmContextPath := filepath.Join(sessionDir, info2.Path, "llm_context.txt")
+	data, err := os.ReadFile(llmContextPath)
+	require.NoError(t, err)
+	assert.Equal(t, "", string(data), "Second checkpoint with empty context writes empty file (expected — defense is at caller level)")
+}


### PR DESCRIPTION
## Summary

Fixes a regression since commit 3ce9871 where `savePreCompactionCheckpoint()` writes empty `llm_context.txt` files when `agentCtx.LLMContext` is empty (e.g. after truncate without `update_llm_context`), overwriting the previous checkpoint that had content.

Bug rate: 14-30% empty checkpoints after May 17 (vs 0-9% baseline before).

## Root Cause

`savePreCompactionCheckpoint()` in `loop_state.go` unconditionally calls `CreateSnapshot()` with `s.agentCtx.LLMContext`, which can be empty string. `CreateSnapshot()` then calls `SaveCheckpoint()` which writes an empty file.

## Fix: Two-layer defense

1. **Guard in `savePreCompactionCheckpoint`**: Skip checkpoint when `LLMContext == ""`. Logs and returns early.
2. **Carry-forward in `CreateSnapshot`**: When `llmContext == ""`, loads the previous checkpoint's `llm_context.txt` via `LoadLatestCheckpoint` + `LoadCheckpointLLMContext` and uses its content. Defense-in-depth for any other caller.

## Tests Added

| Test | Package | What it verifies |
|------|---------|-----------------|
| `TestSavePreCompactionCheckpoint_EmptyLLMContext_SkipsCheckpoint` | agent | Layer 1: empty context → no checkpoint created |
| `TestSavePreCompactionCheckpoint_NonEmptyLLMContext_CreatesCheckpoint` | agent | Normal path still works |
| `TestCheckpointManager_CreateSnapshot_EmptyLLMContext_CarriesForward` | agent | Layer 2: empty context carries forward from previous |
| `TestCheckpointManager_CreateSnapshot_NonEmptyContext_Unchanged` | agent | Non-empty context not affected |
| `TestCheckpointManager_CreateSnapshot_EmptyFirst_NoPrevious` | agent | First checkpoint with empty context → stays empty |
| `TestCheckpoint_EmptyLLMContext_WritesEmptyFile` | context | Documents SaveCheckpoint behavior with empty input |
| `TestCheckpoint_SecondSaveWithEmptyContext_OverwritesPrevious` | context | Documents the overwriting bug at IO level |

All tests pass. Formatted with `make fmt`.