### PR TITLE
feat: cache-friendly message architecture

### DIFF
--- a/.pge/tasks/001-define-cache-policy.md
+++ b/.pge/tasks/001-define-cache-policy.md
@@ -1,0 +1,82 @@
+# Task 001: Define CacheMode types and MessageMutationPolicy interface
+
+## Goal
+定义 `pkg/agent/cache_policy.go`，包含 CacheMode 枚举、IsCacheMode 自动检测函数、MessageMutationPolicy 接口及其两个默认实现（cache-first 和 context-first）。
+
+## Files (scope)
+- `pkg/agent/cache_policy.go` — 新建
+- `pkg/agent/cache_policy_test.go` — 新建
+
+## Estimated Size
+M (100-300 lines)
+
+## Dependencies
+None
+
+## Task Details
+
+### 1. CacheMode 类型
+
+```go
+type CacheMode int
+const (
+    CacheModeAuto    CacheMode = iota // auto-detect from model name
+    CacheModeCache                    // cache-first: persist runtime_state
+    CacheModeContext                  // context-first: ephemeral injection (current behavior)
+)
+```
+
+### 2. IsCacheMode 函数
+
+```go
+func IsCacheMode(model string) CacheMode
+```
+
+- model 包含 "deepseek" (case-insensitive) → CacheModeCache
+- 其他 → CacheModeContext
+- 如果传入空字符串 → CacheModeContext
+
+### 3. RuntimeStateStrategy
+
+```go
+type RuntimeStateStrategy int
+const (
+    RuntimeStateEphemeral  RuntimeStateStrategy = iota // context-first: 随用随弃
+    RuntimeStatePersist                                 // cache-first: 持久化追加
+)
+
+type MessageMutationPolicy interface {
+    RuntimeStateStrategy() RuntimeStateStrategy
+    // Phase 1 只需要这一个方法，Phase 2+ 可扩展
+}
+```
+
+### 4. 两个默认实现
+
+```go
+type cacheFirstPolicy struct{}
+type contextFirstPolicy struct{}
+
+func DefaultMutationPolicy(mode CacheMode) MessageMutationPolicy
+```
+
+- CacheModeCache → cacheFirstPolicy{RuntimeStateStrategy: Persist}
+- CacheModeContext / CacheModeAuto (resolve first) → contextFirstPolicy{RuntimeStateStrategy: Ephemeral}
+
+### 5. LoopConfig 增加 CacheMode
+
+在 `pkg/agent/loop.go` 的 `LoopConfig` 中增加：
+```go
+CacheMode CacheMode // default: CacheModeAuto
+```
+
+### 6. 测试
+
+- `TestAutoCacheModeDetection`: 覆盖 "deepseek-chat", "deepseek-reasoner", "glm-4", "", "claude-3"
+- `TestDefaultMutationPolicyCache`: CacheModeCache → RuntimeStateStrategy == Persist
+- `TestDefaultMutationPolicyContext`: CacheModeContext → RuntimeStateStrategy == Ephemeral
+
+## Acceptance
+- `go build ./...` 通过
+- 所有测试通过
+- spec.md AS-3 (Auto 检测) 验证通过

--- a/.pge/tasks/002-cache-first-runtime-persist.md
+++ b/.pge/tasks/002-cache-first-runtime-persist.md
@@ -1,0 +1,92 @@
+# Task 002: Implement cache-first runtime_state persistent append
+
+## Goal
+修改 `streamAssistantResponse` 中的 runtime_state 注入逻辑。当 CacheMode 为 cache 时，runtime_state 作为持久化 AgentMessage 追加到 RecentMessages；当 CacheMode 为 context 时，保持当前行为（临时注入 insertBeforeLastUserMessage）。
+
+## Files (scope)
+- `pkg/agent/llm_stream.go` — 修改 injectRuntimeMeta 使用路径
+- `pkg/agent/llm_stream_test.go` — 新建/追加测试
+
+## Estimated Size
+M (150-300 lines)
+
+## Dependencies
+Task 001 (CacheMode types and MessageMutationPolicy)
+
+## Task Details
+
+### 当前代码路径（llm_stream.go:53-61）
+
+```go
+runtimeAppendix := injectRuntimeMeta(agentCtx, config)
+if runtimeAppendix != "" {
+    runtimeMsg := llm.LLMMessage{
+        Role:    "user",
+        Content: runtimeAppendix,
+    }
+    llmMessages = insertBeforeLastUserMessage(llmMessages, runtimeMsg)
+}
+```
+
+### 新代码路径
+
+```go
+// Resolve cache mode
+mode := config.CacheMode
+if mode == CacheModeAuto {
+    mode = IsCacheMode(config.Model.ID)
+}
+policy := DefaultMutationPolicy(mode)
+
+runtimeAppendix := injectRuntimeMeta(agentCtx, config)
+if runtimeAppendix != "" {
+    switch policy.RuntimeStateStrategy() {
+    case RuntimeStatePersist:
+        // Cache-first: 创建持久化 AgentMessage，追加到 RecentMessages
+        runtimeAgentMsg := agentctx.AgentMessage{
+            Role:    "user",
+            Content: []agentctx.ContentBlock{{Type: "text", Text: runtimeAppendix}},
+            Kind:    "runtime_state",
+        }
+        agentCtx.RecentMessages = append(agentCtx.RecentMessages, runtimeAgentMsg)
+        // 重新从 RecentMessages 构建 LLM messages（包含新的 runtime_state）
+        selectedMessages, _ = selectMessagesForLLM(agentCtx)
+        llmMessages = ConvertMessagesToLLM(ctx, selectedMessages)
+    case RuntimeStateEphemeral:
+        // Context-first: 当前行为不变
+        runtimeMsg := llm.LLMMessage{
+            Role:    "user",
+            Content: runtimeAppendix,
+        }
+        llmMessages = insertBeforeLastUserMessage(llmMessages, runtimeMsg)
+    }
+}
+```
+
+### 关键约束
+
+1. **`Kind: "runtime_state"`** — 用于标识这类消息，compaction 时可识别并清理
+2. **持久化后的 runtime_state 消息通过正常 `ConvertMessagesToLLM` 路径序列化** — 不需要特殊处理
+3. **Session journal 层面** — runtime_state 消息会随 RecentMessages 一起持久化，这是预期行为
+4. **不要修改 `injectRuntimeMeta` 函数本身** — 它只负责计算内容，不负责注入策略
+
+### 测试
+
+1. **TestCacheFirstRuntimeStatePersist**:
+   - 设置 CacheMode=Cache，mock AgentContext
+   - 调用 3 轮 streamAssistantResponse（mock LLM 返回简单回复）
+   - 每轮检查 RecentMessages 中新增 Kind="runtime_state" 消息
+   - 序列化每轮的 []llm.LLMMessage，对前 N-2 条做 bytes.Equal
+
+2. **TestContextFirstRuntimeStateEphemeral**:
+   - 设置 CacheMode=Context
+   - 验证 RecentMessages 中不含 Kind="runtime_state" 消息
+   - 验证临时注入仍然通过 insertBeforeLastUserMessage
+
+3. **TestPrefixConsistency**:
+   - 10 轮对话 cache-first
+   - 每轮的 []llm.LLMMessage 前缀逐轮单调增长且已有部分不变
+
+## Acceptance
+- `go build ./...` 通过
+- spec.md AS-1, AS-2, AS-5 验证通过

--- a/.pge/tasks/003-compaction-clean-runtime.md
+++ b/.pge/tasks/003-compaction-clean-runtime.md
@@ -1,0 +1,57 @@
+# Task 003: Compaction cleans runtime_state messages
+
+## Goal
+在 compaction 流程中，cache-first 模式下清理所有旧的 Kind="runtime_state" 消息，只保留最新一条。Context-first 模式下不需要此行为（因为没有持久化的 runtime_state）。
+
+## Files (scope)
+- `pkg/compact/compact.go` — 修改 compaction 逻辑
+- `pkg/compact/compact_test.go` — 追加测试
+
+## Estimated Size
+S (<100 lines)
+
+## Dependencies
+Task 002 (runtime_state 持久化)
+
+## Task Details
+
+### Compaction 入口
+
+在 compaction 替换消息时，过滤旧的 runtime_state 消息：
+
+```go
+func cleanOldRuntimeState(messages []agentctx.AgentMessage) []agentctx.AgentMessage {
+    // 找到最后一条 runtime_state
+    lastRuntimeIdx := -1
+    for i := len(messages) - 1; i >= 0; i-- {
+        if messages[i].Kind == "runtime_state" {
+            lastRuntimeIdx = i
+            break
+        }
+    }
+
+    // 移除所有 runtime_state，保留最后一条
+    var result []agentctx.AgentMessage
+    for i, msg := range messages {
+        if msg.Kind == "runtime_state" && i != lastRuntimeIdx {
+            continue
+        }
+        result = append(result, msg)
+    }
+    return result
+}
+```
+
+这个函数只在 cache-first 模式下调用。Compaction 本身已经 cache miss，清理旧 runtime_state 不增加额外代价。
+
+### 测试
+
+1. **TestCompactionCleansRuntimeState**:
+   - 构造 5 条 runtime_state + 其他消息
+   - 调用 cleanOldRuntimeState
+   - 断言只剩 1 条 runtime_state（最新的那条）
+   - 断言其他消息不受影响
+
+## Acceptance
+- `go build ./...` 通过
+- spec.md AS-4 验证通过

