### PR TITLE
feat: move skills from system prompt to user message injection

### DIFF
--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -99,6 +99,11 @@ type rpcApp struct {
 	// AGENTS.md is present. Mirrors the codex contextual_user_message pattern.
 	agentInstructions string
 
+	// Agent skills (loaded from ~/.ai/skills/ and .ai/skills/) injected as a
+	// user message before the first user message on each LLM call. Empty when
+	// no skills are loaded. Kept at the beginning for stable prefix caching.
+	agentSkills string
+
 	// --- RPC Server ---
 	server *rpc.Server
 
@@ -121,6 +126,7 @@ type rpcApp struct {
 	// These are assigned in initHelpers and used by handler closures.
 	buildSystemPrompt               func(currentSess *session.Session) string
 	buildAgentInstructions          func() string
+	buildAgentSkills                func() string
 	restoreLLMContextFromCompaction func(sess *session.Session)
 	createBaseContext               func() *agentctx.AgentContext
 	setAgentContext                 func(ctx *agentctx.AgentContext)
@@ -227,6 +233,15 @@ func (app *rpcApp) initHelpers() {
 		return promptBuilder.BuildInstructionsMessage()
 	}
 
+	// buildAgentSkills formats the loaded skills list as a user message
+	// wrapped in <agent:skills> tags. Returns empty when no skills are
+	// available or minimal mode is enabled.
+	app.buildAgentSkills = func() string {
+		promptBuilder := prompt.NewBuilderWithWorkspace("", app.ws)
+		promptBuilder.SetSkills(app.skillResult.Skills).SetSkillStats(app.skillStats)
+		return promptBuilder.BuildSkillsMessage()
+	}
+
 	// restoreLLMContextFromCompaction restores the llm context overview.md
 	// from the latest compaction summary on the current session branch.
 	app.restoreLLMContextFromCompaction = func(sess *session.Session) {
@@ -254,10 +269,12 @@ func (app *rpcApp) initHelpers() {
 	app.createBaseContext = func() *agentctx.AgentContext {
 		app.systemPrompt = app.buildSystemPrompt(app.sess)
 		app.agentInstructions = app.buildAgentInstructions()
+		app.agentSkills = app.buildAgentSkills()
 		// Keep loopCfg in sync if it has been constructed (createBaseContext
 		// may be re-invoked on session resume while loopCfg already exists).
 		if app.loopCfg != nil {
 			app.loopCfg.AgentInstructions = app.agentInstructions
+			app.loopCfg.AgentSkills = app.agentSkills
 		}
 		ctx := agentctx.NewAgentContext(app.systemPrompt)
 		for _, tool := range app.registry.All() {

--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -81,6 +81,7 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	loopCfg.GetStartupPath = app.ws.GetInitialCWD
 	loopCfg.RunID = app.runID
 	loopCfg.AgentInstructions = app.agentInstructions
+	loopCfg.AgentSkills = app.agentSkills
 	loopCfg.GetSessionDir = func() string {
 		if app.sess != nil {
 			return app.sess.GetDir()

--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -82,6 +82,21 @@ func streamAssistantResponse(
 		}
 	}
 
+	// Inject skills as a user message before the first user message.
+	// This keeps the system prompt + skills prefix stable across turns for
+	// provider prefix caching. Skills are ephemeral — re-injected on every
+	// LLM call from LoopConfig, not persisted in RecentMessages.
+	//
+	// Ordering rationale:
+	//   [system_prompt, <agent:skills>, user1, asst1, ..., <agent:instructions>, <agent:runtime_state>, user_input]
+	if strings.TrimSpace(config.AgentSkills) != "" {
+		skillsMsg := llm.LLMMessage{
+			Role:    "user",
+			Content: config.AgentSkills,
+		}
+		llmMessages = insertBeforeFirstUserMessage(llmMessages, skillsMsg)
+	}
+
 	// Inject project-level agent instructions (e.g. AGENTS.md) as an ephemeral
 	// user message just before the last user input. This content is NOT persisted
 	// to RecentMessages — it is re-injected on every LLM call so the LLM always
@@ -441,5 +456,38 @@ func insertBeforeLastUserMessage(messages []llm.LLMMessage, msg llm.LLMMessage) 
 	result = append(result, messages[:lastUserIdx]...)
 	result = append(result, msg)
 	result = append(result, messages[lastUserIdx:]...)
+	return result
+}
+
+// insertBeforeFirstUserMessage inserts msg immediately before the first user-role
+// message. Used for skills injection to keep the system prompt + skills prefix
+// stable across turns for provider prefix caching.
+func insertBeforeFirstUserMessage(messages []llm.LLMMessage, msg llm.LLMMessage) []llm.LLMMessage {
+	if len(messages) == 0 {
+		return []llm.LLMMessage{msg}
+	}
+
+	// Find the first user message index
+	firstUserIdx := -1
+	for i := 0; i < len(messages); i++ {
+		if messages[i].Role == "user" {
+			firstUserIdx = i
+			break
+		}
+	}
+
+	// If no user message found, prepend to beginning
+	if firstUserIdx == -1 {
+		result := make([]llm.LLMMessage, 0, len(messages)+1)
+		result = append(result, msg)
+		result = append(result, messages...)
+		return result
+	}
+
+	// Insert before the first user message
+	result := make([]llm.LLMMessage, 0, len(messages)+1)
+	result = append(result, messages[:firstUserIdx]...)
+	result = append(result, msg)
+	result = append(result, messages[firstUserIdx:]...)
 	return result
 }

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -85,6 +85,11 @@ type LoopConfig struct {
 	// This mirrors the codex contextual_user_message pattern, keeping the system
 	// prompt stable for caching while still providing project context per turn.
 	AgentInstructions string
+	// AgentSkills is the skills list wrapped in <agent:skills> tags, injected as
+	// a user message before the first user message on each LLM call. Empty means
+	// no injection. Placing skills at the beginning of the conversation keeps the
+	// system prompt + skills prefix stable for provider prefix caching.
+	AgentSkills string
 }
 
 // getEffectiveModel returns the current model, using GetModel callback if available.

--- a/pkg/agent/runtime_meta_test.go
+++ b/pkg/agent/runtime_meta_test.go
@@ -264,6 +264,88 @@ func TestInsertBeforeLastUserMessage(t *testing.T) {
 	}
 }
 
+func TestInsertBeforeFirstUserMessage(t *testing.T) {
+	cases := []struct {
+		name     string
+		messages []llm.LLMMessage
+		insert   llm.LLMMessage
+		wantLen  int
+		check    func([]llm.LLMMessage) bool
+	}{
+		{
+			name:     "empty messages",
+			messages: nil,
+			insert:   llm.LLMMessage{Role: "user", Content: "skills"},
+			wantLen:  1,
+			check: func(msgs []llm.LLMMessage) bool {
+				return len(msgs) == 1 && msgs[0].Content == "skills"
+			},
+		},
+		{
+			name: "no user message - prepend to beginning",
+			messages: []llm.LLMMessage{
+				{Role: "assistant", Content: "hi"},
+			},
+			insert:  llm.LLMMessage{Role: "user", Content: "skills"},
+			wantLen: 2,
+			check: func(msgs []llm.LLMMessage) bool {
+				return msgs[0].Content == "skills" && msgs[1].Content == "hi"
+			},
+		},
+		{
+			name: "single user message - insert before",
+			messages: []llm.LLMMessage{
+				{Role: "user", Content: "hello"},
+			},
+			insert:  llm.LLMMessage{Role: "user", Content: "skills"},
+			wantLen: 2,
+			check: func(msgs []llm.LLMMessage) bool {
+				return msgs[0].Content == "skills" && msgs[1].Content == "hello"
+			},
+		},
+		{
+			name: "multiple messages - insert before first user",
+			messages: []llm.LLMMessage{
+				{Role: "user", Content: "first"},
+				{Role: "assistant", Content: "response"},
+				{Role: "user", Content: "last"},
+			},
+			insert:  llm.LLMMessage{Role: "user", Content: "skills"},
+			wantLen: 4,
+			check: func(msgs []llm.LLMMessage) bool {
+				// skills should be at index 0, before "first" at index 1
+				return msgs[0].Content == "skills" && msgs[1].Content == "first"
+			},
+		},
+		{
+			name: "tool results before user - insert before user",
+			messages: []llm.LLMMessage{
+				{Role: "assistant", Content: ""},
+				{Role: "toolResult", Content: "output"},
+				{Role: "user", Content: "request"},
+			},
+			insert:  llm.LLMMessage{Role: "user", Content: "skills"},
+			wantLen: 4,
+			check: func(msgs []llm.LLMMessage) bool {
+				// skills before "request"
+				return msgs[2].Content == "skills" && msgs[3].Content == "request"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := insertBeforeFirstUserMessage(tc.messages, tc.insert)
+			if len(result) != tc.wantLen {
+				t.Fatalf("expected %d messages, got %d", tc.wantLen, len(result))
+			}
+			if !tc.check(result) {
+				t.Fatalf("check failed for messages: %+v", result)
+			}
+		})
+	}
+}
+
 func TestCollectStaleToolOutputStatsProtectsTaskTracking(t *testing.T) {
 	// Create messages with multiple task_tracking calls
 	msgs := []agentctx.AgentMessage{

--- a/pkg/prompt/builder.go
+++ b/pkg/prompt/builder.go
@@ -167,21 +167,34 @@ func (b *Builder) SetTokensPercent(pct float64) *Builder {
 	return b
 }
 
-// Build builds final system prompt by replacing placeholders in the template.
+// BuildSkillsMessage formats the skills list as a user message wrapped in
+// <agent:skills> tags, ready for injection as a user message before the
+// last user input on each LLM call. Returns empty string when no skills
+// are available or minimal mode is enabled.
+//
+// This replaces the former %SKILLS% placeholder in the system prompt template.
+// Skills are now injected per-LLM-call as a user-role message (similar to
+// AgentInstructions), keeping the system prompt stable for caching while still
+// providing skill context on every turn.
+func (b *Builder) BuildSkillsMessage() string {
+	if b.minimal || len(b.skills) == 0 {
+		return ""
+	}
+	skillsText := skill.FormatForPrompt(b.skills, b.skillStats)
+	if skillsText == "" {
+		return ""
+	}
+	return fmt.Sprintf("<agent:skills>\n%s\n</agent:skills>", skillsText)
+}
+
+// Build builds final system prompt from the template.
+// Skills are no longer included here — use BuildSkillsMessage() to get the
+// skills content for per-LLM-call user message injection.
 func (b *Builder) Build() string {
 	result := promptTemplate
 	if b.template != "" {
 		result = b.template
 	}
-
-	// Replace skills (optional section)
-	skills := ""
-	if !b.minimal && len(b.skills) > 0 {
-		if skillsText := skill.FormatForPrompt(b.skills, b.skillStats); skillsText != "" {
-			skills = skillsText
-		}
-	}
-	result = strings.ReplaceAll(result, "%SKILLS%", skills)
 
 	// Remove empty sections (optional sections that were not enabled)
 	result = b.cleanupEmptySections(result)

--- a/pkg/prompt/builder_test.go
+++ b/pkg/prompt/builder_test.go
@@ -78,14 +78,19 @@ func TestBuilderWithSkills(t *testing.T) {
 
 	b := NewBuilder("", cwd)
 	b.SetSkills(skills)
-	result := b.Build()
 
-	if !contains(result, "## Skills") {
-		t.Error("Skills section missing")
+	// Skills are now in BuildSkillsMessage(), not Build()
+	result := b.Build()
+	if contains(result, "## Skills") {
+		t.Error("Skills section should not appear in Build() output (moved to BuildSkillsMessage)")
 	}
 
-	if !contains(result, "A test skill") {
-		t.Error("Skill description missing")
+	skillsMsg := b.BuildSkillsMessage()
+	if !contains(skillsMsg, "agent:skills") {
+		t.Error("agent:skills wrapper missing from BuildSkillsMessage()")
+	}
+	if !contains(skillsMsg, "A test skill") {
+		t.Error("Skill description missing from BuildSkillsMessage()")
 	}
 }
 
@@ -103,9 +108,10 @@ func TestBuilderMinimalMode(t *testing.T) {
 	b.SetTools(tools).SetSkills(skills).SetMinimal(true)
 	result := b.Build()
 
-	// In minimal mode, skills should be excluded
-	if contains(result, "## Skills") {
-		t.Error("Skills section should not appear in minimal mode")
+	// In minimal mode, skills should be excluded from BuildSkillsMessage too
+	skillsMsg := b.BuildSkillsMessage()
+	if skillsMsg != "" {
+		t.Error("BuildSkillsMessage should return empty in minimal mode")
 	}
 
 	// But tools and workspace should still be there
@@ -127,15 +133,15 @@ func TestBuilderSkillsRendering(t *testing.T) {
 
 	b := NewBuilder("", cwd)
 	b.SetSkills(skills)
-	result := b.Build()
+	skillsMsg := b.BuildSkillsMessage()
 
-	if !contains(result, "## Skills") {
-		t.Error("skills header missing")
+	if !contains(skillsMsg, "agent:skills") {
+		t.Error("agent:skills wrapper missing")
 	}
-	if !contains(result, "- **wf-issue**: issue workflow") {
+	if !contains(skillsMsg, "- **wf-issue**: issue workflow") {
 		t.Error("full skill entry missing")
 	}
-	if !contains(result, "- **subagent**: subagent workflow") {
+	if !contains(skillsMsg, "- **subagent**: subagent workflow") {
 		t.Error("full skill entry missing")
 	}
 }
@@ -330,10 +336,10 @@ func TestBuilderWithSkillStats(t *testing.T) {
 	b := NewBuilder("", cwd)
 	b.SetSkills(skills)
 	b.SetSkillStats(stats)
-	result := b.Build()
+	skillsMsg := b.BuildSkillsMessage()
 
-	if !contains(result, "## Skills") {
-		t.Error("Skills section missing")
+	if !contains(skillsMsg, "agent:skills") {
+		t.Error("agent:skills wrapper missing")
 	}
 
 	// With TopN=2 and "popular" ranked highest, "medium" should not appear
@@ -341,15 +347,15 @@ func TestBuilderWithSkillStats(t *testing.T) {
 	// Actually, let's check: popular (ranked), unpopular (ranked) → top 2 from stats.
 	// "medium" has no stats → it gets added as unranked supplement only if room.
 	// TopN=2, ranked=2 → selected has 2 → medium is excluded.
-	if !contains(result, "**popular**") {
+	if !contains(skillsMsg, "**popular**") {
 		t.Error("popular skill should appear")
 	}
-	if contains(result, "**medium**") {
+	if contains(skillsMsg, "**medium**") {
 		t.Error("medium skill should be filtered out (TopN=2, not in top entries)")
 	}
 
 	// Stats present → should include find_skill hint
-	if !contains(result, "find_skill") {
+	if !contains(skillsMsg, "find_skill") {
 		t.Error("find_skill hint should appear when stats are set")
 	}
 }
@@ -364,16 +370,16 @@ func TestBuilderWithSkillStatsNil(t *testing.T) {
 	b := NewBuilder("", cwd)
 	b.SetSkills(skills)
 	// SetSkillStats not called → skillStats is nil → backward compat
-	result := b.Build()
+	skillsMsg := b.BuildSkillsMessage()
 
-	if !contains(result, "## Skills") {
-		t.Error("Skills section missing")
+	if !contains(skillsMsg, "agent:skills") {
+		t.Error("agent:skills wrapper missing")
 	}
-	if !contains(result, "A test skill") {
+	if !contains(skillsMsg, "A test skill") {
 		t.Error("Skill description missing")
 	}
 	// No stats → should NOT show find_skill hint
-	if contains(result, "find_skill") {
+	if contains(skillsMsg, "find_skill") {
 		t.Error("find_skill hint should not appear when stats are nil")
 	}
 }

--- a/pkg/prompt/orchestrator.md
+++ b/pkg/prompt/orchestrator.md
@@ -47,7 +47,10 @@ When a generator's output fails validation or a sub-agent returns an error:
 3. **Do not silently retry the same task unchanged** — each retry must carry additional context from the previous failure, otherwise the sub-agent will repeat the same mistake.
 4. **Escalate to user** after 2 consecutive failures on the same task, or when the failure is clearly out-of-scope (e.g. missing credentials, external service down).
 
-%WORKSPACE_SECTION%
+## Workspace
+
+Use current_workdir from runtime_state, not a hardcoded path.
+Use `change_workspace` tool for persistent directory switches; "cd <dir> && <command>" for one-off commands.
 
 ## Tools
 
@@ -73,5 +76,3 @@ When a generator's output fails validation or a sub-agent returns an error:
 - **`bash | grep` for source code search:** Use the `grep` tool instead. Only use `bash | grep` for log files, `/tmp/` files, or pipe intermediates.
 - **Compound bash commands:** Each `bash` call should do one thing. For multi-step workflows, split into separate calls or write intermediate results to temp files.
 - **Blind file reads:** Never `read` an entire file blindly. Use `grep` to locate relevant sections first, then `read` with `offset`/`limit`.
-
-%SKILLS%

--- a/pkg/prompt/prompt.md
+++ b/pkg/prompt/prompt.md
@@ -98,5 +98,3 @@ Use `change_workspace` tool for persistent directory switches; "cd <dir> && <com
 - **`bash | grep` for source code search:** Use the `grep` tool instead — it provides structured output, `context` lines, `filePattern` filtering. Only use `bash | grep` for log files, `/tmp/` files, or pipe intermediates.
 - **Compound bash commands:** Each `bash` call should do one thing. For multi-step workflows, split into separate calls or write intermediate results to temp files.
 - **Blind file reads:** Never `read` an entire file blindly. Use `grep` to locate relevant sections first, then `read` with `offset`/`limit`.
-
-%SKILLS%

--- a/pkg/prompt/system_test.go
+++ b/pkg/prompt/system_test.go
@@ -66,7 +66,11 @@ func TestPromptABMetricsSmoke(t *testing.T) {
 	if oldTokens <= 0 || newTokens <= 0 {
 		t.Fatalf("expected positive token estimates, old=%d new=%d", oldTokens, newTokens)
 	}
-	if !strings.Contains(newPrompt, "- **skill-00**:") {
-		t.Fatalf("expected full skill entries in prompt, got: %s", newPrompt)
+	// Skills are no longer in Build() output — they are injected separately via
+	// BuildSkillsMessage() as a user message before the first user input.
+	// Verify skills are available via BuildSkillsMessage instead.
+	skillsMsg := NewBuilder(newRPCBasePrompt, "/workspace").SetTools(tools).SetSkills(skills).BuildSkillsMessage()
+	if !strings.Contains(skillsMsg, "- **skill-00**:") {
+		t.Fatalf("expected full skill entries in skills message, got: %s", skillsMsg)
 	}
 }


### PR DESCRIPTION
## Summary

Move skills out of the system prompt template (`%SKILLS%` placeholder) and inject them as a `role:user` message before the first user message on each LLM call, wrapped in `<agent:skills>` tags.

## Motivation

- **Prefix caching**: The system prompt + skills prefix stays stable across turns, improving provider prefix cache hit rates
- **Consistency**: Follows the same pattern as `agent:instructions` and `agent:runtime_state` — ephemeral injection from `LoopConfig`, not baked into the system prompt
- **Compaction safety**: Skills are re-injected on every LLM call, so compaction cannot lose them

## Message Order

```
[system_prompt, <agent:skills>, user1, asst1, ..., <agent:instructions>, <agent:runtime_state>, last_user]
```

## Changes

| File | Change |
|------|--------|
| `pkg/agent/loop.go` | Add `AgentSkills` field to `LoopConfig` |
| `pkg/agent/llm_stream.go` | Add `insertBeforeFirstUserMessage()`, inject skills before first user message |
| `pkg/agent/runtime_meta_test.go` | Add tests for `insertBeforeFirstUserMessage` |
| `pkg/prompt/builder.go` | `BuildSkillsMessage()` wraps in `<agent:skills>` tags, `Build()` no longer includes skills |
| `pkg/prompt/prompt.md` | Remove `%SKILLS%` placeholder |
| `cmd/ai/rpc_app.go` | Add `agentSkills` field, `buildAgentSkills` helper, wire into `createBaseContext` |
| `cmd/ai/rpc_handlers.go` | Pass `AgentSkills` to `loopCfg` |
| Test files | Update all tests to use `BuildSkillsMessage()` |

## Test Plan

- [x] `go test ./pkg/agent/ -v` — all pass
- [x] `go test ./pkg/prompt/ -v` — all pass  
- [x] `go test ./pkg/compact/ -v` — all pass
- [x] `go test ./pkg/skill/ -v` — all pass
- [x] `go build ./...` — clean build
- [x] `make fmt` — formatted