### PR TITLE
refactor: merge skills+instructions into single prefix user message

### DIFF
--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -94,15 +94,10 @@ type rpcApp struct {
 	// --- System prompt ---
 	systemPrompt string
 
-	// Agent instructions (project-level, e.g. AGENTS.md) injected as a user
-	// message before the last user input on each LLM call. Empty when no
-	// AGENTS.md is present. Mirrors the codex contextual_user_message pattern.
-	agentInstructions string
-
-	// Agent skills (loaded from ~/.ai/skills/ and .ai/skills/) injected as a
-	// user message before the first user message on each LLM call. Empty when
-	// no skills are loaded. Kept at the beginning for stable prefix caching.
-	agentSkills string
+	// Agent context prefix combines skills + AGENTS.md into a single user message
+	// injected before the first user message on each LLM call. Empty when neither
+	// is available. Merged into one message for maximum prefix cache stability.
+	agentContextPrefix string
 
 	// --- RPC Server ---
 	server *rpc.Server
@@ -125,8 +120,7 @@ type rpcApp struct {
 	// --- Internal helper functions ---
 	// These are assigned in initHelpers and used by handler closures.
 	buildSystemPrompt               func(currentSess *session.Session) string
-	buildAgentInstructions          func() string
-	buildAgentSkills                func() string
+	buildAgentContextPrefix         func() string
 	restoreLLMContextFromCompaction func(sess *session.Session)
 	createBaseContext               func() *agentctx.AgentContext
 	setAgentContext                 func(ctx *agentctx.AgentContext)
@@ -219,27 +213,31 @@ func (app *rpcApp) initHelpers() {
 		return promptBuilder.Build()
 	}
 
-	// buildAgentInstructions loads AGENTS.md from the workspace and wraps it
-	// in <agent:instructions> tags. Returns empty when no AGENTS.md is present.
-	//
-	// AGENTS.md is injected as a user message (see llm_stream.go), independent
-	// of the system prompt source. Custom system prompts (including role
-	// templates like orchestrator.md) and agent configs define role behavior,
-	// not project facts — so AGENTS.md is still relevant and is injected in
-	// all modes. If a workspace really wants to suppress AGENTS.md injection,
-	// delete/rename the AGENTS.md file.
-	app.buildAgentInstructions = func() string {
-		promptBuilder := prompt.NewBuilderWithWorkspace("", app.ws)
-		return promptBuilder.BuildInstructionsMessage()
-	}
+	// buildAgentContextPrefix combines skills and AGENTS.md into a single
+	// user message for prefix cache stability. Skills are wrapped in
+	// <agent:skills> tags, instructions in <agent:instructions> tags.
+	// Returns empty when neither is available.
+	app.buildAgentContextPrefix = func() string {
+		var parts []string
 
-	// buildAgentSkills formats the loaded skills list as a user message
-	// wrapped in <agent:skills> tags. Returns empty when no skills are
-	// available or minimal mode is enabled.
-	app.buildAgentSkills = func() string {
 		promptBuilder := prompt.NewBuilderWithWorkspace("", app.ws)
-		promptBuilder.SetSkills(app.skillResult.Skills).SetSkillStats(app.skillStats)
-		return promptBuilder.BuildSkillsMessage()
+
+		// Skills section
+		promptBuilderForSkills := prompt.NewBuilderWithWorkspace("", app.ws)
+		promptBuilderForSkills.SetSkills(app.skillResult.Skills).SetSkillStats(app.skillStats)
+		if skills := promptBuilderForSkills.BuildSkillsMessage(); skills != "" {
+			parts = append(parts, skills)
+		}
+
+		// Instructions section (AGENTS.md)
+		if instructions := promptBuilder.BuildInstructionsMessage(); instructions != "" {
+			parts = append(parts, instructions)
+		}
+
+		if len(parts) == 0 {
+			return ""
+		}
+		return strings.Join(parts, "\n\n")
 	}
 
 	// restoreLLMContextFromCompaction restores the llm context overview.md
@@ -268,13 +266,11 @@ func (app *rpcApp) initHelpers() {
 	// createBaseContext creates a new agent context from the current session.
 	app.createBaseContext = func() *agentctx.AgentContext {
 		app.systemPrompt = app.buildSystemPrompt(app.sess)
-		app.agentInstructions = app.buildAgentInstructions()
-		app.agentSkills = app.buildAgentSkills()
+		app.agentContextPrefix = app.buildAgentContextPrefix()
 		// Keep loopCfg in sync if it has been constructed (createBaseContext
 		// may be re-invoked on session resume while loopCfg already exists).
 		if app.loopCfg != nil {
-			app.loopCfg.AgentInstructions = app.agentInstructions
-			app.loopCfg.AgentSkills = app.agentSkills
+			app.loopCfg.AgentContextPrefix = app.agentContextPrefix
 		}
 		ctx := agentctx.NewAgentContext(app.systemPrompt)
 		for _, tool := range app.registry.All() {

--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -80,8 +80,7 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	loopCfg.GetWorkingDir = app.ws.GetCWD
 	loopCfg.GetStartupPath = app.ws.GetInitialCWD
 	loopCfg.RunID = app.runID
-	loopCfg.AgentInstructions = app.agentInstructions
-	loopCfg.AgentSkills = app.agentSkills
+	loopCfg.AgentContextPrefix = app.agentContextPrefix
 	loopCfg.GetSessionDir = func() string {
 		if app.sess != nil {
 			return app.sess.GetDir()

--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -82,37 +82,25 @@ func streamAssistantResponse(
 		}
 	}
 
-	// Inject skills as a user message before the first user message.
-	// This keeps the system prompt + skills prefix stable across turns for
-	// provider prefix caching. Skills are ephemeral — re-injected on every
-	// LLM call from LoopConfig, not persisted in RecentMessages.
+	// Inject skills + instructions as a single user message before the first
+	// user message. Both are stable within a session (skills rarely change,
+	// instructions are AGENTS.md content), so merging them into one message
+	// and placing them in the prefix maximizes provider prefix cache hits.
 	//
-	// Ordering rationale:
-	//   [system_prompt, <agent:skills>, user1, asst1, ..., <agent:instructions>, <agent:runtime_state>, user_input]
-	if strings.TrimSpace(config.AgentSkills) != "" {
-		skillsMsg := llm.LLMMessage{
-			Role:    "user",
-			Content: config.AgentSkills,
-		}
-		llmMessages = insertBeforeFirstUserMessage(llmMessages, skillsMsg)
-	}
-
-	// Inject project-level agent instructions (e.g. AGENTS.md) as an ephemeral
-	// user message just before the last user input. This content is NOT persisted
-	// to RecentMessages — it is re-injected on every LLM call so the LLM always
-	// sees fresh instructions without bloating session history.
+	// They are NOT persisted to RecentMessages — re-injected on every LLM call.
 	//
-	// Ordering rationale (after runtime_state handling):
-	//   - ephemeral mode:   [..., <agent:instructions>, <agent:runtime_state>, user_input]
-	//     (instructions placed first because it is the most stable context)
-	//   - persist mode:     [..., user_input, <agent:instructions>, <agent:runtime_state>]
-	//     (suboptimal but functionally correct; cache-first is a niche optimization)
-	if strings.TrimSpace(config.AgentInstructions) != "" {
-		instrMsg := llm.LLMMessage{
+	// Final ordering:
+	//   [system_prompt, <skills+instructions>, user1, asst1, ..., <runtime_state>, user_input]
+	//
+	// runtime_state is injected separately below (before last user) because it
+	// can change when the user calls change_workspace, and we don't want it to
+	// break the stable prefix cache.
+	if config.AgentContextPrefix != "" {
+		prefixMsg := llm.LLMMessage{
 			Role:    "user",
-			Content: config.AgentInstructions,
+			Content: config.AgentContextPrefix,
 		}
-		llmMessages = insertBeforeLastUserMessage(llmMessages, instrMsg)
+		llmMessages = insertBeforeFirstUserMessage(llmMessages, prefixMsg)
 	}
 
 	// Convert tools to LLM format

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -79,17 +79,12 @@ type LoopConfig struct {
 	// CacheMode controls how runtime_state telemetry is managed.
 	// CacheModeAuto (default) auto-detects from model name.
 	CacheMode CacheMode
-	// AgentInstructions is the project-level instructions (e.g. AGENTS.md content
-	// wrapped in <agent:instructions> tags) injected as a user message before the
-	// last user input on each LLM call. Empty means no injection.
-	// This mirrors the codex contextual_user_message pattern, keeping the system
-	// prompt stable for caching while still providing project context per turn.
-	AgentInstructions string
-	// AgentSkills is the skills list wrapped in <agent:skills> tags, injected as
-	// a user message before the first user message on each LLM call. Empty means
-	// no injection. Placing skills at the beginning of the conversation keeps the
-	// system prompt + skills prefix stable for provider prefix caching.
-	AgentSkills string
+	// AgentContextPrefix combines skills and project-level instructions (AGENTS.md)
+	// into a single user message injected before the first user message on each LLM call.
+	// Empty means no injection.
+	// Merging into one message and placing it in the prefix maximizes provider
+	// prefix cache hits — both skills and instructions are stable within a session.
+	AgentContextPrefix string
 }
 
 // getEffectiveModel returns the current model, using GetModel callback if available.


### PR DESCRIPTION

## Summary

Merge `AgentSkills` and `AgentInstructions` into a single `AgentContextPrefix` field, injected as one user message before the first user message.

## Message structure change

```
Before: [sys, skills_user, user1, asst1, ..., instr_user, runtime_user, user_input]
After:  [sys, prefix_user(skills+instr), user1, asst1, ..., runtime_user, user_input]
```

## Why

- **skills + instructions are stable within a session** (skills rarely change, instructions = AGENTS.md content). Placing them in the prefix maximizes provider prefix cache hits across turns.
- **runtime_state stays at the tail** (before last user) since `current_workdir` can change on `change_workspace` — this isolates cache invalidation to a small tail without breaking the stable prefix.
- **Reduces consecutive role:user messages** in the prefix from 3 to 1.
- **Simplifies LoopConfig** from 2 fields (`AgentSkills` + `AgentInstructions`) to 1 (`AgentContextPrefix`).

## Data backing the design

Analyzed 3,377 sessions: `change_workspace` was called in only 53 sessions (1.57%), confirming runtime_state rarely changes.

## Files changed

| File | Change |
|------|--------|
| `pkg/agent/loop.go` | `AgentInstructions` + `AgentSkills` → `AgentContextPrefix` |
| `pkg/agent/llm_stream.go` | Two injections → one prefix injection |
| `cmd/ai/rpc_app.go` | Two build funcs → `buildAgentContextPrefix` |
| `cmd/ai/rpc_handlers.go` | Two assignments → one |