--- a/.pge/tasks/004-write-l2-tests.md
+++ b/.pge/tasks/004-write-l2-tests.md
@@ -1,0 +1,98 @@
+# Task 004: Write L2 Behavioral Tests
+
+## Context
+Read .pge/spec.md and .pge/state.md for context. 只实现测试代码，不需要写功能代码。确保 `go build ./...` 和 `go test ./pkg/agent/... ./pkg/compact/...` 通过。
+
+## Goal
+Write 5 L2 behavioral test functions as specified in .pge/spec.md acceptance criteria.
+
+## Test Files to Create
+
+### 1. `pkg/agent/cache_policy_test.go` — Tests AS-3
+
+**TestAutoCacheModeDetection**:
+- `IsCacheMode("deepseek-chat")` → `CacheModeCache`
+- `IsCacheMode("DeepSeek-Reasoner")` → `CacheModeCache` (case-insensitive)
+- `IsCacheMode("glm-4")` → `CacheModeContext`
+- `IsCacheMode("")` → `CacheModeContext`
+- `IsCacheMode("claude-3-opus")` → `CacheModeContext`
+
+**TestResolveCacheMode**:
+- `ResolveCacheMode(CacheModeAuto, "deepseek-chat")` → `CacheModeCache`
+- `ResolveCacheMode(CacheModeAuto, "glm-4")` → `CacheModeContext`
+- `ResolveCacheMode(CacheModeCache, "glm-4")` → `CacheModeCache` (explicit override)
+- `ResolveCacheMode(CacheModeContext, "deepseek-chat")` → `CacheModeContext` (explicit override)
+
+**TestDefaultMutationPolicy**:
+- `DefaultMutationPolicy(CacheModeCache).RuntimeStateStrategy()` → `RuntimeStatePersist`
+- `DefaultMutationPolicy(CacheModeContext).RuntimeStateStrategy()` → `RuntimeStateEphemeral`
+- `DefaultMutationPolicy(CacheModeAuto).RuntimeStateStrategy()` → `RuntimeStateEphemeral` (fallback)
+
+### 2. `pkg/agent/llm_stream_test.go` — Tests AS-1, AS-2, AS-5
+
+These tests verify the runtime_state injection behavior in `streamAssistantResponse`. However, `streamAssistantResponse` requires many dependencies (LLM stream, event stream, etc.) that make direct testing difficult. Instead, test the **observable effects** by testing the isolated logic:
+
+**Approach**: Test the runtime_state injection logic at the unit level by replicating the decision logic. The key code paths are:
+
+For AS-1 and AS-2, the core logic to test is:
+```go
+// In streamAssistantResponse, when runtimeAppendix != "":
+if policy.RuntimeStateStrategy() == RuntimeStatePersist {
+    // AS-1: append AgentMessage{Kind:"runtime_state"} to RecentMessages, rebuild llmMessages
+} else {
+    // AS-2: ephemeral insertBeforeLastUserMessage, NO change to RecentMessages
+}
+```
+
+Since `streamAssistantResponse` is a private function that requires a full LLM setup, write tests that verify:
+
+**TestCacheFirstRuntimeStatePersist** (AS-1):
+- Create an `AgentContext` with some existing `RecentMessages`
+- Simulate the cache-first path: create `AgentMessage{Role:"user", Metadata: &MessageMetadata{Kind:"runtime_state"}, Content: ...}` and append to `RecentMessages`
+- Verify: `RecentMessages` has the new message appended (length increased by 1)
+- Verify: The appended message has `Metadata.Kind == "runtime_state"`
+- Verify: After 3 simulated "turns" (3 appends), all 3 runtime_state messages are in RecentMessages
+- Verify: Serializing the messages to `[]llm.LLMMessage` via `selectMessagesForLLM` + `ConvertMessagesToLLM`, the prefix before each turn's new messages is stable (bytes.Equal)
+
+**TestContextFirstRuntimeStateEphemeral** (AS-2):
+- Create an `AgentContext` with some existing `RecentMessages`
+- Call `insertBeforeLastUserMessage` with a runtime message (context-first path)
+- Verify: `RecentMessages` is UNCHANGED (no new persistent message)
+- Verify: The returned `[]llm.LLMMessage` has the runtime message inserted before the last user message
+
+**TestPrefixConsistency** (AS-5):
+- Simulate 10 turns of cache-first mode
+- Each turn: append user message → append runtime_state message → append assistant message
+- After each turn, call `selectMessagesForLLM` + `ConvertMessagesToLLM`
+- Verify: Turn N's messages[:len(Turn(N-1))] equals Turn N-1's full messages (prefix is stable)
+- Verify: Each turn's message count strictly increases (monotonic growth)
+
+### 3. `pkg/compact/compact_test.go` or `pkg/compact/clean_runtime_state_test.go` — Test AS-4
+
+**TestCompactionCleansRuntimeState** (AS-4):
+- Test `cleanOldRuntimeState` directly (it's a package-level function)
+- Case 1: No runtime_state messages → unchanged
+- Case 2: 1 runtime_state → kept
+- Case 3: 3 runtime_state → only last kept
+- Case 4: Interleaved runtime_state and user messages → only runtime_state cleaned, others preserved
+- Case 5: All messages are runtime_state → only last kept
+- Case 6: Empty slice → empty result
+- Case 7: Messages with nil Metadata → not affected
+
+## Key Types/Functions Reference
+- `agentctx.AgentMessage` — has `Role string`, `Content []ContentBlock`, `Metadata *MessageMetadata`, `Timestamp int64`
+- `agentctx.MessageMetadata` — has `Kind string`
+- `agentctx.NewUserMessage(text string) AgentMessage`
+- `agentctx.NewAssistantMessage() AgentMessage`
+- `agentctx.TextContent{Type: "text", Text: "..."}`
+- `selectMessagesForLLM(agentCtx) ([]AgentMessage, string)` — returns `agentCtx.RecentMessages`
+- `ConvertMessagesToLLM(ctx, messages) []llm.LLMMessage` — converts to LLM format
+- `insertBeforeLastUserMessage(messages []llm.LLMMessage, msg llm.LLMMessage) []llm.LLMMessage`
+- `cleanOldRuntimeState(messages []agentctx.AgentMessage) []agentctx.AgentMessage` — in pkg/compact
+- `llm.LLMMessage` — has `Role string`, `Content string`
+
+## Constraints
+- Use only `testing` and `github.com/stretchr/testify/assert` for assertions
+- Do NOT modify any non-test source files
+- All tests must pass: `go test ./pkg/agent/... ./pkg/compact/... -v`
+- Build must pass: `go build ./...`

--- a/docs/design/cache-friendly-message-architecture.md
+++ b/docs/design/cache-friendly-message-architecture.md
@@ -1,0 +1,441 @@
+# Design: Cache-Friendly Message Architecture
+
+## Problem
+
+当前 ai agent 使用 DeepSeek 等 prefix-caching provider 时，缓存命中率接近 **0%**。
+
+### Cache Hit 的数学模型
+
+LLM prefix cache 要求每次请求的**字节前缀完全一致**。匹配从第一条消息开始，逐 token 向后。一旦遇到不一致，该点之后全部 cache miss。
+
+```
+请求 = [System Prompt] [msg₁] [msg₂] ... [msgₙ]
+                 ↑                    ↑
+           一定命中              从此处开始可能断裂
+```
+
+DeepSeek v4-flash 价格差：
+- 命中缓存：$0.004/百万 token
+- 未命中：$0.14/百万 token（**35 倍**）
+
+### 为什么当前命中率为 0%
+
+`runtime_state` 消息每轮重新计算，注入到 `[]llm.LLMMessage` 的**临时副本**上，不持久化到 session journal。下一轮完全重建：
+
+```
+Turn 1 API: [system][runtime₁][user₁]
+Turn 2 API: [system][user₁][asst₁][runtime₂][user₂]   ← runtime₁ 消失了
+Turn 3 API: [system][user₁][asst₁][user₂][asst₂][runtime₃][user₃]  ← runtime₂ 也消失了
+```
+
+`runtime₁` 不是「变了」，而是**消失了**。下一轮的前缀从 `user₁` 开始就跟上一轮不同，导致系统提示词之后立刻断裂。
+
+### 排除的伪问题
+
+经过 brainstorm 确认，以下问题**不存在**或**不值得优化**：
+
+| 原判定 | 实际情况 |
+|--------|---------|
+| ~~消息时间戳~~ | `time.Now().UnixMilli()` 写入 `AgentMessage.Timestamp`，但 `ConvertMessagesToLLM()` 转成 `LLMMessage` 时 timestamp 不参与 API 序列化。**非问题。** |
+| ~~Tool Call ID~~ | ID 首次生成后写入 Content blocks，持久化到 session journal，后续轮次读取存储值不重新生成。**非问题。** |
+| ~~Session Resume~~ | 跨 session 的 cache 在 provider 端早已冷掉，优化无意义。**过度优化。** |
+| ~~异常路径消息~~ | Malformed recovery 和 loop guard 消息已持久化到 RecentMessages，下一轮作为历史带上。**已正确。** |
+
+### 真正的核心矛盾
+
+**缓存优先 vs 上下文优先**是结构性对立：
+
+| 缓存优先 | 上下文优先 |
+|---------|-----------|
+| 所有消息追加、永不修改、永不删除 | truncate 冗余 tool output |
+| runtime_state 持久化保留 | compact 摘要替换旧消息 |
+| 前缀稳定 → 命中 → 省钱 | 上下文精简 → 任务质量高 |
+
+两者不是调参数能调和的。解决方案是**双模式配置 + 实验验证**。
+
+---
+
+## Design
+
+### 核心原则
+
+> **一旦消息发送给 LLM，就固化下来，后续不修改、不删除、不移位。**
+
+违反此原则就会破坏前缀缓存。但上下文管理（truncate、compact）本质上就是要修改/删除历史消息。所以两种模式分开：
+
+### 双模式
+
+```
+Cache-First Mode (DeepSeek 等 prefix-caching provider):
+  - runtime_state 持久化追加到 RecentMessages
+  - 不主动 truncate tool output（除非超大影响 token 预算）
+  - compaction 只在必要时触发，接受 cache miss
+  - compaction 时顺便清理旧的 runtime_state（反正已经 miss 了）
+
+Context-First Mode (GLM coding plan 等固定费用 provider):
+  - runtime_state 随用随弃（当前行为）
+  - truncate / llm_context_update / compact 积极执行
+  - 上下文精简优先
+```
+
+### 自动检测
+
+基于 `--model` 参数自动选择模式：
+- DeepSeek 模型 → cache-first
+- 其他 → context-first（默认，兼容当前行为）
+- 用户可通过配置覆盖
+
+---
+
+### 核心改动：Runtime State 持久化（Cache-First Mode）
+
+**当前行为**（context-first）：
+```
+injectRuntimeMeta() 计算 runtime_state
+  → 注入到 []llm.LLMMessage 临时副本
+  → insertBeforeLastUserMessage()
+  → 不持久化，下一轮丢弃
+```
+
+**新行为**（cache-first）：
+```
+injectRuntimeMeta() 计算 runtime_state
+  → 创建 AgentMessage{Role: "user", Kind: "runtime_state", Visibility: agent-only}
+  → 追加到 agentCtx.RecentMessages（持久化）
+  → 下一轮作为历史消息带上，位置不变
+```
+
+消息流：
+```
+Turn 1: RecentMessages = [..., runtime_msg₁, user₁]
+        API: [system][...][runtime_msg₁][user₁]
+        LLM 回复 → asst₁
+
+Turn 2: RecentMessages = [..., runtime_msg₁, user₁, asst₁, runtime_msg₂, user₂]
+        API: [system][...][runtime_msg₁][user₁][asst₁][runtime_msg₂][user₂]
+        前缀: [system][...][runtime_msg₁][user₁][asst₁] ✅ 完全一致
+```
+
+#### 关键设计决策
+
+**消息 Role**：`user`，与当前一致。因为：
+- 在 user message 之前，LLM 自然聚焦最后的 user message
+- 不是独立消息在末尾，不存在「LLM 以为要回复」的问题
+
+**消息 Visibility**：`agent-visible, user-hidden`。用户在 TUI 不需要看到重复的 runtime_state。
+
+**CWD 传递**：workspace/cwd 信息通过 runtime_state 传递，这是唯一来源（system prompt 中故意不硬编码 cwd）。持久化不影响 CWD 变更场景 — 新的 cwd 写入新的 runtime_msg，旧的不变。
+
+**Compaction 交互**：compaction 时可以清理所有旧的 runtime_msg（反正 compaction 已经 cache miss 了）。只保留最新的 runtime_msg 作为 compaction 后的起始状态。
+
+#### Token 开销
+
+每条 runtime_msg ~200-400 tokens。10 轮后多 ~3000 tokens。
+相比缓存命中的节省（35 倍价差），这是值得的。
+
+---
+
+### 不需要改动的部分
+
+以下行为经验证已对缓存友好，不需要修改：
+
+| 行为 | 原因 |
+|------|------|
+| Tool definitions | 静态注册，session 内不变 |
+| System prompt 模板 | session 内稳定 |
+| Skill index | 进程启动后固定，不变化 |
+| Tag parser (XML tool call) | 原地修改 assistant 消息，不追加 |
+| Tool output truncation | 原地修改，不追加 |
+| Malformed tool call recovery | 追加并持久化到 RecentMessages ✅ |
+| Loop guard feedback | 追加并持久化到 RecentMessages ✅ |
+
+---
+
+## Known Limitations: Context Management vs Cache
+
+当前 context management 架构（见 `docs/context-management.md`）的核心设计是 **LLM 驱动的上下文管理** — 系统决定时机，LLM 决定策略。LLM 通过 4 个工具操作历史消息：
+
+| 工具 | 操作 | 缓存影响 |
+|------|------|---------|
+| `truncate_messages` | 删除中间消息 | 从删除点开始前缀断裂 |
+| `update_llm_context` | 修改 LLMContext 内容 | 持久化的 runtime_msg 中 `<llm_context>` 块字节变化 |
+| `compact` | 替换全部消息为 summary | 前缀完全归零 |
+| `no_action` | 不动 | ✅ 唯一缓存友好 |
+
+三个工具都是破坏性的 — 不是内容微调，而是消息数组结构本身被改变。
+
+### 自加速问题
+
+Cache-first 模式下存在正反馈循环：
+
+```
+runtime_state 持久化 → token 消耗更快
+→ 更快触发 20%/33%/50% 阈值
+→ 更频繁触发 context management cycle
+→ LLM 更频繁调用 truncate/compact
+→ 更频繁破坏缓存
+→ 缓存命中率反而下降
+```
+
+### 当前处理方式
+
+本设计**不修改 context management 架构**：
+
+1. **Cache-first 模式下**：接受 context management 带来的 cache miss。Compaction 和 truncate 是低频事件，每次发生接受一次 miss，之后前缀重新建立。
+2. **Context-first 模式下**：行为完全不变。
+
+### 待未来演化的问题
+
+以下问题不在本次 scope 内，但接口设计必须保留演化能力：
+
+#### 问题 1：`update_llm_context` 与 runtime_msg 稳定性矛盾
+
+`<llm_context>` 内容由 LLM 维护，每次 update 后写入新的 runtime_msg。旧 runtime_msg 中的 `<llm_context>` 与新 runtime_msg 中的不同 — 两条消息的字节不同，这是正确的（前缀稳定）。但如果 update 只修改旧 runtime_msg 而不追加新的，就会破坏已有前缀。
+
+**演化方向**：`llm_context` 作为独立的消息类型，而非嵌入 runtime_msg。或者 `llm_context` 只追加不修改。
+
+#### 问题 2：`truncate_messages` 与前缀单调增长矛盾
+
+删除中间消息 = 前缀从删除点断裂。cache-first 理想下不应删除任何已发送的消息。
+
+**演化方向**：用「软删除」（visibility 标记）替代真删除。`IsAgentVisible()` 已有过滤机制，可复用。
+
+#### 问题 3：Compact 与前缀完全归零
+
+Compact 替换全部历史为 summary，是最激进的上下文管理操作。
+
+**演化方向**：改为 Reasonix 式的「尾部替换」— 只替换 Region 2 的后半部分，保留前半部分不动。
+
+#### 问题 4：Context management 触发频率
+
+持久化 runtime_state 增加每轮 token 消耗，可能加速触发阈值。
+
+**演化方向**：cache-first 模式下，阈值计算排除 runtime_state 消息的 token。
+
+---
+
+## Interface Design for Evolvability
+
+### MessageMutationPolicy
+
+所有消息变更操作通过统一接口，Cache policy 可以拦截或调整：
+
+```go
+// MessageMutationPolicy — 消息变更策略接口
+// 不同 cache mode 提供不同实现
+type MessageMutationPolicy interface {
+    // 是否允许删除指定消息
+    CanTruncate(messages []AgentMessage, indices []int) (allowed []int, denied []int)
+    // 是否允许修改指定消息
+    CanModify(messages []AgentMessage, index int) bool
+    // 是否允许 compact（替换全部消息）
+    CanCompact(messages []AgentMessage) CompactDecision
+    // Runtime state 注入方式
+    RuntimeStateStrategy() RuntimeStateStrategy
+}
+
+type RuntimeStateStrategy int
+const (
+    RuntimeStateEphemeral  RuntimeStateStrategy = iota // 随用随弃（context-first）
+    RuntimeStatePersist                                  // 持久化追加（cache-first）
+)
+
+type CompactDecision int
+const (
+    CompactAllow    CompactDecision = iota // 允许
+    CompactDefer                           // 延迟到更紧急时
+    CompactDeny                            // 拒绝，改用其他策略
+)
+```
+
+**当前 Phase 1 实现**：
+- Context-first policy：`CanTruncate` 全部允许，`RuntimeStateStrategy()` 返回 `Ephemeral`
+- Cache-first policy：`CanTruncate` 全部允许但记录影响，`RuntimeStateStrategy()` 返回 `Persist`
+
+**未来演化**：
+- Cache-first policy 可以演进为：`CanTruncate` 返回 denied，建议软删除
+- `CanCompact` 可以返回 `CompactDefer`，推迟 compaction
+- 不需要修改 context management 核心逻辑，只换 policy 实现
+
+### Context Management Tool Availability
+
+Context management 工具通过 `ToolRegistry` 注册，cache policy 可以调整哪些工具可用：
+
+```go
+// cache-first 模式下可以：
+registry.Disable("truncate_messages")
+// 或保持启用但通过 MutationPolicy 拦截
+```
+
+未来实验可以测试「禁用 truncate 对 cache hit rate 和任务通过率的影响」。
+
+### 配置驱动的行为选择
+
+```yaml
+cache:
+  mode: auto  # auto | cache | context
+
+  # Phase 1: 只控制 runtime_state
+  persist_runtime_state: true
+
+  # Phase 2+: 控制 context management 行为（预留，当前不实现）
+  # context_management:
+  #   allow_truncate: true        # false = truncate 工具不可用
+  #   allow_compact: true         # false = compact 工具不可用
+  #   soft_delete: false          # true = 用 visibility 替代真删除
+  #   compact_threshold_modifier: 1.0  # >1.0 = 提高 compact 触发阈值
+```
+
+Phase 2+ 的配置项预留但不实现，避免过度设计。等 evolve 实验证明需要时再逐个打开。
+
+---
+
+## 实验验证框架
+
+### 指标
+
+| 指标 | 数据来源 | 说明 |
+|------|---------|------|
+| **Cache hit rate** | API response `usage.cache_read_input_tokens / usage.prompt_tokens` | 核心目标 |
+| **Cost per task** | `usage.total_tokens × pricing` | 省钱效果 |
+| **Task pass rate** | Benchmark 结果 | 上下文质量是否退化 |
+| **Agentic score** | Benchmark 评分 | 细粒度质量 |
+
+### Evolve 集成
+
+`evolve-config.yaml` 增加：
+```yaml
+evolve:
+  axes:
+    - name: cache_mode
+      values: ["cache", "context"]
+    - name: runtime_state_content
+      values: ["full", "minimal"]
+    - name: clean_runtime_on_compact
+      values: [true, false]
+```
+
+Evolve planner 可探索配置组合，观察：
+1. cache 模式下任务通过率是否退化
+2. 是否存在「缓存友好且上下文更好」的配置组合（理想情况）
+3. 退化幅度 vs 节省金额的 trade-off
+
+### 对比矩阵
+
+| 实验 | 模型 | 模式 | 预期 |
+|------|------|------|------|
+| Baseline | GLM | context | 当前行为基准 |
+| Cache baseline | DeepSeek | context | 验证当前 DeepSeek 下的 0% 命中率 |
+| Cache optimized | DeepSeek | cache | 验证缓存命中率提升 |
+| Cross-check | GLM | cache | 验证 GLM 下缓存模式不退化 |
+| Cross-check | DeepSeek | context | 对比 cache 模式的收益 |
+
+---
+
+## Acceptance Scenarios
+
+### AS-1: Cache-first 模式下 runtime_state 持久化
+
+**Given** `cache.mode: cache` 且使用 DeepSeek 模型
+**When** 执行 3 轮对话
+**Then**:
+- 第 2 轮 API 请求中，前缀 `[system][runtime_msg₁][user₁][asst₁]` 与第 1 轮 API 请求中对应部分**字节一致**
+- 第 3 轮 API 请求中，前缀包含第 1-2 轮的所有历史消息，且**字节一致**
+- `RecentMessages` 中包含 `Kind: "runtime_state"` 的持久化消息
+
+**验证方法**：
+- 单元测试：mock `AgentContext`，执行 3 轮 `streamAssistantResponse`，序列化每轮的 `[]llm.LLMMessage`，对前 N-2 条消息做 `bytes.Equal`
+- 集成测试：使用 mock provider 记录每次请求，断言前缀一致性
+
+### AS-2: Context-first 模式下行为不变
+
+**Given** `cache.mode: context`（或 auto + 非 DeepSeek 模型）
+**When** 执行任意对话
+**Then**: 行为与当前完全一致 — runtime_state 不持久化，`insertBeforeLastUserMessage`
+
+**验证方法**：
+- 单元测试：断言 context 模式下 `RecentMessages` 中不包含 `Kind: "runtime_state"` 的消息
+- Evolve benchmark：运行现有 baseline 任务，通过率不低于当前 baseline
+
+### AS-3: Auto 模式正确检测
+
+**Given** `cache.mode: auto`
+**When** model 为 "deepseek-chat" / "deepseek-reasoner" 等
+**Then**: 自动选择 cache 模式
+**When** model 为 "glm-4" 或其他
+**Then**: 自动选择 context 模式
+
+**验证方法**：单元测试，覆盖各种 model 名称
+
+### AS-4: Compaction 清理 runtime_state
+
+**Given** cache 模式，RecentMessages 中有 5 条 runtime_state 消息
+**When** compaction 触发
+**Then**: 旧的 runtime_state 消息被清理，只保留最新一条（或全部清理，compaction summary 中包含 cwd）
+
+**验证方法**：单元测试，检查 compaction 后 RecentMessages 中的 runtime_state 数量
+
+### AS-5: 缓存命中率可量化
+
+**Given** cache 模式 + DeepSeek 模型
+**When** 运行 10 轮对话
+**Then**: 从 API response `usage` 中可提取 `cache_read_input_tokens`，缓存命中率 > 50%
+
+**验证方法**：
+- Mock provider 在 response 中返回 `usage.cache_read_input_tokens` 字段
+- Agent 统计模块记录每轮的 cache hit/miss，计算累计命中率
+- 输出到 benchmark result JSON
+
+### AS-6: 不引入 regression
+
+**Given** 任何 cache.mode 设置
+**When** 运行 evolve benchmark 全部任务
+**Then**: 通过率不低于当前 baseline
+
+**验证方法**：
+- `make evolve-run` 对比 baseline
+- 新增 cache 相关 axis 到 evolve config
+
+---
+
+## Implementation Order
+
+```
+Phase 1: 核心改动
+  ├── 定义 cache mode 配置（auto/cache/context）
+  ├── 定义 MessageMutationPolicy 接口（最小实现：只控制 runtime_state）
+  ├── 实现 auto 检测逻辑（model name matching）
+  ├── Cache 模式：runtime_state 持久化追加
+  ├── Context 模式：保持当前行为
+  └── 确保两种模式通过同一代码路径，只是分支不同
+
+Phase 2: 测试
+  ├── AS-1 ~ AS-4 单元测试
+  ├── AS-5 集成测试（mock provider + cache 统计）
+  └── AS-6 evolve baseline 对比
+
+Phase 3: 可观测性
+  ├── 从 API response 提取 cache 统计到 benchmark result
+  ├── TUI 展示缓存命中率（cache 模式下）
+  └── Evolve 集成
+
+Phase 4: 实验驱动优化（后续迭代）
+  ├── runtime_state 内容精简（minimal mode）
+  ├── compaction 时 runtime_state 清理策略
+  ├── MessageMutationPolicy 完整实现（truncate 拦截、soft delete 等）
+  ├── 多配置组合的 evolve 实验
+  └── 探索是否存在 cache + context 兼得的方案
+```
+
+---
+
+## Risks
+
+| 风险 | 缓解 |
+|------|------|
+| Cache 模式下上下文冗余影响任务质量 | Evolve baseline 对比；如有退化可调参数 |
+| runtime_state 持久化增加 token 消耗 | 约每轮 +300 tokens，但缓存节省远大于此 |
+| CWD 变更场景下旧 runtime_state 中的 cwd 过时 | LLM 以最新 runtime_state 为准；compaction 时清理 |
+| 双模式增加代码复杂度 | 共享代码路径，只分支持久化逻辑；默认 context 模式不改变任何行为 |
+| Cache 模式下 truncate/compact 与缓存矛盾 | 已知限制，见 Known Limitations 章节；通过 MessageMutationPolicy 接口保留未来演化能力 |
+| 自加速问题（持久化加速触发阈值） | 已知限制，Phase 4 可通过阈值调整解决 |

--- a/pkg/agent/cache_policy.go
+++ b/pkg/agent/cache_policy.go
@@ -1,0 +1,78 @@
+package agent
+
+import "strings"
+
+// CacheMode determines how runtime_state telemetry is handled in messages.
+type CacheMode int
+
+const (
+	// CacheModeAuto auto-detects the mode from the model name.
+	CacheModeAuto CacheMode = iota
+	// CacheModeCache uses cache-first strategy: persist runtime_state in RecentMessages
+	// for higher prefix cache hit rates (e.g. DeepSeek).
+	CacheModeCache
+	// CacheModeContext uses context-first strategy: ephemeral injection, current behavior.
+	CacheModeContext
+)
+
+// RuntimeStateStrategy controls how runtime_state messages are managed.
+type RuntimeStateStrategy int
+
+const (
+	// RuntimeStateEphemeral injects runtime_state temporarily per turn (context-first).
+	RuntimeStateEphemeral RuntimeStateStrategy = iota
+	// RuntimeStatePersist appends runtime_state as a persistent message (cache-first).
+	RuntimeStatePersist
+)
+
+// MessageMutationPolicy defines how messages are mutated for a given cache strategy.
+// Phase 1 minimal interface — more methods may be added in Phase 2+.
+type MessageMutationPolicy interface {
+	// RuntimeStateStrategy returns whether runtime_state is ephemeral or persistent.
+	RuntimeStateStrategy() RuntimeStateStrategy
+}
+
+// cacheFirstPolicy implements MessageMutationPolicy for cache-first models.
+type cacheFirstPolicy struct{}
+
+func (cacheFirstPolicy) RuntimeStateStrategy() RuntimeStateStrategy {
+	return RuntimeStatePersist
+}
+
+// contextFirstPolicy implements MessageMutationPolicy for context-first models.
+type contextFirstPolicy struct{}
+
+func (contextFirstPolicy) RuntimeStateStrategy() RuntimeStateStrategy {
+	return RuntimeStateEphemeral
+}
+
+// DefaultMutationPolicy returns the appropriate MessageMutationPolicy for the given CacheMode.
+// CacheModeAuto should be resolved via IsCacheMode before calling this function.
+func DefaultMutationPolicy(mode CacheMode) MessageMutationPolicy {
+	switch mode {
+	case CacheModeCache:
+		return cacheFirstPolicy{}
+	default:
+		// CacheModeContext and CacheModeAuto (fallback) both use ephemeral.
+		return contextFirstPolicy{}
+	}
+}
+
+// IsCacheMode detects the appropriate CacheMode from a model name.
+//   - model contains "deepseek" (case-insensitive) → CacheModeCache
+//   - empty or anything else → CacheModeContext
+func IsCacheMode(model string) CacheMode {
+	if strings.Contains(strings.ToLower(model), "deepseek") {
+		return CacheModeCache
+	}
+	return CacheModeContext
+}
+
+// ResolveCacheMode returns the effective CacheMode, resolving Auto to a concrete mode
+// using the provided model name.
+func ResolveCacheMode(mode CacheMode, model string) CacheMode {
+	if mode == CacheModeAuto {
+		return IsCacheMode(model)
+	}
+	return mode
+}

--- a/pkg/agent/cache_policy_test.go
+++ b/pkg/agent/cache_policy_test.go
@@ -96,9 +96,9 @@ func TestResolveCacheMode(t *testing.T) {
 // RuntimeStateStrategy for each CacheMode.
 func TestDefaultMutationPolicy(t *testing.T) {
 	tests := []struct {
-		name              string
-		mode              CacheMode
-		expectedStrategy  RuntimeStateStrategy
+		name             string
+		mode             CacheMode
+		expectedStrategy RuntimeStateStrategy
 	}{
 		{
 			name:             "CacheModeCache returns RuntimeStatePersist",

--- a/pkg/agent/cache_policy_test.go
+++ b/pkg/agent/cache_policy_test.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAutoCacheModeDetection verifies AS-3: IsCacheMode auto-detects the appropriate
+// CacheMode from a model name.
+func TestAutoCacheModeDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		expected CacheMode
+	}{
+		{
+			name:     "deepseek-chat returns CacheModeCache",
+			model:    "deepseek-chat",
+			expected: CacheModeCache,
+		},
+		{
+			name:     "DeepSeek-Reasoner case-insensitive returns CacheModeCache",
+			model:    "DeepSeek-Reasoner",
+			expected: CacheModeCache,
+		},
+		{
+			name:     "glm-4 returns CacheModeContext",
+			model:    "glm-4",
+			expected: CacheModeContext,
+		},
+		{
+			name:     "empty string returns CacheModeContext",
+			model:    "",
+			expected: CacheModeContext,
+		},
+		{
+			name:     "claude-3-opus returns CacheModeContext",
+			model:    "claude-3-opus",
+			expected: CacheModeContext,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsCacheMode(tc.model)
+			assert.Equal(t, tc.expected, result, "IsCacheMode(%q)", tc.model)
+		})
+	}
+}
+
+// TestResolveCacheMode verifies that ResolveCacheMode correctly resolves Auto
+// to a concrete mode while preserving explicit overrides.
+func TestResolveCacheMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     CacheMode
+		model    string
+		expected CacheMode
+	}{
+		{
+			name:     "Auto with deepseek resolves to Cache",
+			mode:     CacheModeAuto,
+			model:    "deepseek-chat",
+			expected: CacheModeCache,
+		},
+		{
+			name:     "Auto with glm-4 resolves to Context",
+			mode:     CacheModeAuto,
+			model:    "glm-4",
+			expected: CacheModeContext,
+		},
+		{
+			name:     "Explicit Cache overrides model detection",
+			mode:     CacheModeCache,
+			model:    "glm-4",
+			expected: CacheModeCache,
+		},
+		{
+			name:     "Explicit Context overrides model detection",
+			mode:     CacheModeContext,
+			model:    "deepseek-chat",
+			expected: CacheModeContext,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ResolveCacheMode(tc.mode, tc.model)
+			assert.Equal(t, tc.expected, result, "ResolveCacheMode(%v, %q)", tc.mode, tc.model)
+		})
+	}
+}
+
+// TestDefaultMutationPolicy verifies that DefaultMutationPolicy returns the correct
+// RuntimeStateStrategy for each CacheMode.
+func TestDefaultMutationPolicy(t *testing.T) {
+	tests := []struct {
+		name              string
+		mode              CacheMode
+		expectedStrategy  RuntimeStateStrategy
+	}{
+		{
+			name:             "CacheModeCache returns RuntimeStatePersist",
+			mode:             CacheModeCache,
+			expectedStrategy: RuntimeStatePersist,
+		},
+		{
+			name:             "CacheModeContext returns RuntimeStateEphemeral",
+			mode:             CacheModeContext,
+			expectedStrategy: RuntimeStateEphemeral,
+		},
+		{
+			name:             "CacheModeAuto fallback returns RuntimeStateEphemeral",
+			mode:             CacheModeAuto,
+			expectedStrategy: RuntimeStateEphemeral,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := DefaultMutationPolicy(tc.mode)
+			assert.NotNil(t, policy, "DefaultMutationPolicy(%v) returned nil", tc.mode)
+			assert.Equal(t, tc.expectedStrategy, policy.RuntimeStateStrategy(),
+				"DefaultMutationPolicy(%v).RuntimeStateStrategy()", tc.mode)
+		})
+	}
+}

