### PR TITLE
fix: improve find_skill search with query tokenization and keyword field

### DIFF
--- a/pkg/tools/find_skill.go
+++ b/pkg/tools/find_skill.go
@@ -20,6 +20,7 @@ type SkillIndexEntry struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	Aliases     []string `json:"aliases"`
+	Keywords    []string `json:"keywords"`
 	UseWhen     []string `json:"use_when"`
 	Categories  []string `json:"categories"`
 }
@@ -129,19 +130,48 @@ type searchResult struct {
 }
 
 const (
-	rankExactName  = 0
-	rankAliasMatch = 1
-	rankCategory   = 2
-	rankUseWhen    = 3
-	rankDescMatch  = 4
-	rankNameMatch  = 5
+	rankExactName    = 0
+	rankAliasMatch   = 1
+	rankKeywordMatch = 2
+	rankCategory     = 3
+	rankUseWhen      = 4
+	rankDescMatch    = 5
+	rankNameMatch    = 6
 )
 
-// executeSearch searches all loaded skills for a case-insensitive substring match
-// on Name and Description, then enriches results from the skill index.
+// matchTokens checks whether any token in tokens is a substring of any
+// string in fields. Returns true if at least one token matches at least one field.
+func matchTokens(tokens []string, fields ...[]string) bool {
+	for _, token := range tokens {
+		for _, field := range fields {
+			for _, v := range field {
+				if strings.Contains(strings.ToLower(v), token) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// fieldContainsAllTokens checks whether every token appears in at least one
+// of the provided field groups. Used for precise multi-token matching on
+// name and description where we want all tokens to match.
+func fieldContainsAllTokens(value string, tokens []string) bool {
+	lower := strings.ToLower(value)
+	for _, token := range tokens {
+		if !strings.Contains(lower, token) {
+			return false
+		}
+	}
+	return true
+}
+
+// executeSearch searches all loaded skills using tokenized query matching,
+// then enriches results from the skill index (including keywords).
 // Returns up to 5 results sorted by relevance.
 func (t *FindSkillTool) executeSearch(query string) ([]agentctx.ContentBlock, error) {
-	lowerQuery := strings.ToLower(query)
+	tokens := strings.Fields(strings.ToLower(query))
 
 	// Phase 1: direct name/description matching on loaded skills
 	directMatches := make(map[string]bool) // names already found
@@ -151,19 +181,22 @@ func (t *FindSkillTool) executeSearch(query string) ([]agentctx.ContentBlock, er
 		lowerName := strings.ToLower(s.Name)
 		lowerDesc := strings.ToLower(s.Description)
 
-		if lowerName == lowerQuery {
+		if lowerName == strings.ToLower(query) {
+			// Exact full query match on name — highest rank
 			results = append(results, searchResult{skill: s, rank: rankExactName})
 			directMatches[s.Name] = true
-		} else if strings.Contains(lowerName, lowerQuery) {
+		} else if fieldContainsAllTokens(lowerName, tokens) {
+			// All tokens match in name
 			results = append(results, searchResult{skill: s, rank: rankNameMatch})
 			directMatches[s.Name] = true
-		} else if strings.Contains(lowerDesc, lowerQuery) {
+		} else if fieldContainsAllTokens(lowerDesc, tokens) {
+			// All tokens match in description
 			results = append(results, searchResult{skill: s, rank: rankDescMatch})
 			directMatches[s.Name] = true
 		}
 	}
 
-	// Phase 2: enrich from skill index
+	// Phase 2: enrich from skill index (aliases, keywords, categories, use_when)
 	idx := loadSkillIndex(t.indexPath)
 	if idx != nil {
 		for _, entry := range idx.Entries {
@@ -173,32 +206,24 @@ func (t *FindSkillTool) executeSearch(query string) ([]agentctx.ContentBlock, er
 
 			matchedRank := -1
 
-			// Check aliases
-			for _, alias := range entry.Aliases {
-				if strings.Contains(strings.ToLower(alias), lowerQuery) {
-					matchedRank = rankAliasMatch
-					break
-				}
+			// Check aliases — any token matches any alias
+			if matchTokens(tokens, entry.Aliases) {
+				matchedRank = rankAliasMatch
+			}
+
+			// Check keywords — any token matches any keyword
+			if matchedRank < 0 && matchTokens(tokens, entry.Keywords) {
+				matchedRank = rankKeywordMatch
 			}
 
 			// Check categories
-			if matchedRank < 0 {
-				for _, cat := range entry.Categories {
-					if strings.Contains(strings.ToLower(cat), lowerQuery) {
-						matchedRank = rankCategory
-						break
-					}
-				}
+			if matchedRank < 0 && matchTokens(tokens, entry.Categories) {
+				matchedRank = rankCategory
 			}
 
 			// Check use_when
-			if matchedRank < 0 {
-				for _, uw := range entry.UseWhen {
-					if strings.Contains(strings.ToLower(uw), lowerQuery) {
-						matchedRank = rankUseWhen
-						break
-					}
-				}
+			if matchedRank < 0 && matchTokens(tokens, entry.UseWhen) {
+				matchedRank = rankUseWhen
 			}
 
 			if matchedRank >= 0 {

--- a/pkg/tools/find_skill_test.go
+++ b/pkg/tools/find_skill_test.go
@@ -617,3 +617,174 @@ func TestFindSkill_LoadFallbackToDiskReal(t *testing.T) {
 		t.Errorf("Expected loaded content to contain 'Session Analyzer', got: %s", text[:min(len(text), 200, len(text))])
 	}
 }
+
+// --- Tokenized query matching tests ---
+
+func TestFindSkill_TokenizedNameMatch(t *testing.T) {
+	tool := NewFindSkillTool([]skill.Skill{
+		{
+			Name:        "software-engineering-books",
+			Description: "Distilled decision rules from classic software engineering books",
+			FilePath:    "/home/user/.ai/skills/software-engineering-books/SKILL.md",
+		},
+	}, nil)
+	tool.SetIndexPath(filepath.Join(t.TempDir(), "nonexistent-index.json"))
+
+	// Multi-word query "software engineer book" should match "software-engineering-books"
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "software engineer book",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "software-engineering-books") {
+		t.Errorf("Expected 'software-engineering-books' matched by tokens, got: %s", text)
+	}
+}
+
+func TestFindSkill_KeywordMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeTestIndex(t, dir, []SkillIndexEntry{
+		{
+			Name:        "software-engineering-books",
+			Description: "Decision rules from classic SE books",
+			Keywords:    []string{"software-engineering", "books", "clean-code", "refactoring", "DDD"},
+			Categories:  []string{"development"},
+		},
+	})
+
+	tool := newTestToolWithIndex([]skill.Skill{}, nil, dir)
+
+	// "refactor" should match keyword "refactoring" via substring
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "refactor",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "software-engineering-books") {
+		t.Errorf("Expected match via keyword 'refactoring', got: %s", text)
+	}
+}
+
+func TestFindSkill_KeywordMatchAnyToken(t *testing.T) {
+	dir := t.TempDir()
+	writeTestIndex(t, dir, []SkillIndexEntry{
+		{
+			Name:        "software-engineering-books",
+			Description: "Decision rules from classic SE books",
+			Keywords:    []string{"software-engineering", "books", "clean-code"},
+			Categories:  []string{"development"},
+		},
+	})
+
+	tool := newTestToolWithIndex([]skill.Skill{}, nil, dir)
+
+	// "book" should match keyword "books" via substring
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "book",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "software-engineering-books") {
+		t.Errorf("Expected match via keyword 'books' with token 'book', got: %s", text)
+	}
+}
+
+func TestFindSkill_KeywordRankBetweenAliasAndCategory(t *testing.T) {
+	dir := t.TempDir()
+	writeTestIndex(t, dir, []SkillIndexEntry{
+		{
+			Name:        "skill-alias",
+			Description: "Found via alias",
+			Aliases:     []string{"my-alias"},
+			Keywords:    []string{"my-keyword"},
+			Categories:  []string{"cat-a"},
+		},
+		{
+			Name:        "skill-keyword",
+			Description: "Found via keyword",
+			Keywords:    []string{"my-keyword"},
+			Categories:  []string{"cat-a"},
+		},
+		{
+			Name:        "skill-category",
+			Description: "Found via category",
+			Categories:  []string{"my-keyword"},
+		},
+	})
+
+	tool := newTestToolWithIndex([]skill.Skill{}, nil, dir)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "my-keyword",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+
+	// All three should be found, sorted: alias < keyword < category
+	lines := strings.Split(text, "\n")
+	var order []string
+	for _, l := range lines {
+		if strings.HasPrefix(l, "- ") {
+			// Extract skill name
+			name := strings.TrimPrefix(l, "- ")
+			name = name[:strings.Index(name, ":")]
+			order = append(order, name)
+		}
+	}
+
+	if len(order) != 3 {
+		t.Fatalf("Expected 3 results, got %d: %v", len(order), order)
+	}
+	if order[0] != "skill-alias" {
+		t.Errorf("Expected skill-alias first (alias rank), got %s", order[0])
+	}
+	if order[1] != "skill-keyword" {
+		t.Errorf("Expected skill-keyword second (keyword rank), got %s", order[1])
+	}
+	if order[2] != "skill-category" {
+		t.Errorf("Expected skill-category third (category rank), got %s", order[2])
+	}
+}
+
+func TestFindSkill_MultiTokenDescMatch(t *testing.T) {
+	tool := NewFindSkillTool([]skill.Skill{
+		{
+			Name:        "video-watcher",
+			Description: "Fetch transcripts from YouTube and Bilibili videos",
+			FilePath:    "/home/user/.ai/skills/video-watcher/SKILL.md",
+		},
+	}, nil)
+	tool.SetIndexPath(filepath.Join(t.TempDir(), "nonexistent-index.json"))
+
+	// Both tokens must appear in description
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"query": "video transcript",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "video-watcher") {
+		t.Errorf("Expected 'video-watcher' matched by tokens in description, got: %s", text)
+	}
+
+	// Single token that doesn't fully match should not find it
+	result2, err := tool.Execute(context.Background(), map[string]any{
+		"query": "video nonexistentxyz",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	text2 := firstText(result2)
+	if strings.Contains(text2, "video-watcher") {
+		t.Errorf("Should not match when not all tokens present, got: %s", text2)
+	}
+}


### PR DESCRIPTION
## Problem

Two bugs prevented `find_skill` from discovering skills:

1. **Keywords field ignored**: `index-skills` generates rich `keywords` in `skill-index.json`, but `SkillIndexEntry` Go struct had no `Keywords` field — `json.Unmarshal` silently dropped all keyword data.

2. **No query tokenization**: `"software engineer book"` was matched as one whole substring against `"software-engineering-books"` → no match. Even though every individual word clearly relates to the skill.

## Changes

### `pkg/tools/find_skill.go`
- Add `Keywords []string` field to `SkillIndexEntry`
- Tokenize query with `strings.Fields` for multi-word matching
- Phase 1 (name/description): ALL tokens must match (AND semantics for precision)
- Phase 2 (index aliases/keywords/categories/use_when): ANY token matching ANY value suffices (OR semantics for recall)
- Extract `matchTokens()` and `fieldContainsAllTokens()` helpers
- Add `rankKeywordMatch` between alias and category ranks

### `pkg/tools/find_skill_test.go`
- 5 new tests: `TokenizedNameMatch`, `KeywordMatch`, `KeywordMatchAnyToken`, `KeywordRankBetweenAliasAndCategory`, `MultiTokenDescMatch`

### `~/.ai/skills/index-skills/SKILL.md`
- Add **Morphological variants** rule to alias generation: singular/plural and word-form variants (e.g. "book"/"books", "engineer"/"engineering")

## Test Results
- All 29 `TestFindSkill*` tests pass (24 existing + 5 new)
- `make fmt-check` clean