### PR TITLE
fix: loop guard display, hard abort recovery, and polling detection

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -267,6 +267,17 @@ func runInnerLoop(
 				continue
 			}
 
+			// Loop guard hard-abort recovery: give the LLM one final turn
+			// to produce a text response to the user instead of silently
+			// terminating. The sanitizeMessageForToolLoopGuard has already
+			// replaced tool calls with a textual explanation of the abort,
+			// so the LLM will see it and can respond accordingly.
+			if msg.StopReason == "aborted" && !state.guardAbortRecovery {
+				state.guardAbortRecovery = true
+				slog.Info("[Loop] loop guard hard abort — giving LLM one recovery turn")
+				continue
+			}
+
 			// Check for empty response: stop_reason=stop but no actionable content.
 			if msg.StopReason == "stop" && isEmptyActionableResponse(msg) && state.emptyRetries < defaultEmptyResponseMaxRetries {
 				state.emptyRetries++

--- a/pkg/agent/loop_characterization_test.go
+++ b/pkg/agent/loop_characterization_test.go
@@ -252,13 +252,13 @@ func TestCharacterization_ToolLoopGuard(t *testing.T) {
 
 	// LLM should be called MaxConsecutiveToolCalls + 1 + defaultLoopGuardMaxFeedback times
 	// (3 identical calls allowed, then guard triggers → feedback #1 → LLM retries,
-	//  feedback #2 → LLM retries, then hard abort)
-	// Total: 3 normal + 2 feedback + 1 abort = 6
+	//  feedback #2 → LLM retries, then hard abort → recovery turn → hard abort again)
+	// Total: 3 normal + 2 feedback + 1 hard abort + 1 recovery turn = 7
 	mu.Lock()
 	count := llmCallCount
 	mu.Unlock()
-	if count != 6 { // 3 allowed + 2 feedback + 1 hard abort trigger
-		t.Errorf("expected 6 LLM calls (3 allowed + 2 feedback + 1 hard abort), got %d", count)
+	if count != 7 { // 3 allowed + 2 feedback + 1 hard abort + 1 recovery turn
+		t.Errorf("expected 7 LLM calls (3 allowed + 2 feedback + 1 hard abort + 1 recovery turn), got %d", count)
 	}
 
 	// Must end with agent_end

--- a/pkg/agent/loop_recovery_test.go
+++ b/pkg/agent/loop_recovery_test.go
@@ -183,13 +183,14 @@ func TestRunInnerLoopStopsRepeatedToolCalls(t *testing.T) {
 		MaxToolCallsPerName:     100,
 	}, stream)
 
-	// With the feedback-to-LLM strategy:
+	// With the feedback-to-LLM strategy + abort recovery:
 	//   call 1-2: normal execution
 	//   call 3: guard triggers → feedback #1 → LLM retries
 	//   call 4: guard triggers → feedback #2 → LLM retries
-	//   call 5: guard triggers → hard abort (feedback limit exhausted)
-	if callCount != 5 {
-		t.Fatalf("expected loop guard to hard-abort after 5 calls (2 normal + 2 feedback + 1 abort), got %d calls", callCount)
+	//   call 5: guard triggers → hard abort → recovery turn
+	//   call 6: LLM retries same call → hard abort again (no more recovery) → terminate
+	if callCount != 6 {
+		t.Fatalf("expected loop guard to hard-abort after 6 calls (2 normal + 2 feedback + 2 abort with recovery), got %d calls", callCount)
 	}
 
 	var sawGuardedTurn bool
@@ -218,9 +219,9 @@ func TestRunInnerLoopStopsRepeatedToolCalls(t *testing.T) {
 	if !sawGuardEvent {
 		t.Fatal("expected loop_guard_triggered event")
 	}
-	// Guard should trigger 3 times: 2 feedback + 1 hard abort
-	if guardEventCount != 3 {
-		t.Fatalf("expected 3 loop guard events (2 feedback + 1 hard abort), got %d", guardEventCount)
+	// Guard should trigger 4 times: 2 feedback + 2 hard abort (with recovery)
+	if guardEventCount != 4 {
+		t.Fatalf("expected 4 loop guard events (2 feedback + 2 hard abort), got %d", guardEventCount)
 	}
 }
 
@@ -255,13 +256,14 @@ func TestRunInnerLoopStopsRepeatedToolCallsByDefaultGuard(t *testing.T) {
 	runInnerLoop(context.Background(), agentCtx, nil, &LoopConfig{}, stream)
 
 	// defaultLoopMaxConsecutiveToolCalls = 6, so guard triggers on the 7th call.
-	// With feedback-to-LLM strategy (defaultLoopGuardMaxFeedback = 2):
+	// With feedback-to-LLM strategy (defaultLoopGuardMaxFeedback = 2) + abort recovery:
 	//   call 1-6: normal execution
 	//   call 7: guard triggers → feedback #1 → LLM retries
 	//   call 8: guard triggers → feedback #2 → LLM retries
-	//   call 9: guard triggers → hard abort (feedback limit exhausted)
-	if callCount != 9 {
-		t.Fatalf("expected default loop guard to hard-abort after 9 calls (6 normal + 2 feedback + 1 abort), got %d calls", callCount)
+	//   call 9: guard triggers → hard abort → recovery turn
+	//   call 10: LLM retries → hard abort again (no more recovery) → terminate
+	if callCount != 10 {
+		t.Fatalf("expected default loop guard to hard-abort after 10 calls (6 normal + 2 feedback + 2 abort with recovery), got %d calls", callCount)
 	}
 }
 
@@ -1129,5 +1131,197 @@ func TestRunInnerLoopCompactionRecoveryOnContextLimitStopReason(t *testing.T) {
 	// Verify the agent recovered and returned the second response
 	if len(finalMessages) == 0 {
 		t.Fatal("expected final messages after recovery")
+	}
+}
+
+// TestLoopGuardHardAbortRecovery verifies that after a loop guard hard abort,
+// the LLM gets one recovery turn to produce a text response instead of
+// silently terminating. On the recovery turn, if the LLM produces text
+// (stopReason=stop), the agent terminates normally.
+func TestLoopGuardHardAbortRecovery(t *testing.T) {
+	orig := streamAssistantResponseFn
+	defer func() { streamAssistantResponseFn = orig }()
+
+	callCount := 0
+	streamAssistantResponseFn = func(
+		_ context.Context,
+		_ *agentctx.AgentContext,
+		_ *LoopConfig,
+		_ *llm.EventStream[AgentEvent, []agentctx.AgentMessage],
+	) (*agentctx.AgentMessage, error) {
+		callCount++
+		msg := agentctx.NewAssistantMessage()
+
+		if callCount <= 5 {
+			// Calls 1-2: normal execution (maxConsecutive=2)
+			// Call 3: triggers soft feedback #1 (consecutive=3 > 2)
+			// Call 4: triggers soft feedback #2 (consecutive=4)
+			// Call 5: triggers hard abort (consecutive=5, feedback exhausted)
+			msg.Content = []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:        fmt.Sprintf("call-%d", callCount),
+					Type:      "toolCall",
+					Name:      "read",
+					Arguments: map[string]any{"path": "/tmp/a.txt"},
+				},
+			}
+			msg.StopReason = "tool_calls"
+			return &msg, nil
+		}
+
+		// Call 6: recovery turn — LLM responds with text instead of tool call
+		msg.Content = []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "I was stuck in a loop. Here's my final answer."},
+		}
+		msg.StopReason = "stop"
+		return &msg, nil
+	}
+
+	agentCtx := agentctx.NewAgentContext("sys")
+	agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("start"))
+	stream := newTestAgentEventStream()
+	runInnerLoop(context.Background(), agentCtx, nil, &LoopConfig{
+		MaxConsecutiveToolCalls: 2,
+		MaxToolCallsPerName:     100,
+	}, stream)
+
+	// call 1: read (consecutive=1) — executed
+	// call 2: read (consecutive=2) — executed
+	// call 3: read (consecutive=3) → soft feedback #1, guard blocks
+	// call 4: read (consecutive=4) → soft feedback #2, guard blocks
+	// call 5: read (consecutive=5) → hard abort → sanitize → recovery turn → continue
+	// call 6: LLM responds with text → stop
+	if callCount != 6 {
+		t.Fatalf("expected 6 calls (2 normal + 2 feedback + 1 hard abort + 1 recovery text), got %d", callCount)
+	}
+
+	// Verify we got agent_end (normal termination after recovery)
+	var sawAgentEnd bool
+	var sawAbortedTurnEnd int
+	for item := range stream.Iterator(context.Background()) {
+		if item.Done {
+			break
+		}
+		if item.Value.Type == EventAgentEnd {
+			sawAgentEnd = true
+		}
+		if item.Value.Type == EventTurnEnd && item.Value.Message != nil && item.Value.Message.StopReason == "aborted" {
+			sawAbortedTurnEnd++
+		}
+	}
+
+	if !sawAgentEnd {
+		t.Error("expected EventAgentEnd after recovery turn")
+	}
+	// Should see exactly one aborted turn (the hard abort that triggered recovery)
+	if sawAbortedTurnEnd != 1 {
+		t.Errorf("expected 1 aborted turn_end, got %d", sawAbortedTurnEnd)
+	}
+}
+
+// variableOutputTool is a test tool that returns incrementing output each call.
+type variableOutputTool struct {
+	counter int
+}
+
+func (v *variableOutputTool) Name() string               { return "poll" }
+func (v *variableOutputTool) Description() string        { return "poll for status" }
+func (v *variableOutputTool) Parameters() map[string]any { return nil }
+func (v *variableOutputTool) Execute(_ context.Context, _ map[string]any) ([]agentctx.ContentBlock, error) {
+	v.counter++
+	return []agentctx.ContentBlock{
+		agentctx.TextContent{Type: "text", Text: fmt.Sprintf("status: iteration %d complete", v.counter)},
+	}, nil
+}
+
+// TestLoopGuardPollingDetection verifies that when tool output keeps changing
+// despite identical tool calls (polling pattern), the guard suppresses hard
+// abort and only issues soft feedback. This prevents killing legitimate
+// polling behavior like waiting for a benchmark to complete.
+func TestLoopGuardPollingDetection(t *testing.T) {
+	orig := streamAssistantResponseFn
+	defer func() { streamAssistantResponseFn = orig }()
+
+	var callCount int
+	pollTool := &variableOutputTool{}
+
+	streamAssistantResponseFn = func(
+		_ context.Context,
+		agentCtx *agentctx.AgentContext,
+		_ *LoopConfig,
+		_ *llm.EventStream[AgentEvent, []agentctx.AgentMessage],
+	) (*agentctx.AgentMessage, error) {
+		callCount++
+
+		// Register the variable-output tool on first call
+		if callCount == 1 {
+			agentCtx.Tools = []agentctx.Tool{pollTool}
+		}
+
+		msg := agentctx.NewAssistantMessage()
+
+		if callCount <= 8 {
+			// Repeated tool calls with identical arguments but changing output
+			msg.Content = []agentctx.ContentBlock{
+				agentctx.ToolCallContent{
+					ID:        fmt.Sprintf("call-%d", callCount),
+					Type:      "toolCall",
+					Name:      "poll",
+					Arguments: map[string]any{"query": "status"},
+				},
+			}
+			msg.StopReason = "tool_calls"
+			return &msg, nil
+		}
+
+		// After enough polling, LLM produces final answer
+		msg.Content = []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: "Polling complete. All iterations done."},
+		}
+		msg.StopReason = "stop"
+		return &msg, nil
+	}
+
+	agentCtx := agentctx.NewAgentContext("sys")
+	agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("poll for status"))
+	stream := newTestAgentEventStream()
+	runInnerLoop(context.Background(), agentCtx, nil, &LoopConfig{
+		MaxConsecutiveToolCalls: 3, // trigger after 3 consecutive identical calls
+		MaxToolCallsPerName:     100,
+		EnableCheckpoint:        false,
+	}, stream)
+
+	// With polling detection:
+	// call 1-3: normal execution (consecutive 1→3), tool runs, output changes
+	// call 4: guard triggers soft feedback #1 (consecutive=4), output changed → suppress hard abort
+	// call 5: guard triggers soft feedback #2 (consecutive=5), output changed → suppress hard abort
+	// call 6: guard triggers soft feedback #3 (consecutive=6), still changing → would be hard abort but suppressed
+	// call 7: soft feedback #4...
+	// Eventually LLM self-corrects and returns text
+	//
+	// Key assertion: no hard abort despite exceeding maxFeedbackAttempts,
+	// because output keeps changing (polling).
+	var sawHardAbort bool
+	var feedbackCount int
+	for item := range stream.Iterator(context.Background()) {
+		if item.Done {
+			break
+		}
+		if item.Value.Type == EventTurnEnd && item.Value.Message != nil && item.Value.Message.StopReason == "aborted" {
+			sawHardAbort = true
+		}
+		if item.Value.Type == EventLoopGuardTriggered {
+			feedbackCount++
+		}
+	}
+
+	if sawHardAbort {
+		t.Error("expected NO hard abort when output is changing (polling pattern), but got one")
+	}
+	if feedbackCount == 0 {
+		t.Error("expected some loop guard feedback events even with polling")
+	}
+	if callCount < 5 {
+		t.Errorf("expected at least 5 calls (polling should be allowed to continue), got %d", callCount)
 	}
 }