--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -56,7 +56,7 @@ func streamAssistantResponse(
 		cacheMode := ResolveCacheMode(config.CacheMode, model.ID)
 		policy := DefaultMutationPolicy(cacheMode)
 
-				switch policy.RuntimeStateStrategy() {
+		switch policy.RuntimeStateStrategy() {
 		case RuntimeStatePersist:
 			// Cache-first: create a persistent AgentMessage and append to RecentMessages,
 			// then rebuild LLM messages so the new runtime_state is included.

--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -44,21 +44,40 @@ func streamAssistantResponse(
 		}
 	}
 
-	// Build runtime appendix (llm context + context meta) as a user message
-	// injected BEFORE the last user message for better LLM attention.
-	// Placing runtime_state close to the decision point improves context management.
-	//
-	// LLMContext content is always injected when non-empty.
-	// runtime_state telemetry is ALWAYS injected from turn 1 so path info is available immediately.
-	runtimeAppendix := injectRuntimeMeta(agentCtx, config)
+	// Resolve model early — needed for cache mode detection before runtime_state injection.
+	model := getEffectiveModel(config)
 
-	// Insert runtime_state before the last user message for better attention.
+	// Resolve cache mode and determine runtime_state injection strategy.
+	// Cache-first (e.g. DeepSeek): persist runtime_state as AgentMessage in RecentMessages
+	//   for higher prefix cache hit rates across turns.
+	// Context-first (default): ephemeral injection before last user message, current behavior.
+	runtimeAppendix := injectRuntimeMeta(agentCtx, config)
 	if runtimeAppendix != "" {
-		runtimeMsg := llm.LLMMessage{
-			Role:    "user",
-			Content: runtimeAppendix,
+		cacheMode := ResolveCacheMode(config.CacheMode, model.ID)
+		policy := DefaultMutationPolicy(cacheMode)
+
+		switch policy.RuntimeStateStrategy() {
+		case RuntimeStatePersist:
+			// Cache-first: create a persistent AgentMessage and append to RecentMessages,
+			// then rebuild LLM messages so the new runtime_state is included.
+			runtimeAgentMsg := agentctx.AgentMessage{
+				Role:      "user",
+				Content:   []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: runtimeAppendix}},
+				Timestamp: time.Now().UnixMilli(),
+				Metadata:  &agentctx.MessageMetadata{Kind: "runtime_state"},
+			}
+			agentCtx.RecentMessages = append(agentCtx.RecentMessages, runtimeAgentMsg)
+			selectedMessages, _ = selectMessagesForLLM(agentCtx)
+			llmMessages = ConvertMessagesToLLM(ctx, selectedMessages)
+
+		case RuntimeStateEphemeral:
+			// Context-first: current behavior unchanged — temporary injection.
+			runtimeMsg := llm.LLMMessage{
+				Role:    "user",
+				Content: runtimeAppendix,
+			}
+			llmMessages = insertBeforeLastUserMessage(llmMessages, runtimeMsg)
 		}
-		llmMessages = insertBeforeLastUserMessage(llmMessages, runtimeMsg)
 	}
 
 	// Convert tools to LLM format
@@ -73,7 +92,6 @@ func streamAssistantResponse(
 
 	// Stream LLM response
 	llmStart := time.Now()
-	model := getEffectiveModel(config)
 	llmSpan := traceevent.StartSpan(ctx, "llm_call", traceevent.CategoryLLM,
 		traceevent.Field{Key: "model", Value: model.ID},
 		traceevent.Field{Key: "provider", Value: model.Provider},

--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -56,10 +56,12 @@ func streamAssistantResponse(
 		cacheMode := ResolveCacheMode(config.CacheMode, model.ID)
 		policy := DefaultMutationPolicy(cacheMode)
 
-		switch policy.RuntimeStateStrategy() {
+				switch policy.RuntimeStateStrategy() {
 		case RuntimeStatePersist:
 			// Cache-first: create a persistent AgentMessage and append to RecentMessages,
 			// then rebuild LLM messages so the new runtime_state is included.
+			// Remove any stale runtime_state left by a previous retry attempt of this turn.
+			agentCtx.RecentMessages = removeRuntimeStateMessages(agentCtx.RecentMessages)
 			runtimeAgentMsg := agentctx.AgentMessage{
 				Role:      "user",
 				Content:   []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: runtimeAppendix}},
@@ -408,6 +410,20 @@ compact_decision_signals:
 	agentCtx.AgentState.RuntimeMetaTurns = 0
 
 	return snapshot, true
+}
+
+// removeRuntimeStateMessages removes all runtime_state messages from the slice.
+// This prevents duplicate runtime_state messages from accumulating when
+// streamAssistantResponse is retried (each retry appends a fresh one).
+func removeRuntimeStateMessages(msgs []agentctx.AgentMessage) []agentctx.AgentMessage {
+	filtered := msgs[:0]
+	for _, msg := range msgs {
+		if msg.Metadata != nil && msg.Metadata.Kind == "runtime_state" {
+			continue
+		}
+		filtered = append(filtered, msg)
+	}
+	return filtered
 }
 
 func insertBeforeLastUserMessage(messages []llm.LLMMessage, msg llm.LLMMessage) []llm.LLMMessage {

--- a/pkg/agent/llm_stream_test.go
+++ b/pkg/agent/llm_stream_test.go
@@ -1,0 +1,223 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/llm"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCacheFirstRuntimeStatePersist verifies AS-1: In cache-first mode,
+// runtime_state messages are appended to RecentMessages as persistent
+// AgentMessages, and the serialized LLM message prefix stays stable across turns.
+func TestCacheFirstRuntimeStatePersist(t *testing.T) {
+	agentCtx := &agentctx.AgentContext{
+		RecentMessages: []agentctx.AgentMessage{
+			agentctx.NewUserMessage("hello"),
+			agentctx.NewAssistantMessage(),
+		},
+		AgentState: &agentctx.AgentState{},
+	}
+
+	initialLen := len(agentCtx.RecentMessages)
+
+	// Simulate 3 turns of cache-first persistence.
+	// In cache-first mode, runtime_state is appended as a persistent AgentMessage.
+	turnSnapshots := make([][]llm.LLMMessage, 3)
+	for turn := 0; turn < 3; turn++ {
+		// Simulate appending a runtime_state message (cache-first path).
+		runtimeMsg := agentctx.AgentMessage{
+			Role:      "user",
+					Content:   []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "runtime_state_turn_" + string(rune('0'+turn))}},
+			Timestamp: int64(turn),
+			Metadata:  &agentctx.MessageMetadata{Kind: "runtime_state"},
+		}
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages, runtimeMsg)
+
+		// Also append a user and assistant message for realism.
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages,
+			agentctx.NewUserMessage("user turn "+string(rune('0'+turn))),
+		)
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages,
+			agentctx.NewAssistantMessage(),
+		)
+
+		// Serialize via selectMessagesForLLM + ConvertMessagesToLLM.
+		selected, _ := selectMessagesForLLM(agentCtx)
+		llmMessages := ConvertMessagesToLLM(context.Background(), selected)
+		turnSnapshots[turn] = llmMessages
+	}
+
+	// Verify: 3 runtime_state messages were persisted.
+	runtimeCount := 0
+	for _, msg := range agentCtx.RecentMessages {
+		if msg.Metadata != nil && msg.Metadata.Kind == "runtime_state" {
+			runtimeCount++
+		}
+	}
+	assert.Equal(t, 3, runtimeCount, "all 3 runtime_state messages should be in RecentMessages")
+
+	// Verify: message count increased by 3 per turn (1 runtime + 1 user + 1 assistant).
+	assert.Equal(t, initialLen+9, len(agentCtx.RecentMessages),
+		"RecentMessages should have grown by 9 (3 turns × 3 messages)")
+
+	// Verify: the last runtime_state message has correct metadata.
+	lastRuntime := -1
+	for i, msg := range agentCtx.RecentMessages {
+		if msg.Metadata != nil && msg.Metadata.Kind == "runtime_state" {
+			lastRuntime = i
+		}
+	}
+	assert.True(t, lastRuntime >= 0, "should find at least one runtime_state message")
+	assert.Equal(t, "runtime_state", agentCtx.RecentMessages[lastRuntime].Metadata.Kind)
+
+	// Verify prefix stability: Turn N-1's full messages are a prefix of Turn N's messages.
+	for i := 1; i < len(turnSnapshots); i++ {
+		prevLen := len(turnSnapshots[i-1])
+		currLen := len(turnSnapshots[i])
+		assert.Greater(t, currLen, prevLen,
+			"turn %d should have more messages than turn %d", i, i-1)
+
+		// The first prevLen messages of turn i should equal all of turn i-1.
+		// Compare by serializing role+content for determinism.
+		prevSerialized := serializeLLMMessages(turnSnapshots[i-1])
+		currPrefix := serializeLLMMessages(turnSnapshots[i][:prevLen])
+		assert.True(t, bytes.Equal(prevSerialized, currPrefix),
+			"turn %d prefix should equal turn %d full messages", i, i-1)
+	}
+}
+
+// TestContextFirstRuntimeStateEphemeral verifies AS-2: In context-first mode,
+// runtime_state is injected ephemerally via insertBeforeLastUserMessage and
+// does NOT change RecentMessages.
+func TestContextFirstRuntimeStateEphemeral(t *testing.T) {
+	agentCtx := &agentctx.AgentContext{
+		RecentMessages: []agentctx.AgentMessage{
+			agentctx.NewUserMessage("hello"),
+			agentctx.NewAssistantMessage(),
+			agentctx.NewUserMessage("what is 2+2?"),
+		},
+		AgentState: &agentctx.AgentState{},
+	}
+
+	originalLen := len(agentCtx.RecentMessages)
+	originalMessages := make([]agentctx.AgentMessage, len(agentCtx.RecentMessages))
+	copy(originalMessages, agentCtx.RecentMessages)
+
+	// Simulate context-first path: serialize messages to LLM format.
+	selected, _ := selectMessagesForLLM(agentCtx)
+	llmMessages := ConvertMessagesToLLM(context.Background(), selected)
+
+	// Inject ephemeral runtime_state before last user message.
+	runtimeMsg := llm.LLMMessage{
+		Role:    "user",
+		Content: "<agent:runtime_state/>",
+	}
+	result := insertBeforeLastUserMessage(llmMessages, runtimeMsg)
+
+	// Verify: RecentMessages is UNCHANGED (no persistent runtime_state).
+	assert.Equal(t, originalLen, len(agentCtx.RecentMessages),
+		"RecentMessages should not be modified in context-first mode")
+	for i := range agentCtx.RecentMessages {
+		assert.Equal(t, originalMessages[i].Metadata, agentCtx.RecentMessages[i].Metadata,
+			"message %d metadata should be unchanged", i)
+	}
+
+	// Verify: the returned slice has one more message than the original.
+	assert.Equal(t, len(llmMessages)+1, len(result),
+		"insertBeforeLastUserMessage should add exactly one message")
+
+	// Verify: the runtime message is placed before the last user message.
+	// Find the runtime message in the result.
+	runtimeIdx := -1
+	lastUserIdx := -1
+	for i, msg := range result {
+		if msg.Content == "<agent:runtime_state/>" {
+			runtimeIdx = i
+		}
+	}
+	for i := len(result) - 1; i >= 0; i-- {
+		if result[i].Role == "user" && result[i].Content != "<agent:runtime_state/>" {
+			lastUserIdx = i
+			break
+		}
+	}
+	assert.True(t, runtimeIdx >= 0, "runtime message should be found in result")
+	assert.True(t, lastUserIdx >= 0, "last user message should be found in result")
+	assert.Equal(t, runtimeIdx+1, lastUserIdx,
+		"runtime message should be immediately before the last user message")
+
+	// Verify: no runtime_state in RecentMessages.
+	for _, msg := range agentCtx.RecentMessages {
+		if msg.Metadata != nil {
+			assert.NotEqual(t, "runtime_state", msg.Metadata.Kind,
+				"RecentMessages should not contain runtime_state in context-first mode")
+		}
+	}
+}
+
+// TestPrefixConsistency verifies AS-5: Over 10 turns in cache-first mode,
+// each turn's serialized []llm.LLMMessage has a prefix that is byte-identical
+// to the previous turn's full message list, and message count grows monotonically.
+func TestPrefixConsistency(t *testing.T) {
+	agentCtx := &agentctx.AgentContext{
+		RecentMessages: []agentctx.AgentMessage{},
+		AgentState:     &agentctx.AgentState{},
+	}
+
+	numTurns := 10
+	turnSnapshots := make([][]llm.LLMMessage, numTurns)
+
+	for turn := 0; turn < numTurns; turn++ {
+		// Each turn: user message → runtime_state → assistant message.
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages,
+			agentctx.NewUserMessage("user turn"))
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.AgentMessage{
+			Role:      "user",
+			Content:   []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "runtime"}},
+			Timestamp: int64(turn),
+			Metadata:  &agentctx.MessageMetadata{Kind: "runtime_state"},
+		})
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages,
+			agentctx.NewAssistantMessage())
+
+		selected, _ := selectMessagesForLLM(agentCtx)
+		llmMessages := ConvertMessagesToLLM(context.Background(), selected)
+		turnSnapshots[turn] = llmMessages
+	}
+
+	// Verify monotonic growth.
+	for i := 1; i < numTurns; i++ {
+		assert.Greater(t, len(turnSnapshots[i]), len(turnSnapshots[i-1]),
+			"turn %d should have strictly more messages than turn %d", i, i-1)
+	}
+
+	// Verify prefix stability: each turn's prefix equals the previous turn's full messages.
+	for i := 1; i < numTurns; i++ {
+		prevLen := len(turnSnapshots[i-1])
+		prevSerialized := serializeLLMMessages(turnSnapshots[i-1])
+		currPrefix := serializeLLMMessages(turnSnapshots[i][:prevLen])
+		assert.True(t, bytes.Equal(prevSerialized, currPrefix),
+			"turn %d prefix should be byte-identical to turn %d full messages", i, i-1)
+	}
+}
+
+// serializeLLMMessages produces a deterministic byte representation of []llm.LLMMessage
+// for comparison purposes. We use Role+Content as the stable key since other fields
+// like ToolCalls may be nil vs empty slice.
+func serializeLLMMessages(msgs []llm.LLMMessage) []byte {
+	var buf bytes.Buffer
+	for _, msg := range msgs {
+		buf.WriteString(msg.Role)
+		buf.WriteByte(0)
+		buf.WriteString(msg.Content)
+		buf.WriteByte(0)
+		// Also include ToolCallID to distinguish tool messages.
+		buf.WriteString(msg.ToolCallID)
+		buf.WriteByte(0)
+	}
+	return buf.Bytes()
+}

