### PR TITLE
fix(agent): resume replays journal entries after checkpoint

### DIFF
--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -244,44 +244,57 @@ func (app *rpcApp) initHelpers() {
 			}
 			ctx.RecentMessages = app.sess.GetMessages()
 			if sessionDir != "" {
-				if cpInfo, err := agentctx.LoadLatestCheckpoint(sessionDir); err == nil && cpInfo != nil {
-					cpPath := filepath.Join(sessionDir, cpInfo.Path)
-					if snapshot, err := agentctx.LoadCheckpoint(sessionDir, cpInfo); err == nil && snapshot != nil {
-						if len(snapshot.RecentMessages) > 0 {
-							sessionMsgCount := len(ctx.RecentMessages)
-							ctx.RecentMessages = snapshot.RecentMessages
-							slog.Info("Restored messages from checkpoint",
-								"checkpoint_messages", len(snapshot.RecentMessages),
-								"session_messages", sessionMsgCount,
-								"saved", sessionMsgCount-len(snapshot.RecentMessages),
-							)
-						}
-						if snapshot.AgentState != nil {
-							ctx.AgentState = snapshot.AgentState
-							if snapshot.AgentState.CurrentWorkingDir != "" {
-								if err := app.ws.SetCWD(snapshot.AgentState.CurrentWorkingDir); err != nil {
-									slog.Warn("Failed to restore CWD from checkpoint", "cwd", snapshot.AgentState.CurrentWorkingDir, "error", err)
-								}
+				// Resume path: load the latest checkpoint and replay any
+				// journal entries written AFTER the checkpoint. This is the
+				// single source of truth — see pkg/agent/resume.go.
+				msgs, llmCtx, agentState, err := agent.LoadResumeState(sessionDir, ctx.RecentMessages)
+				if err != nil {
+					slog.Warn("Resume state load failed, using session messages",
+						"error", err,
+						"session_messages", len(ctx.RecentMessages))
+				} else {
+					if len(msgs) != len(ctx.RecentMessages) {
+						slog.Info("Resumed messages from checkpoint + journal replay",
+							"resumed_messages", len(msgs),
+							"session_messages", len(ctx.RecentMessages),
+							"replayed", len(msgs)-len(ctx.RecentMessages))
+					}
+					ctx.RecentMessages = msgs
+					if llmCtx != "" {
+						ctx.LLMContext = llmCtx
+					}
+					if agentState != nil {
+						ctx.AgentState = agentState
+						if agentState.CurrentWorkingDir != "" {
+							if err := app.ws.SetCWD(agentState.CurrentWorkingDir); err != nil {
+								slog.Warn("Failed to restore CWD from checkpoint",
+									"cwd", agentState.CurrentWorkingDir, "error", err)
 							}
-							slog.Info("Restored agent state from checkpoint",
-								"turns", snapshot.AgentState.TotalTurns,
-								"tokens", snapshot.AgentState.TokensUsed,
-								"toolCallsSince", snapshot.AgentState.ToolCallsSinceLastTrigger,
-								"cwd", snapshot.AgentState.CurrentWorkingDir,
-							)
 						}
-						if snapshot.LLMContext != "" {
-							ctx.LLMContext = snapshot.LLMContext
-						}
-					} else {
+						slog.Info("Restored agent state from checkpoint",
+							"turns", agentState.TotalTurns,
+							"tokens", agentState.TokensUsed,
+							"toolCallsSince", agentState.ToolCallsSinceLastTrigger,
+							"cwd", agentState.CurrentWorkingDir,
+						)
+					}
+				}
+
+				// Legacy fallback: if LoadResumeState returned no AgentState
+				// (e.g. a very old checkpoint with only agent_state.json and
+				// no RecentMessages), try loading agent_state.json directly.
+				if ctx.AgentState == nil {
+					if cpInfo, err := agentctx.LoadLatestCheckpoint(sessionDir); err == nil && cpInfo != nil {
+						cpPath := filepath.Join(sessionDir, cpInfo.Path)
 						if savedState, err := agentctx.LoadCheckpointAgentState(cpPath); err == nil {
 							ctx.AgentState = savedState
 							if savedState.CurrentWorkingDir != "" {
 								if err := app.ws.SetCWD(savedState.CurrentWorkingDir); err != nil {
-									slog.Warn("Failed to restore CWD from checkpoint", "cwd", savedState.CurrentWorkingDir, "error", err)
+									slog.Warn("Failed to restore CWD from checkpoint",
+										"cwd", savedState.CurrentWorkingDir, "error", err)
 								}
 							}
-							slog.Info("Restored agent state from checkpoint (no messages)",
+							slog.Info("Restored agent state from checkpoint (legacy, no messages)",
 								"turns", savedState.TotalTurns,
 								"tokens", savedState.TokensUsed,
 								"toolCallsSince", savedState.ToolCallsSinceLastTrigger,

--- a/pkg/agent/checkpoint_manager.go
+++ b/pkg/agent/checkpoint_manager.go
@@ -90,7 +90,20 @@ func (m *AgentContextCheckpointManager) CreateSnapshot(
 		AgentState:     agentState,
 	}
 
-	info, err := agentctx.SaveCheckpoint(m.sessionDir, snapshot, totalTurns, m.messageIndex)
+	// Persist MessageIndex = current journal length, so that future
+	// Reconstruct() calls replay only entries written AFTER this checkpoint.
+	// The legacy m.messageIndex counter (incremented by AppendMessage) is
+	// unreliable in production: the Session write path bypasses AppendMessage,
+	// leaving the counter at 0 forever. Reading the on-disk journal length
+	// gives the correct value regardless of which writer produced the entries.
+	messageIndex := m.messageIndex
+	if m.journal != nil {
+		if n := m.journal.GetLength(); n > messageIndex {
+			messageIndex = n
+		}
+	}
+
+	info, err := agentctx.SaveCheckpoint(m.sessionDir, snapshot, totalTurns, messageIndex)
 	if err != nil {
 		return 0, fmt.Errorf("failed to save checkpoint: %w", err)
 	}

--- a/pkg/agent/checkpoint_manager_test.go
+++ b/pkg/agent/checkpoint_manager_test.go
@@ -427,3 +427,73 @@ func (a *alwaysCompactCompactor) Compact(_ *agentctx.AgentContext) (*agentctx.Co
 func (a *alwaysCompactCompactor) CalculateDynamicThreshold() int {
 	return 0
 }
+
+// TestCreateSnapshot_PersistsJournalLength verifies that CreateSnapshot saves
+// MessageIndex equal to the current journal length, so that a subsequent
+// Reconstruct() can correctly replay only entries written AFTER the checkpoint.
+//
+// Bug (pre-fix): CreateSnapshot uses m.messageIndex (incremented only by
+// AgentContextCheckpointManager.AppendMessage), but production code never
+// calls AppendMessage — it writes via Session.AppendMessage instead. The
+// result is that every saved checkpoint has MessageIndex=0, causing
+// Reconstruct() to replay ALL journal entries on top of the snapshot and
+// producing duplicated messages.
+func TestCreateSnapshot_PersistsJournalLength(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	mgr, err := NewAgentContextCheckpointManager(sessionDir)
+	if err != nil {
+		t.Fatalf("NewAgentContextCheckpointManager: %v", err)
+	}
+	defer mgr.Close()
+
+	// Simulate the production write path: messages go directly into the
+	// session journal, bypassing checkpointMgr.AppendMessage. Append 3 user
+	// messages via Journal (same on-disk format as Session writes).
+	for i := 0; i < 3; i++ {
+		if err := mgr.journal.AppendMessage(agentctx.NewUserMessage("pre")); err != nil {
+			t.Fatalf("AppendMessage %d: %v", i, err)
+		}
+	}
+
+	// Create a snapshot — this should record MessageIndex = 3 (current
+	// journal length), so future replays know where the snapshot ends.
+	agentCtx := &agentctx.AgentContext{
+		RecentMessages: []agentctx.AgentMessage{agentctx.NewUserMessage("dummy")},
+		AgentState:     agentctx.NewAgentState("test", "/workspace"),
+	}
+	if _, err := mgr.CreateSnapshot(agentCtx, "# ctx", 1); err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	// Load the saved checkpoint and verify MessageIndex.
+	cpInfo, err := agentctx.LoadLatestCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("LoadLatestCheckpoint: %v", err)
+	}
+	if cpInfo.MessageIndex != 3 {
+		t.Errorf("checkpoint.MessageIndex = %d, want 3 (journal length at snapshot time)", cpInfo.MessageIndex)
+	}
+
+	// Additionally verify by appending 2 more messages and reconstructing:
+	// we should get 1 (snapshot) + 2 (replayed) = 3 messages, NOT 1 + 5 = 6.
+	for i := 0; i < 2; i++ {
+		if err := mgr.journal.AppendMessage(agentctx.NewUserMessage("post")); err != nil {
+			t.Fatalf("AppendMessage post %d: %v", i, err)
+		}
+	}
+
+	_, msgs, _, err := mgr.Reconstruct()
+	if err != nil {
+		t.Fatalf("Reconstruct: %v", err)
+	}
+	// Snapshot has 1 message ("dummy"); replay adds 2 post-checkpoint entries.
+	// If MessageIndex were 0 (the bug), replay would add all 5 journal messages
+	// and we'd see 1 + 5 = 6.
+	if got := len(msgs); got != 3 {
+		t.Errorf("after Reconstruct: message count = %d, want 3 (1 snapshot + 2 replayed)", got)
+		for i, m := range msgs {
+			t.Logf("  msg[%d] role=%s text=%q", i, m.Role, firstText(m))
+		}
+	}
+}

--- a/pkg/agent/resume.go
+++ b/pkg/agent/resume.go
@@ -19,7 +19,8 @@ import (
 //     sess.GetMessages()).
 //
 // Returns:
-//   - messages: reconstructed RecentMessages (checkpoint + replayed post-checkpoint entries)
+//   - messages: reconstructed RecentMessages (checkpoint snapshot + replayed
+//     post-checkpoint journal entries)
 //   - llmContext: LLM context from the checkpoint ("" if no checkpoint)
 //   - agentState: agent state from the checkpoint (nil if no checkpoint)
 //   - err: any I/O or parsing error
@@ -35,7 +36,7 @@ func LoadResumeState(sessionDir string, fallbackMessages []agentctx.AgentMessage
 		return fallbackMessages, "", nil, nil
 	}
 
-		cpInfo, err := agentctx.LoadLatestCheckpoint(sessionDir)
+	cpInfo, err := agentctx.LoadLatestCheckpoint(sessionDir)
 	if err != nil {
 		// "no checkpoints found" or missing index file → fallback path.
 		// We treat any load error as "no checkpoint available" rather than
@@ -47,17 +48,26 @@ func LoadResumeState(sessionDir string, fallbackMessages []agentctx.AgentMessage
 		return fallbackMessages, "", nil, nil
 	}
 
-	snapshot, err := agentctx.LoadCheckpoint(sessionDir, cpInfo)
+	// Read the journal (session-format messages.jsonl) and replay entries
+	// after cpInfo.MessageIndex on top of the checkpoint snapshot. This is
+	// the path that was missing in the original rpcApp.createBaseContext
+	// implementation: that code used snapshot.RecentMessages directly,
+	// silently dropping any messages written after the checkpoint.
+	journal, err := agentctx.OpenJournal(sessionDir)
 	if err != nil {
-		return fallbackMessages, "", nil, fmt.Errorf("load checkpoint: %w", err)
+		return fallbackMessages, "", nil, fmt.Errorf("open journal: %w", err)
+	}
+	defer journal.Close()
+
+	entries, err := journal.ReadAll()
+	if err != nil {
+		return fallbackMessages, "", nil, fmt.Errorf("read journal: %w", err)
 	}
 
-	// TEMPORARY (buggy) implementation — matches current rpc_app.createBaseContext
-	// behavior. Will be replaced by proper Reconstruct() in the fix.
-	if len(snapshot.RecentMessages) > 0 {
-		return snapshot.RecentMessages, snapshot.LLMContext, snapshot.AgentState, nil
+	snapshot, err := agentctx.ReconstructSnapshotWithCheckpoint(sessionDir, cpInfo, entries)
+	if err != nil {
+		return fallbackMessages, "", nil, fmt.Errorf("reconstruct snapshot: %w", err)
 	}
 
-	// No RecentMessages in checkpoint — use fallback.
-	return fallbackMessages, "", snapshot.AgentState, nil
+	return snapshot.RecentMessages, snapshot.LLMContext, snapshot.AgentState, nil
 }

--- a/pkg/agent/resume.go
+++ b/pkg/agent/resume.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"fmt"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+// LoadResumeState loads the most up-to-date agent context state from a session
+// directory, replaying journal entries written after the latest checkpoint.
+//
+// This is the single source of truth for resume semantics — used by
+// rpcApp.createBaseContext on startup and on session resume.
+//
+// Parameters:
+//   - sessionDir: session directory containing messages.jsonl and checkpoints/.
+//     Empty string disables checkpoint-based resume.
+//   - fallbackMessages: messages to use if no checkpoint exists (typically
+//     sess.GetMessages()).
+//
+// Returns:
+//   - messages: reconstructed RecentMessages (checkpoint + replayed post-checkpoint entries)
+//   - llmContext: LLM context from the checkpoint ("" if no checkpoint)
+//   - agentState: agent state from the checkpoint (nil if no checkpoint)
+//   - err: any I/O or parsing error
+//
+// If no checkpoint exists, returns (fallbackMessages, "", nil, nil).
+func LoadResumeState(sessionDir string, fallbackMessages []agentctx.AgentMessage) (
+	messages []agentctx.AgentMessage,
+	llmContext string,
+	agentState *agentctx.AgentState,
+	err error,
+) {
+	if sessionDir == "" {
+		return fallbackMessages, "", nil, nil
+	}
+
+		cpInfo, err := agentctx.LoadLatestCheckpoint(sessionDir)
+	if err != nil {
+		// "no checkpoints found" or missing index file → fallback path.
+		// We treat any load error as "no checkpoint available" rather than
+		// a fatal error, matching the production resume semantics where a
+		// fresh session has no checkpoint yet.
+		return fallbackMessages, "", nil, nil
+	}
+	if cpInfo == nil {
+		return fallbackMessages, "", nil, nil
+	}
+
+	snapshot, err := agentctx.LoadCheckpoint(sessionDir, cpInfo)
+	if err != nil {
+		return fallbackMessages, "", nil, fmt.Errorf("load checkpoint: %w", err)
+	}
+
+	// TEMPORARY (buggy) implementation — matches current rpc_app.createBaseContext
+	// behavior. Will be replaced by proper Reconstruct() in the fix.
+	if len(snapshot.RecentMessages) > 0 {
+		return snapshot.RecentMessages, snapshot.LLMContext, snapshot.AgentState, nil
+	}
+
+	// No RecentMessages in checkpoint — use fallback.
+	return fallbackMessages, "", snapshot.AgentState, nil
+}

--- a/pkg/agent/resume_test.go
+++ b/pkg/agent/resume_test.go
@@ -42,7 +42,7 @@ func TestResume_ReplaysPostCheckpointMessages(t *testing.T) {
 		}
 	}
 
-		// Step 2: snapshot current state and save as a checkpoint.
+	// Step 2: snapshot current state and save as a checkpoint.
 	// Use the production SaveCheckpoint path: recent messages come from the
 	// session, and MessageIndex must reflect the journal length AT THIS POINT
 	// so that replay can skip entries already represented in the snapshot.
@@ -89,7 +89,7 @@ func TestResume_ReplaysPostCheckpointMessages(t *testing.T) {
 	if gotLLMCtx != "# Current Task\npre-checkpoint work" {
 		t.Errorf("LLMContext = %q, want checkpoint's LLMContext", gotLLMCtx)
 	}
-		if gotState == nil {
+	if gotState == nil {
 		t.Error("AgentState = nil, want non-nil")
 	} else if gotState.TotalTurns != 7 {
 		t.Errorf("TotalTurns = %d, want 7 (preserved from checkpoint)", gotState.TotalTurns)

--- a/pkg/agent/resume_test.go
+++ b/pkg/agent/resume_test.go
@@ -1,0 +1,193 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/session"
+)
+
+// TestResume_ReplaysPostCheckpointMessages verifies that resuming a session
+// after a checkpoint correctly returns ALL messages including those written
+// after the checkpoint was created.
+//
+// This test mirrors the production bug reported in session 8c0ef142:
+// after restarting and resuming, 25 journal entries written between the last
+// checkpoint and the resume were lost, because the resume path loaded only
+// checkpoint.RecentMessages and ignored journal entries appended after the
+// checkpoint (commit / push / PR creation flow was dropped).
+//
+// Scenario:
+//  1. Session writes 3 pre-checkpoint messages
+//  2. SaveCheckpoint (snapshot of current state)
+//  3. Session writes 2 more messages (post-checkpoint, not yet checkpointed)
+//  4. Resume: load state from sessionDir via LoadResumeState
+//
+// Expected: LoadResumeState returns 5 messages (3 pre + 2 post).
+// Bug (pre-fix): only 3 messages returned (drops 2 post-checkpoint entries).
+func TestResume_ReplaysPostCheckpointMessages(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	// Use the same sessionDir layout as production.
+	sess := newTestSession(t, sessionDir)
+
+	// Step 1: write 3 pre-checkpoint user messages.
+	for i := 0; i < 3; i++ {
+		msg := agentctx.NewUserMessage(fmt.Sprintf("pre-checkpoint %d", i))
+		if _, err := sess.AppendMessage(msg); err != nil {
+			t.Fatalf("AppendMessage pre %d: %v", i, err)
+		}
+	}
+
+		// Step 2: snapshot current state and save as a checkpoint.
+	// Use the production SaveCheckpoint path: recent messages come from the
+	// session, and MessageIndex must reflect the journal length AT THIS POINT
+	// so that replay can skip entries already represented in the snapshot.
+	preMessages := cloneMessages(sess.GetMessages())
+	preAgentState := agentctx.NewAgentState("test-session", "/workspace")
+	preAgentState.TotalTurns = 7 // simulate prior work in the session
+	snapshot := &agentctx.ContextSnapshot{
+		LLMContext:     "# Current Task\npre-checkpoint work",
+		RecentMessages: preMessages,
+		AgentState:     preAgentState,
+	}
+	checkpointInfo, err := saveCheckpointAtJournalHead(sessionDir, snapshot, 1)
+	if err != nil {
+		t.Fatalf("saveCheckpointAtJournalHead: %v", err)
+	}
+	t.Logf("checkpoint saved: path=%s msgIndex=%d messages=%d",
+		checkpointInfo.Path, checkpointInfo.MessageIndex, len(preMessages))
+
+	// Step 3: write 2 post-checkpoint messages — these are the entries that
+	// were lost in the production bug.
+	for i := 0; i < 2; i++ {
+		msg := agentctx.NewUserMessage(fmt.Sprintf("post-checkpoint %d", i))
+		if _, err := sess.AppendMessage(msg); err != nil {
+			t.Fatalf("AppendMessage post %d: %v", i, err)
+		}
+	}
+
+	// Step 4: simulate a fresh process resuming the session — load state
+	// purely from disk (sessionDir + journal + checkpoint).
+	gotMessages, gotLLMCtx, gotState, err := LoadResumeState(sessionDir, nil)
+	if err != nil {
+		t.Fatalf("LoadResumeState: %v", err)
+	}
+
+	// Expected: 3 pre + 2 post = 5 messages.
+	if got := len(gotMessages); got != 5 {
+		t.Errorf("message count = %d, want 5 (3 pre-checkpoint + 2 post-checkpoint)", got)
+		for i, m := range gotMessages {
+			t.Logf("  msg[%d] role=%s text=%q", i, m.Role, firstText(m))
+		}
+	}
+
+	// Also check that both pre and post messages are present.
+	if gotLLMCtx != "# Current Task\npre-checkpoint work" {
+		t.Errorf("LLMContext = %q, want checkpoint's LLMContext", gotLLMCtx)
+	}
+		if gotState == nil {
+		t.Error("AgentState = nil, want non-nil")
+	} else if gotState.TotalTurns != 7 {
+		t.Errorf("TotalTurns = %d, want 7 (preserved from checkpoint)", gotState.TotalTurns)
+	}
+
+	// Ensure post-checkpoint messages survived.
+	if len(gotMessages) >= 5 {
+		lastMsg := firstText(gotMessages[4])
+		if lastMsg != "post-checkpoint 1" {
+			t.Errorf("last message text = %q, want %q", lastMsg, "post-checkpoint 1")
+		}
+	}
+}
+
+// TestResume_FallsBackWhenNoCheckpoint verifies the no-checkpoint path:
+// LoadResumeState should return the fallback messages as-is.
+func TestResume_FallsBackWhenNoCheckpoint(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	fallback := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("hello"),
+		agentctx.NewAssistantMessage(),
+	}
+
+	gotMessages, gotLLMCtx, gotState, err := LoadResumeState(sessionDir, fallback)
+	if err != nil {
+		t.Fatalf("LoadResumeState: %v", err)
+	}
+
+	if len(gotMessages) != len(fallback) {
+		t.Errorf("message count = %d, want %d (fallback)", len(gotMessages), len(fallback))
+	}
+	if gotLLMCtx != "" {
+		t.Errorf("LLMContext = %q, want empty (no checkpoint)", gotLLMCtx)
+	}
+	if gotState != nil {
+		t.Errorf("AgentState = %v, want nil (no checkpoint)", gotState)
+	}
+}
+
+// TestResume_FallsBackWhenSessionDirEmpty verifies the empty-sessionDir path:
+// LoadResumeState("", fallback) should return fallback messages.
+func TestResume_FallsBackWhenSessionDirEmpty(t *testing.T) {
+	fallback := []agentctx.AgentMessage{agentctx.NewUserMessage("hello")}
+
+	gotMessages, _, _, err := LoadResumeState("", fallback)
+	if err != nil {
+		t.Fatalf("LoadResumeState: %v", err)
+	}
+	if len(gotMessages) != 1 {
+		t.Errorf("message count = %d, want 1", len(gotMessages))
+	}
+}
+
+// --- helpers ---
+
+// newTestSession creates a Session rooted at sessionDir, mimicking the layout
+// used in production (~/.ai/sessions/<id>/).
+func newTestSession(t *testing.T, sessionDir string) *session.Session {
+	t.Helper()
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", sessionDir, err)
+	}
+	sess := session.NewSession(sessionDir)
+	// SessionInfo entry mirrors what production writes shortly after init.
+	if _, err := sess.AppendSessionInfo("test", ""); err != nil {
+		t.Fatalf("AppendSessionInfo: %v", err)
+	}
+	return sess
+}
+
+// saveCheckpointAtJournalHead saves a checkpoint with MessageIndex equal to
+// the current journal length. This mirrors the CORRECT behavior that should
+// happen in production (but currently doesn't — see TestCreateSnapshot_PersistsJournalLength).
+func saveCheckpointAtJournalHead(sessionDir string, snapshot *agentctx.ContextSnapshot, turn int) (*agentctx.CheckpointInfo, error) {
+	journal, err := agentctx.OpenJournal(sessionDir)
+	if err != nil {
+		return nil, fmt.Errorf("open journal: %w", err)
+	}
+	defer journal.Close()
+	msgIdx := journal.GetLength()
+	return agentctx.SaveCheckpoint(sessionDir, snapshot, turn, msgIdx)
+}
+
+func cloneMessages(in []agentctx.AgentMessage) []agentctx.AgentMessage {
+	out := make([]agentctx.AgentMessage, len(in))
+	copy(out, in)
+	return out
+}
+
+func firstText(m agentctx.AgentMessage) string {
+	for _, c := range m.Content {
+		if tc, ok := c.(agentctx.TextContent); ok {
+			return tc.Text
+		}
+	}
+	return ""
+}
+
+// Ensure filepath import is used when sessionDir is constructed via filepath.Join
+var _ = filepath.Join


### PR DESCRIPTION
## Problem

Resume after restart was silently dropping journal entries written between the latest checkpoint and the resume. In the reported case (session `8c0ef142`), 25 entries were lost — the entire commit / push / PR-create flow.

Root cause: `rpcApp.createBaseContext` loaded `snapshot.RecentMessages` from the latest checkpoint and ignored journal entries appended after the checkpoint, even though those entries were safely persisted in `messages.jsonl`.

A second bug amplified the first: `checkpointManager.CreateSnapshot` persisted `MessageIndex = m.messageIndex`, but production code never calls `checkpointMgr.AppendMessage` (it writes via `Session.AppendMessage` instead), so `m.messageIndex` was always 0. Even if the resume path had called `Reconstruct()`, it would have replayed ALL journal entries on top of the snapshot, producing duplicates.

## Fix

1. **`pkg/agent/resume.go`** — new `LoadResumeState` helper: single source of truth for resume. Delegates to `context.ReconstructSnapshotWithCheckpoint`, which loads the checkpoint snapshot and replays post-checkpoint journal entries on top.

2. **`cmd/ai/rpc_app.go`** — `createBaseContext` now calls `LoadResumeState` instead of manually loading `snapshot.RecentMessages`. Legacy fallback for checkpoints without RecentMessages is preserved.

3. **`pkg/agent/checkpoint_manager.go`** — `CreateSnapshot` now reads `journal.GetLength()` to compute the correct `MessageIndex`, instead of relying on the never-incremented `m.messageIndex` counter.

## Tests (TDD)

| Test | Verifies |
|------|----------|
| `TestResume_ReplaysPostCheckpointMessages` | End-to-end: Session writes 3 msgs → SaveCheckpoint → Session writes 2 more → LoadResumeState → expect 5 msgs (was 3 before fix) |
| `TestResume_FallsBackWhenNoCheckpoint` | No checkpoint → return fallback messages |
| `TestResume_FallsBackWhenSessionDirEmpty` | Empty sessionDir → return fallback messages |
| `TestCreateSnapshot_PersistsJournalLength` | MessageIndex persisted as journal length (was 0); Reconstruct returns 1 snapshot + 2 replayed = 3 (was 6) |

```bash
go test ./pkg/agent/... ./pkg/context/... ./pkg/session/... ./cmd/ai/...  # all pass
go test ./...  # full suite, no regressions
```

## Commits

1. `24b8c80` — test: reproduce resume bug (tests fail)
2. `0bffca5` — fix: resume replays journal entries (tests pass)