### PR TITLE
refactor(prompt): simplify runtime_state snapshot and inline Workspace section

### DIFF
--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -346,7 +346,6 @@ func buildRuntimeUserAppendix(llmContextContent, runtimeMetaSnapshot string) str
 	if len(sections) == 0 {
 		return ""
 	}
-	sections = append(sections, `Remember: runtime_state is telemetry, not user intent.`)
 	return strings.Join(sections, "\n\n")
 }
 
@@ -382,48 +381,19 @@ func updateRuntimeMetaSnapshot(
 		return agentCtx.AgentState.RuntimeMetaSnapshot, false
 	}
 
-	tokensUsedApprox := normalizeApprox(meta.TokensUsed)
-	toolPressure := collectRuntimeToolPressure(agentCtx.RecentMessages)
-	toolOutputsSummary := buildToolOutputsSummary(agentCtx.RecentMessages)
-
 	// runtime_state is purely informational - no directives or commands
 	// Build run_id line only when available (subagent spawned via ai serve).
 	var runIDLine string
 	if runID != "" {
 		runIDLine = fmt.Sprintf("\n  run_id: %s", runID)
 	}
-	snapshot := fmt.Sprintf(`<agent:runtime_state comment="telemetry snapshot, updated periodically"/>
-context_meta:
-  tokens_band: %s
-  tokens_used_approx: %d
-  tokens_max: %d
-  messages_in_history_bucket: %s
-  llm_context_size_bucket: %s%s
-workspace:
+	snapshot := fmt.Sprintf(`<agent:runtime_state"/>
+%s
   current_workdir: %s
-  startup_path: %s
-tool_output_pressure:
-  stale_tool_outputs: %d
-  tool_outputs_summary: %s
-  large_tool_outputs: %d
-  largest_tool_output_bucket: %s
-compact_decision_signals:
-  tokens_percent: %.1f
-  context_usage_percent: %.1f`,
-		band,
-		tokensUsedApprox,
-		meta.TokensMax,
-		runtimeMessageBucket(meta.MessagesInHistory),
-		runtimeSizeBucket(meta.LLMContextSize),
+  startup_path: %s`,
 		runIDLine,
 		runtimeYAMLString(currentWorkdir),
 		runtimeYAMLString(startupPath),
-		toolPressure.StaleCount,
-		toolOutputsSummary,
-		toolPressure.LargeCount,
-		runtimeToolOutputSizeBucket(toolPressure.LargestChars),
-		meta.TokensPercent,
-		meta.TokensPercent,
 	)
 
 	agentCtx.AgentState.RuntimeMetaSnapshot = snapshot

--- a/pkg/agent/runtime_meta_test.go
+++ b/pkg/agent/runtime_meta_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"fmt"
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
 	"testing"