--- a/pkg/agent/llm_stream_test.go
+++ b/pkg/agent/llm_stream_test.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestCacheFirstRuntimeStatePersist verifies AS-1: In cache-first mode,
@@ -31,7 +31,7 @@ func TestCacheFirstRuntimeStatePersist(t *testing.T) {
 		// Simulate appending a runtime_state message (cache-first path).
 		runtimeMsg := agentctx.AgentMessage{
 			Role:      "user",
-					Content:   []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "runtime_state_turn_" + string(rune('0'+turn))}},
+			Content:   []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "runtime_state_turn_" + string(rune('0'+turn))}},
 			Timestamp: int64(turn),
 			Metadata:  &agentctx.MessageMetadata{Kind: "runtime_state"},
 		}

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -185,10 +185,25 @@ func runInnerLoop(
 		// Pre-LLM compaction: check thresholds and compact if needed.
 		// Save checkpoint BEFORE compaction so progress is preserved if the
 		// compaction LLM call crashes the process.
-		state.savePreCompactionCheckpoint("pre_llm_threshold")
-		compacted, _ := state.performCompaction(ctx, "pre_llm_threshold", true, false)
-		if compacted != nil {
-			saveCheckpointAfterCompaction(state.checkpointMgr, agentCtx, compacted.LLMContextUpdated, state.turnCount, "pre_llm_threshold")
+		//
+		// In cache-first mode, skip proactive compaction to preserve the
+		// stable message prefix that enables cache hits. The hard-limit
+		// recovery path (context_limit_recovery below) remains active as a
+		// safety net: when the LLM returns context_length_exceeded, it will
+		// force a one-time compaction.
+		effectiveModel := getEffectiveModel(config)
+		cacheMode := ResolveCacheMode(config.CacheMode, effectiveModel.ID)
+		if cacheMode == CacheModeCache {
+			traceevent.Log(ctx, traceevent.CategoryEvent, "compact_skipped_cache_first",
+				traceevent.Field{Key: "reason", Value: "cache_first_mode_preserves_prefix"},
+				traceevent.Field{Key: "model", Value: effectiveModel.ID},
+			)
+		} else {
+			state.savePreCompactionCheckpoint("pre_llm_threshold")
+			compacted, _ := state.performCompaction(ctx, "pre_llm_threshold", true, false)
+			if compacted != nil {
+				saveCheckpointAfterCompaction(state.checkpointMgr, agentCtx, compacted.LLMContextUpdated, state.turnCount, "pre_llm_threshold")
+			}
 		}
 
 		// Run BeforeModel hooks: fan-out, inject additional messages before LLM call.

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -73,6 +73,9 @@ type LoopConfig struct {
 	// Hooks is the hook registry for BeforeModel/AfterTool/AfterAgent hooks.
 	// Nil is safe — all Run* methods are no-ops.
 	Hooks *HookRegistry
+	// CacheMode controls how runtime_state telemetry is managed.
+	// CacheModeAuto (default) auto-detects from model name.
+	CacheMode CacheMode
 }
 
 // getEffectiveModel returns the current model, using GetModel callback if available.

--- a/pkg/compact/clean_runtime_state_test.go
+++ b/pkg/compact/clean_runtime_state_test.go
@@ -3,8 +3,8 @@ package compact
 import (
 	"testing"
 
-	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/stretchr/testify/assert"
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
 )
 
 // TestCompactionCleansRuntimeState verifies AS-4: cleanOldRuntimeState removes
@@ -14,8 +14,8 @@ func TestCompactionCleansRuntimeState(t *testing.T) {
 
 	makeRuntimeMsg := func(content string) agentctx.AgentMessage {
 		return agentctx.AgentMessage{
-			Role:    "user",
-			Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: content}},
+			Role:     "user",
+			Content:  []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: content}},
 			Metadata: &agentctx.MessageMetadata{Kind: runtimeStateKind},
 		}
 	}

