### PR TITLE
feat: inject AGENTS.md as user message instead of system prompt

### DIFF
--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -94,6 +94,11 @@ type rpcApp struct {
 	// --- System prompt ---
 	systemPrompt string
 
+	// Agent instructions (project-level, e.g. AGENTS.md) injected as a user
+	// message before the last user input on each LLM call. Empty when no
+	// AGENTS.md is present. Mirrors the codex contextual_user_message pattern.
+	agentInstructions string
+
 	// --- RPC Server ---
 	server *rpc.Server
 
@@ -115,6 +120,7 @@ type rpcApp struct {
 	// --- Internal helper functions ---
 	// These are assigned in initHelpers and used by handler closures.
 	buildSystemPrompt               func(currentSess *session.Session) string
+	buildAgentInstructions          func() string
 	restoreLLMContextFromCompaction func(sess *session.Session)
 	createBaseContext               func() *agentctx.AgentContext
 	setAgentContext                 func(ctx *agentctx.AgentContext)
@@ -207,6 +213,23 @@ func (app *rpcApp) initHelpers() {
 		return promptBuilder.Build()
 	}
 
+	// buildAgentInstructions loads AGENTS.md from the workspace and wraps it
+	// in <agent:instructions> tags. Returns empty when no AGENTS.md is present
+	// or when a custom/agent-config system prompt is in use (those branches
+	// are responsible for providing their own instructions if needed).
+	app.buildAgentInstructions = func() string {
+		if app.agentConfig != nil {
+			if sp, err := app.agentConfig.ResolveSystemPrompt(); err == nil && sp != "" {
+				return ""
+			}
+		}
+		if app.customSystemPrompt != "" {
+			return ""
+		}
+		promptBuilder := prompt.NewBuilderWithWorkspace("", app.ws)
+		return promptBuilder.BuildInstructionsMessage()
+	}
+
 	// restoreLLMContextFromCompaction restores the llm context overview.md
 	// from the latest compaction summary on the current session branch.
 	app.restoreLLMContextFromCompaction = func(sess *session.Session) {
@@ -233,6 +256,12 @@ func (app *rpcApp) initHelpers() {
 	// createBaseContext creates a new agent context from the current session.
 	app.createBaseContext = func() *agentctx.AgentContext {
 		app.systemPrompt = app.buildSystemPrompt(app.sess)
+		app.agentInstructions = app.buildAgentInstructions()
+		// Keep loopCfg in sync if it has been constructed (createBaseContext
+		// may be re-invoked on session resume while loopCfg already exists).
+		if app.loopCfg != nil {
+			app.loopCfg.AgentInstructions = app.agentInstructions
+		}
 		ctx := agentctx.NewAgentContext(app.systemPrompt)
 		for _, tool := range app.registry.All() {
 			ctx.AddTool(tool)

--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -80,6 +80,7 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	loopCfg.GetWorkingDir = app.ws.GetCWD
 	loopCfg.GetStartupPath = app.ws.GetInitialCWD
 	loopCfg.RunID = app.runID
+	loopCfg.AgentInstructions = app.agentInstructions
 	loopCfg.GetSessionDir = func() string {
 		if app.sess != nil {
 			return app.sess.GetDir()

--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -82,6 +82,24 @@ func streamAssistantResponse(
 		}
 	}
 
+	// Inject project-level agent instructions (e.g. AGENTS.md) as an ephemeral
+	// user message just before the last user input. This content is NOT persisted
+	// to RecentMessages — it is re-injected on every LLM call so the LLM always
+	// sees fresh instructions without bloating session history.
+	//
+	// Ordering rationale (after runtime_state handling):
+	//   - ephemeral mode:   [..., <agent:instructions>, <agent:runtime_state>, user_input]
+	//     (instructions placed first because it is the most stable context)
+	//   - persist mode:     [..., user_input, <agent:instructions>, <agent:runtime_state>]
+	//     (suboptimal but functionally correct; cache-first is a niche optimization)
+	if strings.TrimSpace(config.AgentInstructions) != "" {
+		instrMsg := llm.LLMMessage{
+			Role:    "user",
+			Content: config.AgentInstructions,
+		}
+		llmMessages = insertBeforeLastUserMessage(llmMessages, instrMsg)
+	}
+
 	// Convert tools to LLM format
 	llmTools := ConvertToolsToLLM(ctx, agentCtx.Tools)
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -79,6 +79,12 @@ type LoopConfig struct {
 	// CacheMode controls how runtime_state telemetry is managed.
 	// CacheModeAuto (default) auto-detects from model name.
 	CacheMode CacheMode
+	// AgentInstructions is the project-level instructions (e.g. AGENTS.md content
+	// wrapped in <agent:instructions> tags) injected as a user message before the
+	// last user input on each LLM call. Empty means no injection.
+	// This mirrors the codex contextual_user_message pattern, keeping the system
+	// prompt stable for caching while still providing project context per turn.
+	AgentInstructions string
 }
 
 // getEffectiveModel returns the current model, using GetModel callback if available.

--- a/pkg/prompt/builder.go
+++ b/pkg/prompt/builder.go
@@ -231,7 +231,8 @@ Use change_workspace for persistent directory switches; "cd <dir> && <command>" 
 var bootstrapFiles = []string{
 	"TOOLS.md",    // Tool usage instructions
 	"IDENTITY.md", // User/owner identity
-	"AGENTS.md",   // Project-level agent instructions
+	// AGENTS.md is intentionally NOT loaded into the system prompt.
+	// It is loaded separately and injected as a user message via BuildInstructionsMessage().
 }
 
 func (b *Builder) buildProjectContext() string {
@@ -267,6 +268,28 @@ func (b *Builder) loadBootstrapFile(filename string) string {
 	}
 
 	return ""
+}
+
+// loadAgentInstructions reads AGENTS.md content from the workspace.
+// Lookup order: .ai/AGENTS.md (project-local) → AGENTS.md (workspace root).
+// Returns empty string if not found.
+func (b *Builder) loadAgentInstructions() string {
+	return b.loadBootstrapFile("AGENTS.md")
+}
+
+// BuildInstructionsMessage returns the AGENTS.md content wrapped in
+// <agent:instructions> tags, ready for injection as a user message.
+// Returns empty string when no AGENTS.md is present.
+//
+// Unlike Build() output (which becomes the static system prompt), this content
+// is injected per-LLM-call as a user-role message placed before the user's
+// actual input — matching the codex contextual_user_message pattern.
+func (b *Builder) BuildInstructionsMessage() string {
+	content := b.loadAgentInstructions()
+	if content == "" {
+		return ""
+	}
+	return fmt.Sprintf("<agent:instructions>\n%s\n</agent:instructions>", content)
 }
 
 func (b *Builder) cleanupEmptySections(prompt string) string {

--- a/pkg/prompt/builder_test.go
+++ b/pkg/prompt/builder_test.go
@@ -3,6 +3,7 @@ package prompt
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tiancaiamao/ai/pkg/skill"
@@ -229,7 +230,7 @@ func TestConvertToolsNonSlice(t *testing.T) {
 	}
 }
 
-func TestProjectContextEmbedsAgentsMd(t *testing.T) {
+func TestProjectContextExcludesAgentsMd(t *testing.T) {
 	cwd := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte("agents instructions"), 0644); err != nil {
 		t.Fatalf("write AGENTS.md: %v", err)
@@ -241,15 +242,72 @@ func TestProjectContextEmbedsAgentsMd(t *testing.T) {
 	b := NewBuilder("", cwd)
 	result := b.Build()
 
-	if contains(result, "## AGENTS.md Convention") {
-		t.Fatalf("AGENTS.md Convention section should not be embedded in prompt")
-	}
-	if !contains(result, "agents instructions") {
-		t.Fatalf("AGENTS.md file content should be embedded in prompt")
+	// AGENTS.md must NOT appear in the system prompt — it is injected separately
+	// as a user message via BuildInstructionsMessage().
+	if contains(result, "agents instructions") {
+		t.Fatalf("AGENTS.md file content should NOT be embedded in system prompt (it's injected as a user message now)")
 	}
 	if contains(result, "claude instructions") {
 		t.Fatalf("CLAUDE.md file content should not be embedded in prompt")
 	}
+}
+
+func TestBuildInstructionsMessage(t *testing.T) {
+	t.Run("loads AGENTS.md from workspace root", func(t *testing.T) {
+		cwd := t.TempDir()
+		if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte("# My Project\n\nSome rules."), 0644); err != nil {
+			t.Fatalf("write AGENTS.md: %v", err)
+		}
+
+		b := NewBuilder("", cwd)
+		got := b.BuildInstructionsMessage()
+
+		if !strings.HasPrefix(got, "<agent:instructions>\n") {
+			t.Fatalf("expected <agent:instructions> open tag, got: %q", got)
+		}
+		if !strings.HasSuffix(got, "\n</agent:instructions>") {
+			t.Fatalf("expected </agent:instructions> close tag, got: %q", got)
+		}
+		if !contains(got, "# My Project") || !contains(got, "Some rules.") {
+			t.Fatalf("AGENTS.md content missing from instructions message: %q", got)
+		}
+		// Sanity: the wrapped content must NOT leak into Build().
+		if contains(b.Build(), "<agent:instructions>") {
+			t.Fatalf("Build() should not contain <agent:instructions> tag")
+		}
+	})
+
+	t.Run("prefers .ai/AGENTS.md over root", func(t *testing.T) {
+		cwd := t.TempDir()
+		if err := os.Mkdir(filepath.Join(cwd, ".ai"), 0755); err != nil {
+			t.Fatalf("mkdir .ai: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(cwd, ".ai", "AGENTS.md"), []byte("local override"), 0644); err != nil {
+			t.Fatalf("write .ai/AGENTS.md: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte("root content"), 0644); err != nil {
+			t.Fatalf("write AGENTS.md: %v", err)
+		}
+
+		b := NewBuilder("", cwd)
+		got := b.BuildInstructionsMessage()
+
+		if !contains(got, "local override") {
+			t.Fatalf("expected .ai/AGENTS.md content; got: %q", got)
+		}
+		if contains(got, "root content") {
+			t.Fatalf("root AGENTS.md should be shadowed by .ai/AGENTS.md; got: %q", got)
+		}
+	})
+
+	t.Run("returns empty when no AGENTS.md exists", func(t *testing.T) {
+		cwd := t.TempDir()
+		b := NewBuilder("", cwd)
+		got := b.BuildInstructionsMessage()
+		if got != "" {
+			t.Fatalf("expected empty string, got: %q", got)
+		}
+	})
 }
 
 func TestNoWorkspaceMode(t *testing.T) {


### PR DESCRIPTION
## Background

Previously AGENTS.md was loaded directly into the system prompt via `%PROJECT_CONTEXT%`, which:

1. Inflated the static system prompt on every LLM call (even when the conversation was unrelated to project rules)
2. Defeated prompt caching — system prompt is expected to be stable across turns
3. Was inconsistent with how other AI coding tools (codex, goose, claude-code) handle project-level instructions

A quick survey of `~/project/codex`, `~/project/goose`, and `~/project/claude-code` showed that **none of them embed AGENTS.md into the system prompt**. Codex's approach (contextual_user_message) is the cleanest match for this codebase.

## Change

Following the **codex contextual_user_message pattern**, AGENTS.md content is now:

- Loaded from `.ai/AGENTS.md` (preferred) or workspace root `AGENTS.md`
- Wrapped in `<agent:instructions>...</agent:instructions>` tags (matches the existing `<agent:runtime_state>` convention)
- Injected as an **ephemeral user message** before the last user input on each LLM call
- **NOT persisted** to `RecentMessages` — re-injected per call, so edits to AGENTS.md take effect immediately without restart

## Message ordering (per LLM call)

```
[system] <static prompt, no AGENTS.md>
[user]   ...history...
[asst]   ...
[user]   <agent:instructions>...AGENTS.md...</agent:instructions>   ← new
[user]   <agent:runtime_state .../>                                 ← existing
[user]   actual user input
```

## Files

| File | Change |
|------|--------|
| `pkg/prompt/builder.go` | Remove AGENTS.md from `bootstrapFiles`; add `BuildInstructionsMessage()` |
| `pkg/agent/loop.go` | Add `LoopConfig.AgentInstructions` field |
| `pkg/agent/llm_stream.go` | Inject instructions before last user message |
| `cmd/ai/rpc_app.go` | Add `rpcApp.agentInstructions`, `buildAgentInstructions` closure; sync in `createBaseContext` for session resume |
| `cmd/ai/rpc_handlers.go` | Pass `app.agentInstructions` to `loopCfg` |
| `pkg/prompt/builder_test.go` | Update existing test; add 3 new sub-tests for `BuildInstructionsMessage` |

## Behavior in compaction scenarios

- AGENTS.md inject is ephemeral, so compaction does not touch it
- After compaction + new user turn: inject lands correctly between `[Previous conversation summary]` and user input
- In tool-call loop (without new user message): inject lands before the original user prompt — same niche position as existing `<agent:runtime_state>` (not a regression)

## Test plan

- [x] `go build ./...` passes
- [x] `pkg/prompt/...` tests pass (including new `TestBuildInstructionsMessage` with 3 sub-tests)
- [x] `pkg/agent/...` tests pass
- [x] `cmd/ai/...` tests pass
- [x] `go test ./...` all green
- [x] `make fmt` applied