### PR TITLE
fix: compaction fallback blocked by no-op context manager

### DIFF
--- a/cmd/ai/session_writer.go
+++ b/cmd/ai/session_writer.go
@@ -62,13 +62,13 @@ func (sc *sessionCompactor) Compact(ctx *agentctx.AgentContext) (*agentctx.Compa
 	writer := sc.writer
 	sc.mu.Unlock()
 	if sess == nil || comp == nil {
-		return &agentctx.CompactionResult{}, nil
+		return nil, nil
 	}
 	if writer != nil {
 		compacted, err := writer.Compact(sess, comp)
 		if err != nil {
 			if session.IsNonActionableCompactionError(err) {
-				return &agentctx.CompactionResult{}, nil
+				return nil, nil
 			}
 			return nil, err
 		}
@@ -87,7 +87,7 @@ func (sc *sessionCompactor) Compact(ctx *agentctx.AgentContext) (*agentctx.Compa
 	sessionResult, err := sess.Compact(comp)
 	if err != nil {
 		if session.IsNonActionableCompactionError(err) {
-			return &agentctx.CompactionResult{}, nil
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/pkg/agent/loop_recovery_test.go
+++ b/pkg/agent/loop_recovery_test.go
@@ -1325,3 +1325,110 @@ func TestLoopGuardPollingDetection(t *testing.T) {
 		t.Errorf("expected at least 5 calls (polling should be allowed to continue), got %d", callCount)
 	}
 }
+
+// noopCompactor returns (nil, nil) — simulating ContextManager doing no work.
+type noopCompactor struct {
+	calls         int
+	shouldCompact bool
+}
+
+func (c *noopCompactor) ShouldCompact(_ context.Context, _ *agentctx.AgentContext) bool {
+	return c.shouldCompact
+}
+
+func (c *noopCompactor) Compact(_ *agentctx.AgentContext) (*agentctx.CompactionResult, error) {
+	c.calls++
+	return nil, nil // no-op
+}
+
+func (c *noopCompactor) CalculateDynamicThreshold() int {
+	return 100000
+}
+
+// TestPerformCompaction_NoOpDoesNotBlockFallback verifies that when the first
+// compactor returns (nil, nil) (no actual work), the loop falls through to the
+// next compactor which can then perform real compaction.
+func TestPerformCompaction_NoOpDoesNotBlockFallback(t *testing.T) {
+	orig := streamAssistantResponseFn
+	defer func() { streamAssistantResponseFn = orig }()
+
+	noop := &noopCompactor{shouldCompact: true}
+	real := &recoveryCompactor{shouldCompact: true}
+
+	streamAssistantResponseFn = func(
+		_ context.Context,
+		_ *agentctx.AgentContext,
+		_ *LoopConfig,
+		_ *llm.EventStream[AgentEvent, []agentctx.AgentMessage],
+	) (*agentctx.AgentMessage, error) {
+		msg := agentctx.NewAssistantMessage()
+		msg.Content = []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "done"}}
+		msg.StopReason = "stop"
+		return &msg, nil
+	}
+
+	agentCtx := agentctx.NewAgentContext("sys")
+	agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("hello"))
+	stream := newTestAgentEventStream()
+
+	ls := &loopState{
+		agentCtx: agentCtx,
+		config: &LoopConfig{
+			Compactors: []Compactor{noop, real},
+		},
+		stream: stream,
+	}
+
+	result, err := ls.performCompaction(context.Background(), "test", true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// noopCompactor should have been called but returned nil
+	if noop.calls != 1 {
+		t.Fatalf("expected noop compactor to be called once, got %d", noop.calls)
+	}
+
+	// recoveryCompactor should have been called as fallback
+	if real.calls != 1 {
+		t.Fatalf("expected real compactor to be called once as fallback, got %d", real.calls)
+	}
+
+	// The result should come from the real compactor
+	if result == nil {
+		t.Fatal("expected non-nil compaction result from fallback compactor")
+	}
+	if result.Summary != "[summary]" {
+		t.Fatalf("expected summary from real compactor, got %q", result.Summary)
+	}
+}
+
+// TestPerformCompaction_AllNoOpsReturnsNil verifies that when all compactors
+// return (nil, nil), the overall result is nil with no error.
+func TestPerformCompaction_AllNoOpsReturnsNil(t *testing.T) {
+	noop1 := &noopCompactor{shouldCompact: true}
+	noop2 := &noopCompactor{shouldCompact: true}
+
+	agentCtx := agentctx.NewAgentContext("sys")
+	agentCtx.RecentMessages = append(agentCtx.RecentMessages, agentctx.NewUserMessage("hello"))
+	stream := newTestAgentEventStream()
+
+	ls := &loopState{
+		agentCtx: agentCtx,
+		config: &LoopConfig{
+			Compactors: []Compactor{noop1, noop2},
+		},
+		stream: stream,
+	}
+
+	result, err := ls.performCompaction(context.Background(), "test", true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result when all compactors are no-op, got %+v", result)
+	}
+	if noop1.calls != 1 || noop2.calls != 1 {
+		t.Fatalf("expected both compactors to be called, got noop1=%d noop2=%d", noop1.calls, noop2.calls)
+	}
+}

--- a/pkg/agent/loop_state.go
+++ b/pkg/agent/loop_state.go
@@ -161,8 +161,12 @@ func (s *loopState) performCompaction(
 
 		slog.Info("[Loop] Compaction triggered", "trigger", trigger, "compactor", fmt.Sprintf("%T", c))
 		compacted, compactErr = c.Compact(s.agentCtx)
-		if compactErr == nil {
-			break // First successful compaction wins
+		if compactErr == nil && compacted != nil {
+			break // Compactor performed work; first real result wins
+		}
+		if compactErr == nil && compacted == nil {
+			slog.Info("[Loop] Compactor returned nil result, trying next", "trigger", trigger, "compactor", fmt.Sprintf("%T", c))
+			continue // No-op: try the next compactor
 		}
 		slog.Warn("[Loop] Compaction failed", "trigger", trigger, "compactor", fmt.Sprintf("%T", c), "error", compactErr)
 	}

--- a/pkg/compact/context_management.go
+++ b/pkg/compact/context_management.go
@@ -420,6 +420,13 @@ func (c *ContextManager) CompactWithCtx(parent context.Context, agentCtx *agentc
 		"duration", duration,
 	)
 
+	// Return nil when no actual work was performed so the compaction loop can
+	// fall through to the next compactor (e.g. full session compaction).
+	if truncatedCount == 0 && !llmContextUpdated && len(toolCalls) == 0 {
+		slog.Info("[CtxMgmt] No action taken, returning nil to allow fallback compactor")
+		return nil, nil
+	}
+
 	return &agentctx.CompactionResult{
 		Summary:           fmt.Sprintf("LLM context management: %d tool calls executed", len(toolCalls)),
 		TokensBefore:      tokensBefore,

--- a/pkg/session/compaction.go
+++ b/pkg/session/compaction.go
@@ -2,10 +2,11 @@ package session
 
 import (
 	"errors"
-	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"log/slog"
 	"time"
 
 	"github.com/tiancaiamao/ai/pkg/compact"
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
 )
 
 var (
@@ -48,9 +49,13 @@ func (s *Session) CanCompact(compactor *compact.Compactor) bool {
 func canCompactLocked(s *Session, compactor *compact.Compactor) bool {
 	path := s.getBranchLocked("")
 	if len(path) == 0 {
+		slog.Debug("[CanCompact] no entries in branch path")
 		return false
 	}
 	if path[len(path)-1].Type == EntryTypeCompaction {
+		slog.Debug("[CanCompact] last entry is a compaction, cannot compact",
+			"total_entries", len(path),
+			"last_type", path[len(path)-1].Type)
 		return false
 	}
 
@@ -65,10 +70,19 @@ func canCompactLocked(s *Session, compactor *compact.Compactor) bool {
 	boundaryStart := prevCompactionIndex + 1
 	refs := buildMessageRefs(path[boundaryStart:])
 	if len(refs) == 0 {
+		slog.Debug("[CanCompact] no message refs after compaction boundary",
+			"total_entries", len(path),
+			"prev_compaction_idx", prevCompactionIndex)
 		return false
 	}
 
 	firstKeptIndex := findFirstKeptIndex(refs, compactor)
+	slog.Debug("[CanCompact] result",
+		"total_entries", len(path),
+		"refs_count", len(refs),
+		"prev_compaction_idx", prevCompactionIndex,
+		"first_kept_index", firstKeptIndex,
+		"can_compact", firstKeptIndex > 0)
 	return firstKeptIndex > 0
 }
 
@@ -214,9 +228,14 @@ func findFirstKeptIndex(refs []messageRef, compactor *compact.Compactor) int {
 
 	if keepTokens <= 0 {
 		if keepMessages <= 0 {
+			slog.Debug("[findFirstKeptIndex] both keepTokens and keepMessages are 0",
+				"refs_count", len(refs))
 			return 0
 		}
 		if len(refs) <= keepMessages {
+			slog.Debug("[findFirstKeptIndex] refs within keepMessages budget",
+				"refs_count", len(refs),
+				"keep_messages", keepMessages)
 			return 0
 		}
 		idx := len(refs) - keepMessages
@@ -225,6 +244,10 @@ func findFirstKeptIndex(refs []messageRef, compactor *compact.Compactor) int {
 
 	used := 0
 	cutIndex := len(refs)
+	totalTokens := 0
+	for _, ref := range refs {
+		totalTokens += compact.EstimateMessageTokens(ref.Message)
+	}
 	for i := len(refs) - 1; i >= 0; i-- {
 		used += compact.EstimateMessageTokens(refs[i].Message)
 		cutIndex = i
@@ -234,10 +257,24 @@ func findFirstKeptIndex(refs []messageRef, compactor *compact.Compactor) int {
 	}
 
 	if cutIndex <= 0 || cutIndex >= len(refs) {
+		slog.Debug("[findFirstKeptIndex] cutIndex out of range",
+			"refs_count", len(refs),
+			"total_tokens", totalTokens,
+			"keep_tokens", keepTokens,
+			"accumulated_tokens", used,
+			"cut_index", cutIndex)
 		return 0
 	}
 
-	return adjustToCuttable(refs, cutIndex)
+	result := adjustToCuttable(refs, cutIndex)
+	slog.Debug("[findFirstKeptIndex] result",
+		"refs_count", len(refs),
+		"total_tokens", totalTokens,
+		"keep_tokens", keepTokens,
+		"accumulated_tokens", used,
+		"cut_index", cutIndex,
+		"adjusted_index", result)
+	return result
 }
 
 func adjustToCuttable(refs []messageRef, idx int) int {


### PR DESCRIPTION
## Problem

The `performCompaction` loop in the agent breaks after the first compactor (`ctxManager`) returns a nil error, even when it performed **no real work** (0 truncations, no compact, no LLM context update). This prevents the session compactor from ever running full compaction as a fallback.

**Trace evidence** (from a live session with 540+ messages, 0 full compactions):
- Context management ran 10 times — every time it only called `truncate_messages`/`update_llm_context`, never `compact`
- `before == after` message count on every compaction: truncate only marks content as `[truncated]`, it never removes messages
- Session compactor never got a chance to run

## Root Cause

```go
// Before: breaks on nil error even when result is nil (no-op)
compacted, compactErr = c.Compact(...)
if compactErr == nil {
    break // ← always breaks after ctxManager
}
```

Two compounding issues:
1. `performCompaction` breaks on `compactErr == nil` regardless of result
2. `ContextManager.CompactWithCtx` always returned non-nil result even with 0 tool calls

## Fix

### 1. `loop_state.go` — Fix break condition
```go
if compactErr == nil && compacted != nil {
    break // Only break when compactor actually did work
}
if compactErr == nil && compacted == nil {
    continue // No-op: try the next compactor
}
```

### 2. `context_management.go` — Return nil when no action taken
```go
if truncatedCount == 0 && !llmContextUpdated && len(toolCalls) == 0 {
    return nil, nil // Allow fallback to next compactor
}
```

### 3. `session_writer.go` — Return nil for non-actionable errors
```go
if session.IsNonActionableCompactionError(err) {
    return nil, nil // Was returning empty result, blocking fallback
}
```

### 4. `session/compaction.go` — Diagnostic logging
Added logging to `canCompactLocked` and `findFirstKeptIndex` to aid debugging the manual `/compact` "retention window" error.

## Testing

- `TestPerformCompaction_NoOpDoesNotBlockFallback` — verifies no-op compactor does not block the next one
- `TestPerformCompaction_AllNoOpsReturnsNil` — verifies all no-ops return nil
- `go test ./...` — all pass
- `make fmt` — clean