### PR TITLE
fix: /fork and /rewind index resolution uses agent messages

### DIFF
--- a/cmd/ai/rpc_session_handlers.go
+++ b/cmd/ai/rpc_session_handlers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/rpc"
 	"github.com/tiancaiamao/ai/pkg/session"
 	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
@@ -163,9 +164,17 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 		return nil, fmt.Errorf("agent is busy")
 	}
 
+	// Lazy loading may not have all entries in byID (e.g., pre-compaction).
+	// Ensure the full session is loaded before resolving indices.
+	if entryID != "root" {
+		if err := app.sess.EnsureFullyLoaded(); err != nil {
+			return nil, err
+		}
+	}
+
 	// Resolve index-based reference (e.g. "/rewind 5" → message at index 5 in /messages).
 	if entryID != "root" {
-		if resolved, ok := resolveMessageIndex(app.sess, entryID); ok {
+		if resolved, ok := resolveMessageIndex(app.ag, app.sess, entryID); ok {
 			entryID = resolved
 		}
 	}
@@ -173,11 +182,6 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 	if entryID == "root" {
 		app.sess.ResetLeaf()
 	} else {
-		// Lazy loading may not have all entries in byID (e.g., pre-compaction).
-		// Ensure the full session is loaded so Branch can find the entry.
-		if err := app.sess.EnsureFullyLoaded(); err != nil {
-			return nil, err
-		}
 		if err := app.sess.Branch(entryID); err != nil {
 			return nil, err
 		}
@@ -192,27 +196,40 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 	return map[string]any{"switched": true, "entryId": entryID}, nil
 }
 
+// messageIndexResolver provides the messages needed for index resolution.
+type messageIndexResolver interface {
+	GetMessages() []agentctx.AgentMessage
+}
+
 // resolveMessageIndex maps a numeric string (from /messages index) to the corresponding
-// session entry ID. Uses GetBranch (same path as /messages) and counts only EntryTypeMessage
-// entries, which is the same set /messages shows (compaction/branch_summary messages are
-// generated dynamically and have no rewind target).
-func resolveMessageIndex(sess *session.Session, arg string) (string, bool) {
+// session entry ID. Uses the agent's message list (same source as /messages) so indices
+// are consistent regardless of compaction or resume state.
+func resolveMessageIndex(ag messageIndexResolver, sess *session.Session, arg string) (string, bool) {
 	idx, err := strconv.Atoi(arg)
 	if err != nil {
 		return "", false // not a number — caller should treat as entryId string
 	}
+	messages := ag.GetMessages()
+	if idx < 0 || idx >= len(messages) {
+		return "", false
+	}
+	msg := messages[idx]
+	// If the message has an entryId (from buildSessionContext), use it directly.
+	if msg.EntryID != "" {
+		return msg.EntryID, true
+	}
+	// Fallback: search session entries for a matching message by timestamp.
+	// This handles cases where the agent loaded messages from a checkpoint
+	// that doesn't carry entry IDs.
 	branch := sess.GetBranch("")
-	msgIdx := 0
 	for _, entry := range branch {
-		if entry.Type != session.EntryTypeMessage {
+		if entry.Type != session.EntryTypeMessage || entry.Message == nil {
 			continue
 		}
-		if msgIdx == idx {
+		if entry.Message.Role == msg.Role && entry.Message.Timestamp == msg.Timestamp && msg.Timestamp != 0 {
 			return entry.ID, true
 		}
-		msgIdx++
 	}
-	// Index out of range — return empty so caller falls through to entryId lookup.
 	return "", false
 }
 
@@ -224,12 +241,22 @@ func (app *rpcApp) handleFork(args string) (any, error) {
 	if app.parseJSONArgs(args, &jsonData) && jsonData.EntryID != "" {
 		entryID = jsonData.EntryID
 	}
-	slog.Info("Received fork: entryId=", "value", entryID)
+
+	if entryID == "" {
+		return nil, fmt.Errorf("usage: /fork <index|entryId>  (use /messages to see indices)")
+	}
+
 	// Lazy loading may not have all entries in byID (e.g., pre-compaction).
-	// Ensure the full session is loaded so GetEntry can find the entry.
+	// Ensure the full session is loaded before resolving indices.
 	if err := app.sess.EnsureFullyLoaded(); err != nil {
 		return nil, err
 	}
+
+	// Resolve index-based reference (e.g. "/fork 5" → message at index 5 in /messages).
+	if resolved, ok := resolveMessageIndex(app.ag, app.sess, entryID); ok {
+		entryID = resolved
+	}
+
 	entry, ok := app.sess.GetEntry(entryID)
 	if !ok || entry.Type != session.EntryTypeMessage || entry.Message == nil || entry.Message.Role != "user" {
 		return nil, fmt.Errorf("invalid entryId: %s", entryID)

--- a/cmd/ai/rpc_session_handlers_test.go
+++ b/cmd/ai/rpc_session_handlers_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/session"
+)
+
+// mockAgent implements messageIndexResolver for testing.
+type mockAgent struct {
+	messages []agentctx.AgentMessage
+}
+
+func (m *mockAgent) GetMessages() []agentctx.AgentMessage {
+	return m.messages
+}
+
+// TestResolveMessageIndex_EntryIDFromMessages tests that resolveMessageIndex
+// correctly maps a /messages index to a session entry ID when the agent's
+// messages carry EntryID (set by buildSessionContext).
+func TestResolveMessageIndex_EntryIDFromMessages(t *testing.T) {
+	sess := session.NewSession("")
+	// Build agent messages with EntryID set (simulating buildSessionContext output)
+	messages := []agentctx.AgentMessage{
+		{Role: "user", EntryID: "aaa", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "hello"}}},
+		{Role: "assistant", EntryID: "bbb", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "hi"}}},
+		{Role: "user", EntryID: "ccc", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "how are you"}}},
+	}
+
+	ag := &mockAgent{messages: messages}
+
+	// Resolve index 0 → "aaa"
+	if id, ok := resolveMessageIndex(ag, sess, "0"); !ok || id != "aaa" {
+		t.Errorf("expected (aaa, true), got (%q, %v)", id, ok)
+	}
+	// Resolve index 2 → "ccc"
+	if id, ok := resolveMessageIndex(ag, sess, "2"); !ok || id != "ccc" {
+		t.Errorf("expected (ccc, true), got (%q, %v)", id, ok)
+	}
+	// Out of range
+	if _, ok := resolveMessageIndex(ag, sess, "5"); ok {
+		t.Error("expected false for out-of-range index")
+	}
+	// Non-numeric passthrough
+	if _, ok := resolveMessageIndex(ag, sess, "someEntryId"); ok {
+		t.Error("expected false for non-numeric arg")
+	}
+}
+
+// TestResolveMessageIndex_TimestampFallback tests that resolveMessageIndex
+// falls back to timestamp+role matching when agent messages don't have EntryID.
+// This is the scenario that was previously broken: agent loads messages from
+// checkpoint (no EntryID), but /messages shows indices based on those messages.
+func TestResolveMessageIndex_TimestampFallback(t *testing.T) {
+	sess := session.NewSession("")
+
+	// Manually set unique timestamps to avoid same-millisecond collisions
+	msg1 := agentctx.NewUserMessage("hello")
+	msg1.Timestamp = 1000
+	id1, _ := sess.AppendMessage(msg1)
+
+	msg2 := agentctx.AgentMessage{
+		Role:      "assistant",
+		Content:   []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "hi"}},
+		Timestamp: 2000,
+	}
+	sess.AppendMessage(msg2)
+
+	msg3 := agentctx.NewUserMessage("how are you")
+	msg3.Timestamp = 3000
+	id3, _ := sess.AppendMessage(msg3)
+
+	// Get session messages — these have EntryID set
+	sessMsgs := sess.GetMessages()
+
+	// Build agent messages WITHOUT EntryID (simulating checkpoint resume)
+	agentMsgs := make([]agentctx.AgentMessage, len(sessMsgs))
+	for i, m := range sessMsgs {
+		cp := m
+		cp.EntryID = "" // Simulate checkpoint that doesn't preserve EntryID
+		agentMsgs[i] = cp
+	}
+
+	ag := &mockAgent{messages: agentMsgs}
+
+	// Resolve index 0 → should find id1 via timestamp fallback
+	if id, ok := resolveMessageIndex(ag, sess, "0"); !ok || id != id1 {
+		t.Errorf("expected (%q, true), got (%q, %v)", id1, id, ok)
+	}
+	// Resolve index 2 → should find id3 via timestamp fallback
+	if id, ok := resolveMessageIndex(ag, sess, "2"); !ok || id != id3 {
+		t.Errorf("expected (%q, true), got (%q, %v)", id3, id, ok)
+	}
+}
+
+// TestResolveMessageIndex_CompactionIndexMismatch demonstrates the old bug:
+// the old resolveMessageIndex used sess.GetBranch("") and counted entries,
+// but /messages uses ag.GetMessages() — after compaction/resume these differ.
+// With the fix, the function uses ag.GetMessages() so indices match.
+func TestResolveMessageIndex_CompactionIndexMismatch(t *testing.T) {
+	sess := session.NewSession("")
+
+	// Add 10 messages (5 user + 5 assistant pairs) with unique timestamps
+	ts := int64(1000)
+	for i := 0; i < 5; i++ {
+		msg := agentctx.NewUserMessage("msg")
+		msg.Timestamp = ts
+		ts += 100
+		sess.AppendMessage(msg)
+
+		reply := agentctx.AgentMessage{
+			Role:      "assistant",
+			Content:   []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "reply"}},
+			Timestamp: ts,
+		}
+		ts += 100
+		sess.AppendMessage(reply)
+	}
+	// Session branch has 10 messages
+	branch := sess.GetBranch("")
+	branchMsgCount := 0
+	for _, e := range branch {
+		if e.Type == session.EntryTypeMessage {
+			branchMsgCount++
+		}
+	}
+	if branchMsgCount != 10 {
+		t.Fatalf("expected 10 branch messages, got %d", branchMsgCount)
+	}
+
+	// Simulate agent having only 4 messages (e.g. after resume from checkpoint)
+	// without EntryID — same timestamps as the last 4 session messages
+	allMsgs := sess.GetMessages()
+	agentMsgs := make([]agentctx.AgentMessage, 4)
+	copy(agentMsgs, allMsgs[6:]) // Last 4 messages
+	for i := range agentMsgs {
+		agentMsgs[i].EntryID = "" // No EntryID from checkpoint
+	}
+
+	ag := &mockAgent{messages: agentMsgs}
+
+	// Index 3 in agent (4 messages: [0,1,2,3]) should resolve to the LAST
+	// session entry via timestamp match — NOT branch entry #3.
+	if id, ok := resolveMessageIndex(ag, sess, "3"); !ok {
+		t.Error("expected to resolve index 3")
+	} else if id == "" {
+		t.Error("expected non-empty entry ID")
+	}
+
+	// Verify: the resolved entry should be branch[9] (last one), not branch[3]
+	lastEntry := branch[len(branch)-1]
+	if lastEntry.Type != session.EntryTypeMessage || lastEntry.Message == nil {
+		t.Fatal("expected last branch entry to be a message")
+	}
+	if agentMsgs[3].Timestamp != lastEntry.Message.Timestamp {
+		t.Errorf("timestamp mismatch: agent=%d, branch_last=%d",
+			agentMsgs[3].Timestamp, lastEntry.Message.Timestamp)
+	}
+	// The old code would have returned branch[3] for index 3,
+	// which has a different timestamp.
+	wrongEntry := branch[3]
+	if wrongEntry.Message != nil && agentMsgs[3].Timestamp == wrongEntry.Message.Timestamp {
+		t.Error("sanity check failed: branch[3] has same timestamp as agent[3] — test setup issue")
+	}
+}