--- a/pkg/agent/loop_state.go
+++ b/pkg/agent/loop_state.go
@@ -26,6 +26,10 @@ type loopState struct {
 	emptyRetries   int
 	malformedRecs  int
 	newMessages    []agentctx.AgentMessage
+	// guardAbortRecovery tracks whether we've already given the LLM a
+	// recovery turn after a loop guard hard abort. Prevents re-triggering
+	// if the LLM continues the loop.
+	guardAbortRecovery bool
 }
 
 func newLoopState(
@@ -289,6 +293,17 @@ func (s *loopState) processToolCalls(
 	for _, result := range toolResults {
 		s.agentCtx.RecentMessages = append(s.agentCtx.RecentMessages, result)
 		s.newMessages = append(s.newMessages, result)
+	}
+
+	// Notify loop guard of tool output so it can detect polling patterns
+	// (same tool+args but changing output = legitimate polling, not stuck loop).
+	if s.loopGuard != nil {
+		for _, result := range toolResults {
+			outputHash := result.OutputHash()
+			if outputHash != "" {
+				s.loopGuard.NotifyToolOutput(outputHash)
+			}
+		}
 	}
 
 	// Increment tool call counter for compactor trigger intervals.

--- a/pkg/agent/tool_guard.go
+++ b/pkg/agent/tool_guard.go
@@ -13,11 +13,17 @@ import (
 
 // toolLoopGuard detects and prevents infinite tool call loops.
 // It only counts consecutive calls with the same signature (name + arguments hash).
-// When the tool or arguments change, the counter resets to 1.
+// When the tool or arguments change, the counter resets.
+//
+// The guard also tracks tool output changes: if the output keeps changing despite
+// identical tool calls, this indicates legitimate polling rather than a stuck loop.
+// In that case the guard softens its response — soft feedback is still issued to
+// encourage the LLM to change approach, but hard abort is suppressed until the
+// output stops changing.
 //
 // Strategy: instead of aborting immediately, the guard returns a ToolResult
 // with actionable feedback so the LLM can self-correct. After maxFeedbackAttempts
-// the guard escalates to a hard abort.
+// the guard escalates to a hard abort (unless output is still changing).
 type toolLoopGuard struct {
 	maxConsecutive int
 
@@ -30,6 +36,15 @@ type toolLoopGuard struct {
 	// maxFeedbackAttempts is the number of feedback rounds before hard abort.
 	// 0 means use the default (defaultLoopGuardMaxFeedback).
 	maxFeedbackAttempts int
+
+	// lastOutputHash is a hash of the last tool output for the current signature.
+	// Used to detect whether a repeated tool call is producing different results
+	// (legitimate polling) vs. identical results (stuck loop).
+	lastOutputHash string
+	// outputChangedSinceBlock is true when tool output has changed since the
+	// guard first started blocking this signature. When true, hard abort is
+	// suppressed — the guard only issues soft feedback.
+	outputChangedSinceBlock bool
 }
 
 const defaultLoopGuardMaxFeedback = 2
@@ -75,9 +90,23 @@ type ObserveResult struct {
 	FeedbackAttempt int
 }
 
+// NotifyToolOutput records the output of a tool execution so the guard can
+// detect polling patterns (same tool+args but changing output).
+// Call this after tool execution completes with a hash of the output content.
+func (g *toolLoopGuard) NotifyToolOutput(outputHash string) {
+	if g.lastOutputHash != "" && g.lastOutputHash != outputHash {
+		g.outputChangedSinceBlock = true
+	}
+	g.lastOutputHash = outputHash
+}
+
 // Observe checks tool calls for loop patterns.
 // It only counts consecutive calls with the same signature (name + arguments hash).
 // When the signature changes, the counter resets.
+//
+// If tool output has been changing (detected via NotifyToolOutput), the guard
+// suppresses hard abort and only issues soft feedback — the LLM may be
+// legitimately polling for progress.
 //
 // Returns an ObserveResult indicating whether a loop was detected and whether
 // the guard should return feedback to the LLM (soft) or abort (hard).
@@ -95,13 +124,19 @@ func (g *toolLoopGuard) Observe(toolCalls []agentctx.ToolCallContent) ObserveRes
 			g.lastSignature = signature
 			g.consecutiveRun = 1
 			g.feedbackCount = 0
+			g.lastOutputHash = ""
+			g.outputChangedSinceBlock = false
 		}
 
 		if g.maxConsecutive > 0 && g.consecutiveRun > g.maxConsecutive {
 			reason := fmt.Sprintf("detected %d consecutive identical tool calls (%s)", g.consecutiveRun, name)
+			if g.outputChangedSinceBlock {
+				reason += " (output is changing — likely polling, not stuck)"
+			}
 
 			// Check if we've exhausted feedback attempts.
-			if g.feedbackCount >= g.maxFeedbackAttempts {
+			// Suppress hard abort if output is still changing (legitimate polling).
+			if g.feedbackCount >= g.maxFeedbackAttempts && !g.outputChangedSinceBlock {
 				return ObserveResult{
 					Blocked:   true,
 					Reason:    reason,

--- a/pkg/context/message.go
+++ b/pkg/context/message.go
@@ -162,6 +162,31 @@ func (m *AgentMessage) ExtractText() string {
 	return b.String()
 }
 
+// OutputHash returns a short hash of the tool result text content.
+// Used by the loop guard to detect whether repeated tool calls are
+// producing different output (polling) vs. identical output (stuck loop).
+// Returns empty string for non-toolResult messages.
+func (m AgentMessage) OutputHash() string {
+	if m.Role != "toolResult" {
+		return ""
+	}
+	text := m.ExtractText()
+	if text == "" {
+		return ""
+	}
+	// FNV-1a 32-bit: fast, no crypto import needed.
+	const (
+		offset32 = 2166136261
+		prime32  = 16777619
+	)
+	h := uint32(offset32)
+	for _, b := range text {
+		h ^= uint32(b)
+		h *= prime32
+	}
+	return fmt.Sprintf("%08x", h)
+}
+
 // ExtractThinking extracts all thinking content from a message.
 func (m *AgentMessage) ExtractThinking() string {
 	var b strings.Builder

--- a/pkg/run/conv.go
+++ b/pkg/run/conv.go
@@ -403,7 +403,13 @@ func parseCompactionEnd(evt map[string]any) *FormattedEvent {
 
 // parseLoopGuard handles loop_guard_triggered events.
 func parseLoopGuard(evt map[string]any) *FormattedEvent {
-	reason, _ := evt["reason"].(string)
+	reason := ""
+	if lg, ok := evt["loopGuard"].(map[string]any); ok {
+		reason, _ = lg["reason"].(string)
+	}
+	if reason == "" {
+		reason, _ = evt["reason"].(string)
+	}
 	if reason == "" {
 		reason = "unknown"
 	}


### PR DESCRIPTION
## Summary

Three fixes for the tool loop guard system, addressing a real incident where the agent was killed while legitimately polling a benchmark log file.

### Fix 1: parseLoopGuard display bug
- **Problem**: parseLoopGuard in pkg/run/conv.go read evt["reason"] but the JSON serializes under evt["loopGuard"]["reason"] -- always showed "unknown"
- **Fix**: Read from evt["loopGuard"]["reason"] first, fallback to evt["reason"]

### Fix 2: Hard abort recovery
- **Problem**: After loop guard hard abort, agent silently terminated -- no chance for LLM to produce a final text response
- **Fix**: Give the LLM one recovery turn via continue. Uses guardAbortRecovery flag to prevent retry loops.

### Fix 3: Polling detection (output-aware guard)
- **Problem**: Guard only checked call signature, not output. Polling with identical args but changing output was falsely killed.
- **Fix**: Track tool output hashes. When output changes, suppress hard abort (still issue soft feedback).

## Test Plan
- go test ./pkg/agent/ -- all pass
- go test ./pkg/run/ -- all pass
- go test ./... -- all pass
- New tests: TestLoopGuardHardAbortRecovery, TestLoopGuardPollingDetection