--- a/pkg/compact/clean_runtime_state_test.go
+++ b/pkg/compact/clean_runtime_state_test.go
@@ -1,0 +1,116 @@
+package compact
+
+import (
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCompactionCleansRuntimeState verifies AS-4: cleanOldRuntimeState removes
+// all but the last runtime_state message, leaving other messages untouched.
+func TestCompactionCleansRuntimeState(t *testing.T) {
+	runtimeStateKind := "runtime_state"
+
+	makeRuntimeMsg := func(content string) agentctx.AgentMessage {
+		return agentctx.AgentMessage{
+			Role:    "user",
+			Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: content}},
+			Metadata: &agentctx.MessageMetadata{Kind: runtimeStateKind},
+		}
+	}
+
+	t.Run("no runtime_state messages unchanged", func(t *testing.T) {
+		input := []agentctx.AgentMessage{
+			agentctx.NewUserMessage("hello"),
+			agentctx.NewAssistantMessage(),
+		}
+		result := cleanOldRuntimeState(input)
+		assert.Equal(t, len(input), len(result), "should not remove any messages")
+	})
+
+	t.Run("single runtime_state kept", func(t *testing.T) {
+		input := []agentctx.AgentMessage{
+			agentctx.NewUserMessage("hello"),
+			makeRuntimeMsg("runtime_0"),
+		}
+		result := cleanOldRuntimeState(input)
+		assert.Equal(t, 2, len(result), "should keep both messages")
+		// The runtime_state message should still be there.
+		foundRuntime := false
+		for _, msg := range result {
+			if msg.Metadata != nil && msg.Metadata.Kind == runtimeStateKind {
+				foundRuntime = true
+			}
+		}
+		assert.True(t, foundRuntime, "runtime_state message should be preserved")
+	})
+
+	t.Run("three runtime_state only last kept", func(t *testing.T) {
+		input := []agentctx.AgentMessage{
+			makeRuntimeMsg("runtime_0"),
+			makeRuntimeMsg("runtime_1"),
+			makeRuntimeMsg("runtime_2"),
+		}
+		result := cleanOldRuntimeState(input)
+		assert.Equal(t, 1, len(result), "should keep only the last runtime_state")
+		assert.Equal(t, "runtime_2", result[0].ExtractText())
+	})
+
+	t.Run("interleaved runtime_state and user messages", func(t *testing.T) {
+		input := []agentctx.AgentMessage{
+			agentctx.NewUserMessage("hello"),
+			makeRuntimeMsg("runtime_0"),
+			agentctx.NewUserMessage("turn 2"),
+			makeRuntimeMsg("runtime_1"),
+			agentctx.NewAssistantMessage(),
+			makeRuntimeMsg("runtime_2"),
+		}
+		result := cleanOldRuntimeState(input)
+		// user "hello" + user "turn 2" + assistant + runtime "runtime_2" = 4
+		assert.Equal(t, 4, len(result), "should keep non-runtime messages and last runtime_state")
+
+		// Verify non-runtime messages are preserved.
+		assert.Equal(t, "hello", result[0].ExtractText())
+		assert.Equal(t, "turn 2", result[1].ExtractText())
+		assert.Equal(t, "assistant", result[2].Role)
+
+		// Verify last message is the final runtime_state.
+		assert.Equal(t, runtimeStateKind, result[3].Metadata.Kind)
+		assert.Equal(t, "runtime_2", result[3].ExtractText())
+	})
+
+	t.Run("all messages are runtime_state only last kept", func(t *testing.T) {
+		input := []agentctx.AgentMessage{
+			makeRuntimeMsg("r0"),
+			makeRuntimeMsg("r1"),
+			makeRuntimeMsg("r2"),
+			makeRuntimeMsg("r3"),
+		}
+		result := cleanOldRuntimeState(input)
+		assert.Equal(t, 1, len(result), "should keep only the last runtime_state")
+		assert.Equal(t, "r3", result[0].ExtractText())
+	})
+
+	t.Run("empty slice returns empty", func(t *testing.T) {
+		input := []agentctx.AgentMessage{}
+		result := cleanOldRuntimeState(input)
+		assert.Equal(t, 0, len(result), "empty input should return empty result")
+	})
+
+	t.Run("nil Metadata messages not affected", func(t *testing.T) {
+		msgNoMeta := agentctx.AgentMessage{
+			Role:    "user",
+			Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "no meta"}},
+		}
+		input := []agentctx.AgentMessage{
+			msgNoMeta,
+			makeRuntimeMsg("runtime_0"),
+			msgNoMeta,
+		}
+		result := cleanOldRuntimeState(input)
+		assert.Equal(t, 3, len(result), "nil metadata messages should not be affected")
+		// The runtime_state in the middle is the only (and last) one, so it stays.
+		assert.Equal(t, runtimeStateKind, result[1].Metadata.Kind)
+	})
+}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1055,7 +1055,7 @@ func (c *Compactor) Compact(ctx *agentctx.AgentContext) (*agentctx.CompactionRes
 		agentctx.NewCompactionSummaryMessage(summary),
 	}
 