--- a/pkg/context/message.go
+++ b/pkg/context/message.go
@@ -99,6 +99,9 @@ type AgentMessage struct {
 	Truncated    bool `json:"truncated,omitempty"`
 	TruncatedAt  int  `json:"truncated_at,omitempty"`
 	OriginalSize int  `json:"original_size,omitempty"`
+
+	// Session entry tracking (set by buildSessionContext)
+	EntryID string `json:"entryId,omitempty"`
 }
 
 // IsTruncated checks if a message is truncated.

--- a/pkg/session/entries.go
+++ b/pkg/session/entries.go
@@ -159,11 +159,15 @@ func buildSessionContext(entries []*SessionEntry, leafID *string, byID map[strin
 		switch entry.Type {
 		case EntryTypeMessage:
 			if entry.Message != nil {
-				messages = append(messages, *entry.Message)
+				msg := *entry.Message
+				msg.EntryID = entry.ID
+				messages = append(messages, msg)
 			}
 		case EntryTypeBranchSummary:
 			if entry.Summary != "" {
-				messages = append(messages, branchSummaryMessage(entry.Summary, entry.Timestamp))
+				msg := branchSummaryMessage(entry.Summary, entry.Timestamp)
+				msg.EntryID = entry.ID
+				messages = append(messages, msg)
 			}
 		}
 	}

--- a/pkg/session/entries_test.go
+++ b/pkg/session/entries_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+// TestGetMessages_EntryID tests that buildSessionContext propagates
+// session entry IDs into the AgentMessage.EntryID field.
+func TestGetMessages_EntryID(t *testing.T) {
+	sess := NewSession("")
+
+	id1, err := sess.AppendMessage(agentctx.NewUserMessage("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := sess.AppendMessage(agentctx.AgentMessage{
+		Role:    "assistant",
+		Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id3, err := sess.AppendMessage(agentctx.NewUserMessage("how are you"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs := sess.GetMessages()
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+
+	// Each message should have its entry ID set
+	if msgs[0].EntryID != id1 {
+		t.Errorf("msgs[0].EntryID = %q, want %q", msgs[0].EntryID, id1)
+	}
+	if msgs[1].EntryID != id2 {
+		t.Errorf("msgs[1].EntryID = %q, want %q", msgs[1].EntryID, id2)
+	}
+	if msgs[2].EntryID != id3 {
+		t.Errorf("msgs[2].EntryID = %q, want %q", msgs[2].EntryID, id3)
+	}
+
+	// Roles should be correct
+	if msgs[0].Role != "user" || msgs[1].Role != "assistant" || msgs[2].Role != "user" {
+		t.Errorf("roles: %q, %q, %q", msgs[0].Role, msgs[1].Role, msgs[2].Role)
+	}
+}
+
+// TestGetMessages_EntryID_AfterRoundTrip tests that EntryID survives save/load.
+func TestGetMessages_EntryID_AfterRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	sess := NewSession(dir)
+
+	id1, _ := sess.AppendMessage(agentctx.NewUserMessage("first"))
+	sess.AppendMessage(agentctx.AgentMessage{
+		Role:    "assistant",
+		Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "reply"}},
+	})
+	id3, _ := sess.AppendMessage(agentctx.NewUserMessage("second"))
+
+	// Reload from disk
+	loaded, err := LoadSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgs := loaded.GetMessages()
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages after reload, got %d", len(msgs))
+	}
+
+	// Entry IDs should still match
+	if msgs[0].EntryID != id1 {
+		t.Errorf("after reload: msgs[0].EntryID = %q, want %q", msgs[0].EntryID, id1)
+	}
+	if msgs[2].EntryID != id3 {
+		t.Errorf("after reload: msgs[2].EntryID = %q, want %q", msgs[2].EntryID, id3)
+	}
+}


### PR DESCRIPTION

## Problem

`/fork` and `/rewind` accept a numeric index from `/messages`, but `resolveMessageIndex` was using `sess.GetBranch()` to map indices to entry IDs. After compaction or checkpoint resume, the agent's message list (shown by `/messages`) can differ significantly from the session branch, causing wrong or failed lookups.

Example: user sees `[255] user: ...` in `/messages`, but `/fork 255` fails because `sess.GetBranch()` only has 249 entries.

## Changes

- **`pkg/context/message.go`**: Add `EntryID` field to `AgentMessage`
- **`pkg/session/entries.go`**: `buildSessionContext` sets `EntryID` on each message
- **`cmd/ai/rpc_session_handlers.go`**:
  - Rewrite `resolveMessageIndex` to use `ag.GetMessages()` (same source as `/messages`) with timestamp fallback for checkpoint-resume scenarios
  - Move `EnsureFullyLoaded` before index resolution in both `/fork` and `/rewind`
  - Add usage hint when `/fork` is called without arguments
  - Introduce `messageIndexResolver` interface for testability
- **Tests**:
  - `TestGetMessages_EntryID`: verifies EntryID propagation
  - `TestGetMessages_EntryID_AfterRoundTrip`: verifies EntryID survives save/load
  - `TestResolveMessageIndex_EntryIDFromMessages`: happy path
  - `TestResolveMessageIndex_TimestampFallback`: checkpoint resume scenario
  - `TestResolveMessageIndex_CompactionIndexMismatch`: reproduces the old bug