@@ -24,8 +23,8 @@ func TestUpdateRuntimeMetaSnapshotRefreshRules(t *testing.T) {
 	if snapshot == "" {
 		t.Fatal("expected non-empty snapshot")
 	}
-	if !containsString(snapshot, "tokens_band: 20-40") {
-		t.Fatalf("expected 20-40 band, got: %s", snapshot)
+	if !containsString(snapshot, "current_workdir:") {
+		t.Fatalf("expected current_workdir in snapshot, got: %s", snapshot)
 	}
 	// action_hint field has been removed
 
@@ -55,8 +54,8 @@ func TestUpdateRuntimeMetaSnapshotRefreshRules(t *testing.T) {
 	if !refreshed5 {
 		t.Fatal("expected refresh on band change")
 	}
-	if !containsString(snapshot5, "tokens_band: 60-75") {
-		t.Fatalf("expected 60-75 band, got: %s", snapshot5)
+	if !containsString(snapshot5, "current_workdir:") {
+		t.Fatalf("expected current_workdir after band-change refresh, got: %s", snapshot5)
 	}
 	// action_hint field has been removed
 }
@@ -68,9 +67,6 @@ func TestBuildRuntimeSystemAppendix(t *testing.T) {
 	}
 	if !containsString(appendix, "<runtime_state>ok</runtime_state>") {
 		t.Fatalf("expected runtime_state section, got: %s", appendix)
-	}
-	if !containsString(appendix, "runtime_state is telemetry") {
-		t.Fatalf("expected telemetry reminder, got: %s", appendix)
 	}
 
 	empty := buildRuntimeSystemAppendix("", "")
@@ -146,73 +142,6 @@ func TestExtractRecentMessagesSkipsOrphanedToolResults(t *testing.T) {
 	// Should start with user or assistant
 	if active[0].Role != "user" && active[0].Role != "assistant" {
 		t.Fatalf("expected first message to be user or assistant, got %q", active[0].Role)
-	}
-}
-
-func TestBuildToolOutputsSummaryUsesStaleHistoryExcludingRecent10(t *testing.T) {
-	msgs := []agentctx.AgentMessage{agentctx.NewUserMessage("old")}
-	msgs = append(msgs, agentctx.NewToolResultMessage("call-1", "read", []agentctx.ContentBlock{
-		agentctx.TextContent{Type: "text", Text: "stale-1"},
-	}, false))
-	msgs = append(msgs, agentctx.NewToolResultMessage("call-2", "bash", []agentctx.ContentBlock{
-		agentctx.TextContent{Type: "text", Text: "stale-2"},
-	}, false))
-	for i := 3; i <= 12; i++ {
-		msgs = append(msgs, agentctx.NewToolResultMessage(
-			fmt.Sprintf("call-%d", i),
-			"grep",
-			[]agentctx.ContentBlock{
-				agentctx.TextContent{Type: "text", Text: fmt.Sprintf("recent-%d", i)},
-			},
-			false,
-		))
-	}
-	msgs = append(msgs, agentctx.NewUserMessage("latest"))
-
-	summary := buildToolOutputsSummary(msgs)
-	if !containsString(summary, "2 stale outputs") {
-		t.Fatalf("expected 2 stale outputs in summary, got: %s", summary)
-	}
-	if !containsString(summary, "1 bash, 1 read") {
-		t.Fatalf("expected grouped tool counts, got: %s", summary)
-	}
-	// Note: guidance is no longer included in buildToolOutputsSummary
-	// LLM decides based on runtime_state telemetry
-}
-
-func TestUpdateRuntimeMetaSnapshotIncludesCompactDecisionSignals(t *testing.T) {
-	agentCtx := agentctx.NewAgentContext("sys")
-	agentCtx.RecentMessages = []agentctx.AgentMessage{
-		agentctx.NewUserMessage("修复 truncate compact 协议"),
-		func() agentctx.AgentMessage {
-			m := agentctx.NewAssistantMessage()
-			m.Content = []agentctx.ContentBlock{
-				agentctx.TextContent{Type: "text", Text: "阶段完成：truncate 已完成"},
-			}
-			return m
-		}(),
-		agentctx.NewUserMessage("顺便看看前端动画设计"),
-	}
-	meta := agentctx.ContextMeta{
-		TokensUsed:        64000,
-		TokensMax:         128000,
-		TokensPercent:     50.0,
-		MessagesInHistory: len(agentCtx.RecentMessages),
-		LLMContextSize:    1200,
-	}
-
-	snapshot, refreshed := updateRuntimeMetaSnapshot(agentCtx, meta, 3, "", "", "")
-	if !refreshed {
-		t.Fatal("expected refreshed snapshot")
-	}
-	if !containsString(snapshot, "compact_decision_signals:") {
-		t.Fatalf("expected compact_decision_signals section, got: %s", snapshot)
-	}
-	if !containsString(snapshot, "tokens_percent: 50.0") {
-		t.Fatalf("expected tokens_percent field, got: %s", snapshot)
-	}
-	if containsString(snapshot, "llm_judge") {
-		t.Fatalf("did not expect llm_judge placeholder fields, got: %s", snapshot)
 	}
 }
 

--- a/pkg/agent/tool_metadata.go
+++ b/pkg/agent/tool_metadata.go
@@ -1,8 +1,6 @@
 package agent
 
 import (
-	"fmt"
-	"sort"
 	"strings"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
@@ -108,40 +106,4 @@ func findLatestToolCallID(messages []agentctx.AgentMessage, toolName string) str
 		}
 	}
 	return ""
-}
-
-func buildToolOutputsSummary(messages []agentctx.AgentMessage) string {
-	staleCount, byTool := collectStaleToolOutputStats(messages, recentToolResultsNoMetadata)
-	if staleCount == 0 || len(byTool) == 0 {
-		return "none"
-	}
-
-	type pair struct {
-		name  string
-		count int
-	}
-	pairs := make([]pair, 0, len(byTool))
-	for name, count := range byTool {
-		pairs = append(pairs, pair{name: name, count: count})
-	}
-	sort.Slice(pairs, func(i, j int) bool {
-		if pairs[i].count == pairs[j].count {
-			return pairs[i].name < pairs[j].name
-		}
-		return pairs[i].count > pairs[j].count
-	})
-
-	limit := toolOutputSummaryTypeLimit
-	if len(pairs) < limit {
-		limit = len(pairs)
-	}
-	parts := make([]string, 0, limit)
-	for i := 0; i < limit; i++ {
-		parts = append(parts, fmt.Sprintf("%d %s", pairs[i].count, pairs[i].name))
-	}
-	if len(pairs) > limit {
-		parts = append(parts, "...")
-	}
-
-	return fmt.Sprintf("%d stale outputs (%s)", staleCount, strings.Join(parts, ", "))
 }

--- a/pkg/prompt/builder.go
+++ b/pkg/prompt/builder.go
@@ -67,12 +67,6 @@ type Builder struct {
 	// Minimal mode (excludes optional sections like skills, project context)
 	minimal bool
 
-	// No workspace mode (excludes workspace section, for chat bots like claw)
-	noWorkspace bool
-
-	// Workspace notes (optional reminders)
-	workspaceNotes string
-
 	// Available tools (for Tooling section)
 	tools []ToolInfo
 
@@ -119,18 +113,6 @@ func (b *Builder) GetCWD() string {
 // SetMinimal enables/disables minimal mode.
 func (b *Builder) SetMinimal(minimal bool) *Builder {
 	b.minimal = minimal
-	return b
-}
-
-// SetNoWorkspace enables/disables no-workspace mode.
-func (b *Builder) SetNoWorkspace(noWorkspace bool) *Builder {
-	b.noWorkspace = noWorkspace
-	return b
-}
-
-// SetWorkspaceNotes sets optional workspace notes.
-func (b *Builder) SetWorkspaceNotes(notes string) *Builder {
-	b.workspaceNotes = notes
 	return b
 }
 
@@ -191,19 +173,6 @@ func (b *Builder) Build() string {
 	if b.template != "" {
 		result = b.template
 	}
-
-	// Replace workspace section (optional - empty when noWorkspace is true)
-	workspaceSection := ""
-	if !b.noWorkspace {
-		workspaceNotes := ""
-		if b.workspaceNotes != "" {
-			workspaceNotes = "\n" + b.workspaceNotes
-		}
-		workspaceSection = fmt.Sprintf(`## Workspace
-Use current_workdir from runtime_state, not a hardcoded path.
-Use change_workspace for persistent directory switches; "cd <dir> && <command>" for one-off commands.%s`, workspaceNotes)
-	}
-	result = strings.ReplaceAll(result, "%WORKSPACE_SECTION%", workspaceSection)
 
 	// Replace skills (optional section)
 	skills := ""

--- a/pkg/prompt/builder_test.go
+++ b/pkg/prompt/builder_test.go
@@ -288,34 +288,24 @@ func TestBuildInstructionsMessage(t *testing.T) {
 	})
 }
 
-func TestNoWorkspaceMode(t *testing.T) {
+func TestWorkspaceSectionPresent(t *testing.T) {
 	cwd := t.TempDir()
 
-	// Add minimal tools for both builders
+	// Add minimal tools
 	tools := []ToolInfo{mockTool{name: "read", description: "Read files"}}
 
-	// Test with workspace (default)
-	builderWithWorkspace := NewBuilder("", cwd)
-	builderWithWorkspace.SetTools(tools)
-	resultWith := builderWithWorkspace.Build()
-	if !contains(resultWith, "## Workspace") {
-		t.Error("expected Workspace section when noWorkspace is false")
+	// The Workspace section is hardcoded in the prompt template.
+	builder := NewBuilder("", cwd)
+	builder.SetTools(tools)
+	result := builder.Build()
+	if !contains(result, "## Workspace") {
+		t.Error("expected Workspace section in default build")
 	}
-
-	// Test without workspace (noWorkspace mode)
-	builderNoWorkspace := NewBuilder("", cwd).SetNoWorkspace(true)
-	builderNoWorkspace.SetTools(tools)
-	resultWithout := builderNoWorkspace.Build()
-	if contains(resultWithout, "## Workspace") {
-		t.Error("expected no Workspace section when noWorkspace is true")
+	if !contains(result, "current_workdir") {
+		t.Error("expected current_workdir guidance in Workspace section")
 	}
-	if contains(resultWithout, "Your working directory is:") {
-		t.Error("expected no working directory mention when noWorkspace is true")
-	}
-
-	// Ensure the prompt still has content (it will have Tooling section)
-	if resultWithout == "" {
-		t.Error("expected non-empty prompt even in noWorkspace mode")
+	if result == "" {
+		t.Error("expected non-empty prompt")
 	}
 }
 
@@ -459,9 +449,6 @@ func TestBuilderSetters(t *testing.T) {
 	// All Set* methods should return the builder for chaining.
 	if got := b.SetMinimal(true); got != b {
 		t.Error("SetMinimal did not return builder")
-	}
-	if got := b.SetWorkspaceNotes("notes"); got != b {
-		t.Error("SetWorkspaceNotes did not return builder")
 	}
 	if got := b.SetTemplate("custom template {{workspace_section}} {{tool_descriptions}}"); got != b {
 		t.Error("SetTemplate did not return builder")

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -14,6 +14,11 @@ When instructions conflict, follow this order:
 2. **System capabilities and prompts** — Tool schemas, runtime limits, this system prompt
 3. **User instructions** — Including project rules and style preferences (use context judgment)
 
+## Workspace
+
+Use current_workdir from runtime_state, not a hardcoded path.
+Use `change_workspace` tool for persistent directory switches; "cd <dir> && <command>" for one-off commands.
+
 ## Skills Reference
 
 - **`subagent`** — 子 agent spawn/watch/kill 生命周期。所有子 agent 操作遵循此技能。

--- a/pkg/prompt/prompt.md
+++ b/pkg/prompt/prompt.md
@@ -16,6 +16,7 @@ When instructions conflict, follow this order:
 
 - Your reply MUST begin with [ready]
 - If you forget, it means you are losing track of context
+- This is a cheap way to detect context rot
 
 ✅ Right: [ready] 关于这个问题，我来帮您分析一下...
 ❌ Wrong: 关于这个问题，我来帮您分析一下...
@@ -70,7 +71,10 @@ This is a hard constraint, not a style preference. For any task where thinking m
 
 This keeps the connection alive and gives the orchestrator a signal you're still on track.
 
-%WORKSPACE_SECTION%
+## Workspace
+
+Use current_workdir from runtime_state, not a hardcoded path.
+Use `change_workspace` tool for persistent directory switches; "cd <dir> && <command>" for one-off commands.
 
 ## Tools
 


### PR DESCRIPTION
## Summary

Simplifies the runtime_state telemetry snapshot and inlines the Workspace section directly into prompt templates, removing the `%WORKSPACE_SECTION%` placeholder injection.

- **Simplify `updateRuntimeMetaSnapshot`** to only include `run_id`, `current_workdir`, `startup_path`. Drop telemetry-only fields (`tokens_band`, `tool_output_pressure`, `compact_decision_signals`) that are not consumed by any decision path.
- **Inline Workspace section** into `prompt.md` / `orchestrator.md` directly, removing the `%WORKSPACE_SECTION%` placeholder replacement.
- **Remove dead code** exposed by the above: `noWorkspace` field + `SetNoWorkspace` + `SetWorkspaceNotes`, `buildToolOutputsSummary`, `toolOutputSummaryTypeLimit`.
- **Update tests** to match the simplified snapshot format.

## Context management impact: NONE ✅

Verified the full decision chain to confirm no decision-relevant information is lost:

| Stage | Decider | Information source | Reads runtime_state text? |
|-------|---------|--------------------|---------------------------|
| **WHEN** (trigger) | `ShouldCompact` (code) | `ContextMeta` struct via `estimateTokenPercent` | ❌ No |
| **HOW** (reshape) | context-mgmt LLM | `buildContextMgmtMessages` injects its own `<current_state>` block (tokens%, large outputs, savings, force_truncate_recommended) — all computed independently | ❌ No |

The dropped fields were telemetry shown only to the main agent, which is **not** the context-management decision maker and has no compact tool / proactive-compact path. No prompt instruction depends on these fields.

## Dead code note

`pkg/agent/runtime_meta.go` still contains some now-orphaned helpers (`collectRuntimeToolPressure`, a few bucket functions) that were left in place to avoid risky non-contiguous edits. They are harmless (unused) and can be cleaned in a follow-up.

## CI

All local checks green (verified with real exit codes):
- `make fmt-check` ✅
- `go build ./...` ✅
- `go vet ./...` ✅
- `make test` ✅ (exit 0)
- `make coverage-check` ✅ 82.3% ≥ 80%