-				recentMessages = compactToolResultsInRecent(recentMessages, c.config.ToolCallCutoff)
+	recentMessages = compactToolResultsInRecent(recentMessages, c.config.ToolCallCutoff)
 	recentMessages = cleanOldRuntimeState(recentMessages)
 	newRecentMessages = append(newRecentMessages, recentMessages...)
 	messagesBefore := len(ctx.RecentMessages)

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -1055,7 +1055,8 @@ func (c *Compactor) Compact(ctx *agentctx.AgentContext) (*agentctx.CompactionRes
 		agentctx.NewCompactionSummaryMessage(summary),
 	}
 
-	recentMessages = compactToolResultsInRecent(recentMessages, c.config.ToolCallCutoff)
+				recentMessages = compactToolResultsInRecent(recentMessages, c.config.ToolCallCutoff)
+	recentMessages = cleanOldRuntimeState(recentMessages)
 	newRecentMessages = append(newRecentMessages, recentMessages...)
 	messagesBefore := len(ctx.RecentMessages)
 
@@ -1079,6 +1080,33 @@ func (c *Compactor) Compact(ctx *agentctx.AgentContext) (*agentctx.CompactionRes
 		MessagesAfter:  messagesAfter,
 		Type:           "major",
 	}, nil
+}
+
+// cleanOldRuntimeState removes all but the last runtime_state message from the
+// given slice. During compaction, older runtime_state snapshots are stale — only
+// the most recent one carries useful telemetry. Cleaning them unconditionally
+// keeps pkg/compact independent of cache mode logic.
+func cleanOldRuntimeState(messages []agentctx.AgentMessage) []agentctx.AgentMessage {
+	lastIdx := -1
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Metadata != nil && messages[i].Metadata.Kind == "runtime_state" {
+			lastIdx = i
+			break
+		}
+	}
+
+	if lastIdx == -1 {
+		return messages
+	}
+
+	var result []agentctx.AgentMessage
+	for i, msg := range messages {
+		if msg.Metadata != nil && msg.Metadata.Kind == "runtime_state" && i != lastIdx {
+			continue
+		}
+		result = append(result, msg)
+	}
+	return result
 }
 
 // ShouldCompact determines if context should be compressed using AgentContext.

--- a/pkg/traceevent/config.go
+++ b/pkg/traceevent/config.go
@@ -246,6 +246,7 @@ var eventNameToBit = map[string]int{
 	"context_mgmt_messages_truncated":     54,
 	"context_mgmt_llm_context_updated":    55,
 	"context_mgmt":                        56,
+	"compact_skipped_cache_first":         57,
 }
 
 var defaultEnabledEvents = []string{
@@ -291,6 +292,7 @@ var defaultEnabledEvents = []string{
 	"context_mgmt_check",
 	"context_mgmt_messages_truncated",
 	"context_mgmt_llm_context_updated",
+	"compact_skipped_cache_first",
 	// Default log events
 	"log:info",
 	"log:warn",


### PR DESCRIPTION
## Summary

Dual-mode `runtime_state` injection for optimal LLM prefix cache hit rates.

DeepSeek 等支持 prefix cache 的模型，每个 turn 的 `runtime_state` 注入方式会导致消息前缀漂移，缓存命中率低。本 PR 引入 cache-first / context-first 双模式架构，解决此问题。

## Changes

### Core (`pkg/agent/`)
- **`cache_policy.go`** (NEW): `CacheMode` enum (Auto/Cache/Context), `RuntimeStateStrategy`, `MessageMutationPolicy` interface, `IsCacheMode()`, `ResolveCacheMode()`, `DefaultMutationPolicy()`
- **`loop.go`**: Added `CacheMode CacheMode` field to `LoopConfig`
- **`llm_stream.go`**: Dual-path runtime_state injection
  - Cache-first (DeepSeek): persist as `AgentMessage{Kind: "runtime_state"}` → stable prefix across turns
  - Context-first (default): ephemeral `insertBeforeLastUserMessage` — behavior unchanged

### Compaction (`pkg/compact/`)
- **`compact.go`**: `cleanOldRuntimeState()` — removes stale runtime_state during compaction, keeps only latest

### Tests
- `cache_policy_test.go`: Auto-detection (5 cases), ResolveCacheMode (4 cases), DefaultMutationPolicy (3 cases)
- `llm_stream_test.go`: Cache-first persist + prefix stability (3 turns), context-first ephemeral, 10-turn prefix consistency
- `clean_runtime_state_test.go`: 7 edge-case tests for compaction cleanup

### Design Doc
- `docs/design/cache-friendly-message-architecture.md`: Full architecture doc with rationale, known limitations, future evolution

## Verification

```
go build ./pkg/agent/... ./pkg/compact/...  ✅
go test ./pkg/agent/... ./pkg/compact/...   ✅ (all existing + new tests pass)
```

## Key Design Decisions

1. **Core principle**: "Once a message is sent to LLM, freeze it" — append-only in cache-first mode
2. **Auto-detection**: `strings.Contains(model, "deepseek")` → Cache, else → Context
3. **MessageMutationPolicy interface**: Phase 1 minimal (only `RuntimeStateStrategy`), extensible for future truncate/compact interception
4. **Compaction cleanup**: Unconditional — keeps `pkg/compact` independent of cache mode logic

## Known Limitations (documented in design doc)
- Context management (truncate/compact) may still invalidate cache — documented as future work
- `runtime_state` literal not centralized in `message.go` (uses string field)