### PR TITLE
feat: handoff-based context management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ agent/benchmarks/evolve/iter-*-artifacts/agent-snapshot/
 # Evolve iteration-*.json files contain full agent traces (100-500MB each).
 # Too large for git. The structured summaries live in iter-*-artifacts/.
 agent/benchmarks/evolve/iteration-*.json
+-e 
+# PGE workflow artifacts
+.pge/
+explorer/

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ agent/benchmarks/evolve/iter-*-artifacts/agent-snapshot/
 # Evolve iteration-*.json files contain full agent traces (100-500MB each).
 # Too large for git. The structured summaries live in iter-*-artifacts/.
 agent/benchmarks/evolve/iteration-*.json
--e 
 # PGE workflow artifacts
 .pge/
 explorer/
+.ai/

--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -63,9 +63,17 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	}
 	app.toolOutputConfig = toolOutputConfig
 
+	// Build compactors list, filtering out nil entries (e.g. ctxManager in handoff mode).
+	var compactors []agent.Compactor
+	for _, c := range []agent.Compactor{app.ctxManager, sessionComp} {
+		if c != nil {
+			compactors = append(compactors, c)
+		}
+	}
+
 	// Build LoopConfig with all settings
 	loopCfg := app.cfg.ToLoopConfig(
-		config.WithCompactors([]agent.Compactor{app.ctxManager, sessionComp}),
+		config.WithCompactors(compactors),
 		config.WithContextWindow(app.currentContextWindow),
 		config.WithToolCallCutoff(app.compactorConfig.ToolCallCutoff),
 		config.WithExecutor(executor),
@@ -77,6 +85,7 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	// Set model and apiKey
 	loopCfg.Model = app.model
 	loopCfg.APIKey = app.apiKey
+	loopCfg.ContextManagementMode = app.cfg.ContextManagementMode()
 	loopCfg.GetWorkingDir = app.ws.GetCWD
 	loopCfg.GetStartupPath = app.ws.GetInitialCWD
 	loopCfg.RunID = app.runID

--- a/cmd/ai/rpc_helpers.go
+++ b/cmd/ai/rpc_helpers.go
@@ -106,8 +106,10 @@ func (app *rpcApp) createBaseContext() *agentctx.AgentContext {
 		if sessionDir != "" {
 			// Handoff-mode initialization: for new sessions, create the
 			// checkpoint directory structure (cp_001 + current.txt) if it
-			// doesn't already exist.
-			if app.cfg.ContextManagementMode() == config.ContextModeHandoff && !session.IsHandoffSessionWithDefault(sessionDir, app.cfg.ContextManagementMode()) {
+			// doesn't already exist. InitHandoffSession is idempotent — it
+			// returns nil when current.txt already exists — so calling it
+			// unconditionally in handoff mode is safe.
+			if app.cfg.ContextManagementMode() == config.ContextModeHandoff {
 				if err := session.InitHandoffSession(sessionDir); err != nil {
 					slog.Warn("Failed to initialize handoff session, falling back to legacy path",
 						"error", err)

--- a/cmd/ai/rpc_helpers.go
+++ b/cmd/ai/rpc_helpers.go
@@ -107,7 +107,7 @@ func (app *rpcApp) createBaseContext() *agentctx.AgentContext {
 			// Handoff-mode initialization: for new sessions, create the
 			// checkpoint directory structure (cp_001 + current.txt) if it
 			// doesn't already exist.
-			if app.cfg.ContextManagementMode() == config.ContextModeHandoff && !session.IsHandoffSession(sessionDir) {
+			if app.cfg.ContextManagementMode() == config.ContextModeHandoff && !session.IsHandoffSessionWithDefault(sessionDir, app.cfg.ContextManagementMode()) {
 				if err := session.InitHandoffSession(sessionDir); err != nil {
 					slog.Warn("Failed to initialize handoff session, falling back to legacy path",
 						"error", err)

--- a/cmd/ai/rpc_helpers.go
+++ b/cmd/ai/rpc_helpers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/tiancaiamao/ai/pkg/agent"
+	"github.com/tiancaiamao/ai/pkg/config"
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/prompt"
 	"github.com/tiancaiamao/ai/pkg/session"
@@ -103,6 +104,15 @@ func (app *rpcApp) createBaseContext() *agentctx.AgentContext {
 	if app.sess != nil {
 		sessionDir := app.sess.GetDir()
 		if sessionDir != "" {
+			// Handoff-mode initialization: for new sessions, create the
+			// checkpoint directory structure (cp_001 + current.txt) if it
+			// doesn't already exist.
+			if app.cfg.ContextManagementMode() == config.ContextModeHandoff && !session.IsHandoffSession(sessionDir) {
+				if err := session.InitHandoffSession(sessionDir); err != nil {
+					slog.Warn("Failed to initialize handoff session, falling back to legacy path",
+						"error", err)
+				}
+			}
 			ctx.LLMContext = ""
 		}
 		ctx.RecentMessages = app.sess.GetMessages()

--- a/cmd/ai/rpc_message_handlers.go
+++ b/cmd/ai/rpc_message_handlers.go
@@ -21,14 +21,29 @@ import (
 
 // --- Message and content handlers --@
 
+// reloadMessagesIfEmpty populates the agent context with session messages
+// when the context is currently empty. This handles legacy sessions resumed
+// in handoff mode that lack checkpoint structure. It is a no-op when the
+// agent context is nil.
+func (app *rpcApp) reloadMessagesIfEmpty() {
+	if app.sess == nil {
+		return
+	}
+	ctx := app.ag.GetContext()
+	if ctx == nil {
+		return
+	}
+	if len(ctx.RecentMessages) == 0 {
+		ctx.RecentMessages = app.sess.GetMessages()
+	}
+}
+
 func (app *rpcApp) handleCompact(args string) (any, error) {
 	_ = args
 	slog.Info("Received compact")
 	// Reload messages from session if agent context is empty (e.g. legacy
 	// session resumed in handoff mode without checkpoint structure).
-	if len(app.ag.GetMessages()) == 0 && app.sess != nil {
-		app.ag.GetContext().RecentMessages = app.sess.GetMessages()
-	}
+	app.reloadMessagesIfEmpty()
 
 	beforeCount := len(app.ag.GetMessages())
 
@@ -73,7 +88,9 @@ func (app *rpcApp) handleCompact(args string) (any, error) {
 				return err
 			}
 
-			app.ag.GetContext().RecentMessages = app.sess.GetMessages()
+			if ctx := app.ag.GetContext(); ctx != nil {
+				ctx.RecentMessages = app.sess.GetMessages()
+			}
 
 			afterCount := len(app.ag.GetMessages())
 			span.AddField("after_messages", afterCount)
@@ -113,6 +130,10 @@ func (app *rpcApp) handleHandoff(args string) (any, error) {
 
 	app.stateMu.Lock()
 	streaming := app.isStreaming
+	if app.isCompacting {
+		app.stateMu.Unlock()
+		return nil, fmt.Errorf("context management already in progress")
+	}
 	app.stateMu.Unlock()
 	if streaming {
 		return nil, fmt.Errorf("agent is busy")
@@ -144,9 +165,7 @@ func (app *rpcApp) handleHandoff(args string) (any, error) {
 	// Reload messages from session if agent context is empty. This can happen
 	// when a legacy session was resumed in handoff mode without checkpoint
 	// structure — the resume path returns empty messages in that case.
-	if len(app.ag.GetMessages()) == 0 && app.sess != nil {
-		app.ag.GetContext().RecentMessages = app.sess.GetMessages()
-	}
+	app.reloadMessagesIfEmpty()
 
 	beforeCount := len(app.ag.GetMessages())
 	if beforeCount == 0 {
@@ -154,8 +173,32 @@ func (app *rpcApp) handleHandoff(args string) (any, error) {
 	}
 	slog.Info("[Handoff] Manual handoff triggered", "before_messages", beforeCount)
 
+	// Emit compaction events with Type="handoff" so the TUI shows progress
+	// (same pattern as /compact). The compaction_start event also sets
+	// app.isCompacting=true via the event handler, guarding against double
+	// execution.
+	compactionInfo := agent.CompactionInfo{
+		Type:   "handoff",
+		Before: beforeCount,
+	}
+	app.stateMu.Lock()
+	app.isCompacting = true
+	app.stateMu.Unlock()
+	app.server.EmitEvent(agent.NewCompactionStartEvent(compactionInfo))
+	defer func() {
+		app.stateMu.Lock()
+		app.isCompacting = false
+		app.stateMu.Unlock()
+		compactionInfo.After = len(app.ag.GetMessages())
+		if compactionInfo.Error != "" {
+			compactionInfo.After = 0
+		}
+		app.server.EmitEvent(agent.NewCompactionEndEvent(compactionInfo))
+	}()
+
 	ctx := context.Background()
 	if err := app.ag.Handoff(ctx); err != nil {
+		compactionInfo.Error = err.Error()
 		return nil, fmt.Errorf("handoff failed: %w", err)
 	}
 

--- a/cmd/ai/rpc_message_handlers.go
+++ b/cmd/ai/rpc_message_handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tiancaiamao/ai/pkg/agent"
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/rpc"
+	"github.com/tiancaiamao/ai/pkg/session"
 	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
 )
 
@@ -23,6 +24,12 @@ import (
 func (app *rpcApp) handleCompact(args string) (any, error) {
 	_ = args
 	slog.Info("Received compact")
+	// Reload messages from session if agent context is empty (e.g. legacy
+	// session resumed in handoff mode without checkpoint structure).
+	if len(app.ag.GetMessages()) == 0 && app.sess != nil {
+		app.ag.GetContext().RecentMessages = app.sess.GetMessages()
+	}
+
 	beforeCount := len(app.ag.GetMessages())
 
 	estimatedTokens := app.compactor.EstimateTokens(app.ag.GetMessages())
@@ -99,6 +106,72 @@ func (app *rpcApp) handleCompact(args string) (any, error) {
 		return nil, err
 	}
 	return response, nil
+}
+
+func (app *rpcApp) handleHandoff(args string) (any, error) {
+	_ = args
+
+	app.stateMu.Lock()
+	streaming := app.isStreaming
+	app.stateMu.Unlock()
+	if streaming {
+		return nil, fmt.Errorf("agent is busy")
+	}
+
+	sessionDir := app.sess.GetDir()
+	if sessionDir == "" {
+		return nil, fmt.Errorf("handoff requires a session directory")
+	}
+
+	// Initialize handoff checkpoint structure if current.txt does not exist.
+	// This handles resumed legacy sessions that have messages but no checkpoint
+	// directory. The existing messages are imported into cp_001.
+	if _, err := os.Stat(filepath.Join(sessionDir, "current.txt")); err != nil {
+		slog.Info("[Handoff] Initializing handoff structure for legacy session")
+		entries := app.sess.GetEntries()
+		var msgEntries []session.SessionEntry
+		for _, e := range entries {
+			if e.Type == session.EntryTypeMessage {
+				cp := e
+				msgEntries = append(msgEntries, cp)
+			}
+		}
+		if err := session.InitHandoffFromExisting(sessionDir, msgEntries); err != nil {
+			return nil, fmt.Errorf("init handoff session: %w", err)
+		}
+	}
+
+	// Reload messages from session if agent context is empty. This can happen
+	// when a legacy session was resumed in handoff mode without checkpoint
+	// structure — the resume path returns empty messages in that case.
+	if len(app.ag.GetMessages()) == 0 && app.sess != nil {
+		app.ag.GetContext().RecentMessages = app.sess.GetMessages()
+	}
+
+	beforeCount := len(app.ag.GetMessages())
+	if beforeCount == 0 {
+		return nil, fmt.Errorf("no messages to handoff")
+	}
+	slog.Info("[Handoff] Manual handoff triggered", "before_messages", beforeCount)
+
+	ctx := context.Background()
+	if err := app.ag.Handoff(ctx); err != nil {
+		return nil, fmt.Errorf("handoff failed: %w", err)
+	}
+
+	afterCount := len(app.ag.GetMessages())
+	checkpoint, _ := session.GetCurrentCheckpoint(sessionDir)
+	slog.Info("[Handoff] Manual handoff complete",
+		"checkpoint", checkpoint,
+		"before_messages", beforeCount,
+		"after_messages", afterCount)
+
+	return map[string]any{
+		"status":          "ok",
+		"checkpoint":      checkpoint,
+		"before_messages": beforeCount,
+		"after_messages":  afterCount,
+	}, nil
 }
 
 func (app *rpcApp) handleGetMessages(args string) (any, error) {
@@ -312,6 +385,10 @@ func (app *rpcApp) registerMessageHandlers() {
 
 	app.server.RegisterSlash("compact", "Compact conversation history to reduce context size", func(args string) (any, error) {
 		return app.handleCompact(args)
+	})
+
+	app.server.RegisterSlash("handoff", "Manually trigger context handoff (generates handoff doc, runs Q&A, creates new checkpoint)", func(args string) (any, error) {
+		return app.handleHandoff(args)
 	})
 
 	app.server.RegisterSlash("export_html", "Export the current session as HTML", func(args string) (any, error) {

--- a/cmd/ai/rpc_session_handlers.go
+++ b/cmd/ai/rpc_session_handlers.go
@@ -164,6 +164,14 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 		return nil, fmt.Errorf("agent is busy")
 	}
 
+	// In handoff mode, rewind operates on the root journal which contains ALL
+	// messages (pre and post handoff). Cross-checkpoint rewind is not supported.
+	// Returning an error is the safest correct behavior — users should use /fork
+	// to branch from a specific point instead.
+	if session.IsHandoffSession(app.sess.GetDir()) {
+		return nil, fmt.Errorf("rewind is not supported in handoff mode; use /fork to branch from a specific checkpoint point")
+	}
+
 	// Lazy loading may not have all entries in byID (e.g., pre-compaction).
 	// Ensure the full session is loaded before resolving indices.
 	if entryID != "root" {
@@ -242,6 +250,31 @@ func (app *rpcApp) handleFork(args string) (any, error) {
 		entryID = jsonData.EntryID
 	}
 
+	name := fmt.Sprintf("fork-%s", time.Now().Format("20060102-150405"))
+	title := "Forked Session"
+
+	// Handoff mode: fork copies the entire session directory (all checkpoints,
+	// current.txt, meta.json). Entry-level branching is not needed.
+	sessionDir := app.sess.GetDir()
+	if session.IsHandoffSession(sessionDir) {
+		slog.Info("Forking handoff session (directory copy)", "sourceDir", sessionDir)
+		newSess, err := app.sessionMgr.ForkHandoffSession(app.sess, name, title)
+		if err != nil {
+			return nil, err
+		}
+		newSessionID := newSess.GetID()
+		if err := app.sessionMgr.SetCurrent(newSessionID); err != nil {
+			return nil, err
+		}
+		if err := app.sessionMgr.SaveCurrent(); err != nil {
+			slog.Info("Failed to update session metadata:", "value", err)
+		}
+		app.setSession(newSess, newSessionID, name)
+		slog.Info("Forked handoff session to new session", "name", name, "id", newSessionID)
+		return &rpc.ForkResult{Cancelled: false}, nil
+	}
+
+	// Legacy mode: entry-level branching via ForkSessionFrom.
 	if entryID == "" {
 		return nil, fmt.Errorf("usage: /fork <index|entryId>  (use /messages to see indices)")
 	}
@@ -263,8 +296,6 @@ func (app *rpcApp) handleFork(args string) (any, error) {
 	}
 
 	text := entry.Message.ExtractText()
-	name := fmt.Sprintf("fork-%s", time.Now().Format("20060102-150405"))
-	title := "Forked Session"
 	newSess, err := app.sessionMgr.ForkSessionFrom(app.sess, entry.ParentID, name, title)
 	if err != nil {
 		return nil, err

--- a/cmd/ai/rpc_session_handlers.go
+++ b/cmd/ai/rpc_session_handlers.go
@@ -168,7 +168,7 @@ func (app *rpcApp) handleRewind(args string) (any, error) {
 	// messages (pre and post handoff). Cross-checkpoint rewind is not supported.
 	// Returning an error is the safest correct behavior — users should use /fork
 	// to branch from a specific point instead.
-	if session.IsHandoffSession(app.sess.GetDir()) {
+	if session.IsHandoffSessionWithDefault(app.sess.GetDir(), app.cfg.ContextManagementMode()) {
 		return nil, fmt.Errorf("rewind is not supported in handoff mode; use /fork to branch from a specific checkpoint point")
 	}
 
@@ -256,7 +256,7 @@ func (app *rpcApp) handleFork(args string) (any, error) {
 	// Handoff mode: fork copies the entire session directory (all checkpoints,
 	// current.txt, meta.json). Entry-level branching is not needed.
 	sessionDir := app.sess.GetDir()
-	if session.IsHandoffSession(sessionDir) {
+	if session.IsHandoffSessionWithDefault(sessionDir, app.cfg.ContextManagementMode()) {
 		slog.Info("Forking handoff session (directory copy)", "sourceDir", sessionDir)
 		newSess, err := app.sessionMgr.ForkHandoffSession(app.sess, name, title)
 		if err != nil {

--- a/cmd/ai/rpc_setup.go
+++ b/cmd/ai/rpc_setup.go
@@ -151,9 +151,12 @@ func newRPCApp(sessionPath string, params rpcAppSetupParams) (*rpcApp, error) {
 
 	// Skip context management (proactive LLM-driven cycle) in cache-first mode.
 	// Full compaction (75% threshold) is still active.
-	ctxManager.SetSkipCondition(func() bool {
-		return agent.IsCacheMode(app.model.ID) == agent.CacheModeCache
-	})
+	// In handoff mode ctxManager is nil (no proactive context management).
+	if app.ctxManager != nil {
+		app.ctxManager.SetSkipCondition(func() bool {
+			return agent.IsCacheMode(app.model.ID) == agent.CacheModeCache
+		})
+	}
 
 	return app, nil
 }
@@ -325,6 +328,12 @@ func createCompactors(cfg *config.Config, model llm.Model, apiKey string, contex
 		prompt.ContextManagementSystemPrompt(),
 		compactor,
 	)
+
+	// In handoff mode, disable the proactive ContextManager.
+	// The compactor is still created (needed for reactive context_limit_recovery).
+	if cfg.ContextManagementMode() == config.ContextModeHandoff {
+		return compactor, nil, compactorConfig
+	}
 
 	return compactor, ctxManager, compactorConfig
 }

--- a/docs/handoff-context-mgmt-design.md
+++ b/docs/handoff-context-mgmt-design.md
@@ -1,0 +1,661 @@
+# Handoff-Based Context Management Design
+
+> Status: Design specification. All decisions confirmed through iterative
+> review (3 rounds). References code paths on `main` (commit `f6dd3d5`).
+>
+> This document supersedes the LLM-driven compaction model described in
+> [`context-management.md`](./context-management.md) for the *proactive* context
+> management path. The reactive recovery path is retained.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 The two governing principles
+
+The maintainer stated two non-negotiable principles:
+
+1. **"Only incremental is viable."** Near-full compaction is too late — by the
+   time the window is 75% full, context quality has already degraded. Percentage
+   thresholds scale incorrectly when windows grow (200K→1M: the same percentage
+   represents a vastly different absolute token count and cost). The only viable
+   strategy is incremental management.
+
+2. **"Compaction always breaks cache, so the decision must weigh cost-effectiveness
+   AND context quality."** Any compaction that **edits or replaces** existing
+   messages invalidates the provider's prefix cache from the edit point onward —
+   the previously cached prefix no longer matches. Note the asymmetry:
+   **appending** messages (like Q&A turns during handoff) extends the prefix but
+   does not invalidate the already-cached portion — the cache hit applies to the
+   unchanged prefix, only the new suffix is a miss. This is why Q&A turns are
+   cache-warm for the new checkpoint (§3.2 Phase B) while compaction edits are
+   cache-hostile. Therefore the trigger cannot be purely mechanical (token count).
+   It must consider both the economic tradeoff (cache miss cost vs. token savings)
+   and context quality.
+
+### 1.2 Why existing approaches fail
+
+| Approach | Violates | Reason |
+|----------|----------|--------|
+| Percentage threshold (75%) | Principle 1 | Scales wrong with window growth; triggers too late |
+| Near-full compaction | Principle 1 | Context already rot by the time it fires |
+| Delta compaction (blind summary) | Principle 2 | LLM writes a summary that no one verifies; errors frozen into context |
+| Existing ContextManager | Both | LLM-driven but unverified: a separate LLM call decides which tool (`truncate_messages`, `compact`, `no_action`) to invoke, but no fresh agent verifies the result — the summary is accepted on faith. Token-threshold trigger still scales wrong (Principle 1). |
+
+### 1.3 Why handoff is different
+
+Handoff replaces blind compression with **verified context transfer**. A fresh
+context (seeded with a handoff document) reads the document, explores the
+codebase, and asks questions about anything unclear. The Q&A verification loop
+makes information loss *discoverable and correctable* — the critical capability
+that all compaction approaches lack.
+
+An experiment validated this: a fresh agent reading a handoff document
+identified 11 gaps including factual errors that a Q&A loop caught and corrected.
+
+---
+
+## 2. Core Concept
+
+### 2.1 Two checkpoint systems, selected by mode
+
+The codebase **already has** a checkpoint system for crash recovery:
+`pkg/context/checkpoint.go` creates `checkpoints/checkpoint_%05d/` directories,
+each holding an `AgentContext` snapshot (`agent_state.json`, `llm_context.txt`,
+snapshot `messages.jsonl`). A `current` symlink and `checkpoint_index.json`
+track the latest. This is a snapshot+WAL recovery model — the session's
+`messages.jsonl` is the write-ahead log; resume loads the snapshot then replays
+journal entries after it. See `pkg/context/README.md`.
+
+Handoff introduces a **second** checkpoint concept: context-segment boundaries.
+These are fundamentally different purposes:
+
+| | Legacy checkpoint (`checkpoint_%05d`) | Handoff checkpoint (`cp_NNN`) |
+|--|--|--|
+| Purpose | Crash recovery (snapshot + WAL replay) | Context segmentation (handoff boundary) |
+| Trigger | Pre/post-compaction, context-limit recovery | Economic threshold + quality signals |
+| Contents | `AgentContext` memory snapshot | A segment of conversation history |
+| Mutability | Frozen snapshot, WAL appends after | Frozen segment, new segment created |
+
+**The two systems never interact.** A `contextManagement.mode` field in
+`SessionMeta` selects which system a session uses. On resume, the mode is read
+first; each mode has its own checkpoint directory layout, loading code, and
+lifecycle. Legacy sessions keep their existing layout unchanged. Handoff
+sessions use the layout below.
+
+### 2.2 Handoff checkpoint layout (handoff mode only)
+
+A handoff-mode session is a chain of context-segment checkpoints, each with its
+own `messages.jsonl`:
+
+```
+~/.ai/sessions/--<cwd>--/
+  meta.json                         # SessionMeta, includes contextManagement.mode
+  current.txt                       # "cp_003" — points to the active segment
+  checkpoints/                      # Handoff segments
+    cp_001/
+      messages.jsonl                # Frozen after handoff. Never modified again.
+    cp_002/
+      handoff.md                    # cp_001→cp_002 handoff document
+      messages.jsonl                # Frozen. Contains: [handoff doc seed + Q&A turns]
+    cp_003/
+      handoff.md                    # cp_002→cp_003 handoff document
+      messages.jsonl                # Currently active
+```
+
+Each checkpoint's `messages.jsonl` uses the **existing SessionEntry format**
+(`pkg/session/entries.go`). No new file format is invented. The handoff document
+is the first `EntryTypeMessage` (role=user); Q&A turns are subsequent
+`EntryTypeMessage` entries. The `SessionHeader` gains a `ParentCheckpoint`
+field pointing to the parent segment's path, enabling full history recovery.
+
+**Crash recovery in handoff mode:** Handoff mode does not use the legacy
+snapshot+WAL system. Instead, crash recovery relies on: (1) each segment's
+`messages.jsonl` is append-only and frozen after handoff, so it is always
+consistent; (2) `current.txt` is updated atomically (write temp + rename) only
+after the new segment is fully written (§3.4). A crash mid-handoff leaves
+`current.txt` pointing to the old segment; the half-written new segment is
+ignored. No journal replay needed.
+
+### 2.2 What handoff does NOT replace
+
+Handoff replaces **proactive** context management. It does **not** replace the
+**reactive** safety net at `loop.go:214`:
+
+```go
+if llm.IsContextLengthExceeded(err) && len(config.Compactors) > 0 && state.compactionRecs < maxCompactionRecoveries {
+    recoveryResult, recoveryErr := state.performCompaction(ctx, "context_limit_recovery", false, true)
+```
+
+This path fires when the LLM API itself rejects a request for exceeding the
+context window. It needs an *immediate synchronous compression*, not a
+multi-minute handoff. It stays as-is, operating **within** the current
+checkpoint's `messages.jsonl` via the existing `EntryTypeCompaction` mechanism.
+
+**Two levels, independent:**
+
+| Level | Mechanism | Trigger | Scope |
+|-------|-----------|---------|-------|
+| Inter-checkpoint | Handoff (new checkpoint) | Quality signals + economic model | Full context reset |
+| Intra-checkpoint | Reactive compaction (existing) | `context_limit_recovery` | Single checkpoint file |
+
+### 2.4 Economic model
+
+The decision to handoff is fundamentally economic:
+
+```
+Cost of staying:       N × oldTokens × cacheHitRate        (cheap per-call, but tokens are large)
+Cost of switching:     handoffMissCost + N × newTokens × cacheHitRate
+                       (one-time cache miss + cheaper per-call afterwards)
+
+Switch when:           handoffMissCost < N × (oldTokens - newTokens) × cacheHitRate
+                       i.e., payback period < N remaining rounds
+```
+
+Where:
+- `handoffMissCost ≈ newTokens × 50` (cache-miss input rate is ~50× hit rate)
+- `N` = remaining rounds (unknowable; assume a conservative lower bound, e.g., ≥5)
+- `oldTokens` = current context size
+- `newTokens` = handoff document + Q&A size (typically 1-5% of oldTokens)
+
+**Example:** 100K context → 1K handoff, 50× cache miss penalty:
+```
+Payback = (1K × 50) / (100K - 1K) ≈ 0.5 rounds  → pays back in ONE round
+```
+
+This is why a 1M-window model can trigger at 100K — not because 100K is "10%",
+but because the compression ratio makes it economically justified. The threshold
+is **payback-period-based**, not percentage-based.
+
+---
+
+## 3. Implementation: Loop-Driven (Not Subagent)
+
+### 3.1 Why loop-driven, not subagent
+
+> **Note:** The shipped skill (`.ai/skills/handoff/SKILL.md`) describes a
+> **subagent-driven** handoff (spawn `ai serve`, Q&A via `ai send --wait`,
+> subagent takes over). This design **supersedes** that approach. The skill
+> documents the original interactive concept; this section explains why the
+> production implementation moves the mechanism into the loop. Once the
+> loop-driven implementation lands, the skill will be updated to describe the
+> new mechanism (and reduced to the operator-facing parts: when to trigger,
+> how to write a good handoff doc).
+
+Handoff is a **base feature** of the RPC layer, not a user-level tool. Spawning
+a subagent (`ai serve`) would create a bottom-layer-depends-on-top-layer
+inversion: `pkg/agent` (the loop) would depend on `cmd/ai` (the CLI that spawns
+subagents) — a layering violation. The loop-driven approach keeps handoff in
+`pkg/agent` / `pkg/compact`, parallel to `performCompaction`.
+
+The implementation is structurally identical to the existing compaction path.
+The `GenerateSummaryWithPrevious` function (`pkg/compact/compact_summary.go:27`)
+already uses `llm.StreamLLM(ctx, model, llmCtx, apiKey, timeout)` — a low-level
+primitive independent of the loop's streaming mechanism. Handoff reuses this
+same primitive.
+
+```
+performCompaction:                  performHandoff:
+├─ GenerateSummaryWithPrevious      ├─ GenerateHandoffDoc       (1× llm.StreamLLM)
+│  (1× llm.StreamLLM)               ├─ Q&A loop (≤3 rounds)     (2× llm.StreamLLM per round)
+├─ Replace RecentMessages           ├─ Write new checkpoint
+└─ Return                           ├─ Switch current.txt
+                                    └─ Replace RecentMessages
+```
+
+### 3.2 The handoff process (4 phases)
+
+#### Phase A: Main agent writes handoff document
+
+The main agent (whose context is degrading but not yet critical) writes the
+handoff document using the handoff skill template
+(`.ai/skills/handoff/references/handoff-template.md`). This is one
+`llm.StreamLLM` call with a prompt that requests the structured document.
+
+**Why the main agent writes it (not a subagent):** The main agent's context is
+still cache-warm. Writing the document as an LLM call reuses the cached prefix,
+minimizing cost. The main agent's context has NOT fully rotted yet — handoff
+triggers early (see §4), while the agent is still coherent enough to write an
+accurate document.
+
+#### Phase B: Q&A verification loop
+
+The core innovation. The main agent's loop drives a bounded Q&A process between
+two LLM call targets:
+
+```go
+// Pseudocode for the Q&A loop
+newCtx := []AgentMessage{handoffDocSeed}  // Fresh context = handoff doc only
+
+for round := 0; round < 3; round++ {
+    // New context asks questions (1× llm.StreamLLM on newCtx)
+    questions := streamLLM(systemPrompt_qa, newCtx)
+    if questions signals "READY" {
+        break
+    }
+    newCtx = append(newCtx, userMsg(questions))
+
+    // Old context answers (1× llm.StreamLLM on oldMessages + question)
+    answers := streamLLM(systemPrompt_answer, append(oldMessages, userMsg(questions)))
+    newCtx = append(newCtx, assistantMsg(answers))
+}
+
+// After loop: newCtx contains [handoff doc + Q1 + A1 + ... + READY]
+```
+
+**Key points:**
+- The "old context answering" call appends the question to oldMessages and makes
+  one `llm.StreamLLM` call. The result is NOT persisted to oldMessages — it is a
+  read-only query on the old context. The old checkpoint's `messages.jsonl` is
+  frozen; it never grows during handoff.
+- The "new context asking" call operates on `newCtx` (handoff doc + accumulated
+  Q&A), which grows each round.
+- Maximum 3 rounds, but often 0-1 rounds suffice if the handoff document is
+  complete (the subagent says "READY" immediately).
+- Each round = 2 `llm.StreamLLM` calls. Total handoff cost: 1 (doc) + 2×3 (QA) =
+  up to 7 LLM calls.
+
+**The Q&A process IS the context of the new checkpoint.** After completion,
+`newCtx` (handoff doc + all Q&A turns) becomes the seed for the new
+checkpoint's `messages.jsonl`. This is intentional: the Q&A turns build a
+cache-warm prefix for the new checkpoint, so its first real working turn gets a
+cache hit.
+
+#### Phase C: Checkpoint creation
+
+1. Create `checkpoints/cp_NNN/` directory (next sequential number).
+2. Write `handoff.md` (the handoff document).
+3. Write `messages.jsonl` using the existing `SessionEntry` format:
+   - `SessionHeader` with `ParentCheckpoint` = parent checkpoint path.
+   - `EntryTypeMessage` entries for: handoff doc (role=user), each Q&A turn.
+4. Update `current.txt` to `cp_NNN` (atomic write — this is the commit point).
+
+#### Phase D: Context switch
+
+After `current.txt` is updated, the loop reloads `agentCtx` from the new
+checkpoint's `messages.jsonl`. The old `agentCtx` is discarded. The next LLM
+turn runs with the fresh, Q&A-verified context.
+
+The switch is **silent** — no system message telling the LLM "you were
+handoff'd." The handoff document + Q&A is a complete, self-contained context.
+
+### 3.3 LLM decision protocol
+
+The LLM decides whether to execute handoff, but does **not** use a tool call.
+The flow is:
+
+1. Loop detects conditions → injects `<context_management>` reminder as a user
+   message into `agentCtx.RecentMessages` before the next LLM call.
+2. The reminder describes the handoff skill (or references it) and includes
+   current context metrics (token count, quality signals, cache stats).
+3. The LLM either:
+   - **Ignores it** and continues working (handoff not warranted for this task).
+   - **Executes handoff**: writes the handoff document as its text output, then
+     emits a `<handoff_complete>` marker.
+4. The loop detects `<handoff_complete>` in the LLM response, extracts the
+   handoff document, and enters Phase B (Q&A loop) using `llm.StreamLLM`.
+
+No new tool is registered. The protocol is a combination of injected reminders
+and output markers — simpler than a tool call, and keeps all handoff logic in
+the loop layer.
+
+### 3.4 Failure and rollback
+
+Handoff failure is safe by construction:
+
+- **During Phase A/B (writing doc + Q&A):** The main session's `current.txt`
+  has not changed. The old checkpoint (`cp_NNN`) is untouched. If anything fails
+  (LLM error, timeout, user cancellation), discard the in-progress work. The
+  loop continues from the current checkpoint as if nothing happened.
+
+- **During Phase C (checkpoint creation):** Files are written before
+  `current.txt` is updated. If the process crashes mid-write, `current.txt`
+  still points to the old checkpoint. On resume, the old checkpoint loads
+  normally. The half-written `cp_NNN+1` is ignored (can be GC'd or manually
+  deleted).
+
+- **After Phase D (switch complete):** No rollback. The old checkpoint is
+  frozen but accessible via the `ParentCheckpoint` pointer. If the new context
+  turns out to be wrong, the user can fork from a parent checkpoint.
+
+**Dead-loop prevention:** If handoff fails due to OOM (`context_length_exceeded`
+during Phase A/B), the reactive compaction path (`loop.go:213`) fires as a
+fallback, compressing within the current checkpoint. This breaks the
+"trigger→fail→retrigger" cycle because reactive compaction reduces the context
+enough for the next handoff attempt to succeed.
+
+---
+
+## 4. Trigger Design
+
+### 4.1 Two-layer trigger
+
+| Layer | Mechanism | Purpose |
+|-------|-----------|---------|
+| **Soft trigger** | Quality/economic signals → inject reminder → LLM decides | Normal operation |
+| **Hard底线** | Absolute token threshold → force handoff (override LLM) | Safety net against LLM refusal |
+
+### 4.2 Soft trigger: economic threshold
+
+The soft trigger fires based on the payback-period economic model (§2.4).
+Rather than computing the exact formula at runtime (N is unknowable), we use
+**absolute token-count thresholds** that approximate the payback crossover:
+
+| Context window | Soft trigger starts at | Rationale |
+|----------------|----------------------|-----------|
+| 200K | 40K tokens used (20%) | At 40K, a handoff to ~2K pays back in ~1 round (50× miss penalty) |
+| 1M | 100K tokens used (10%) | At 100K, a handoff to ~2K pays back in ~0.5 rounds |
+
+**Reconciliation with Principle 1 (§1.1):** Principle 1 rejects *percentage*
+thresholds ("75% full") because they scale wrong with window growth and trigger
+too late. The thresholds here are **absolute token counts** derived from the
+payback model, not percentages. They scale with window size because the payback
+crossover does (larger windows can afford more context before handoff pays off).
+This is economically grounded, not "purely mechanical." The ideal trigger (v2)
+adds quality signals on top; v1 starts with the economic floor.
+
+**These are starting points, not final values.** The constants are provisional
+and should be tuned from real session traces. The design commits to the
+*payback-period model*, not to exact threshold numbers.
+
+The soft trigger does NOT immediately execute handoff. It injects a
+`<context_management>` reminder and lets the LLM decide.
+
+### 4.3 Soft trigger: injection frequency
+
+Once the soft threshold is crossed, reminders are injected periodically:
+
+- **First injection:** Immediately when threshold is crossed.
+- **Subsequent injections:** Every N tool calls, where N is **dynamic** —
+  the more context is used, the more frequent the reminders.
+
+```
+N = max(1, baseInterval - (currentTokens / softThreshold) × decayFactor)
+```
+
+Where `baseInterval` (e.g., 10) decreases as context usage approaches the hard
+底线. At 2× the soft threshold, reminders may come every 2-3 tool calls. This
+reuses the existing `ToolCallsSinceLastTrigger` counter
+(`loop_state.go:314`).
+
+### 4.4 Soft trigger: quality signals (future enhancement)
+
+The economic threshold is the **initial** trigger. Quality signals — detecting
+*context degradation* independent of token count — are a future enhancement
+layered on top. Candidates identified during design:
+
+| Signal | Source | Status |
+|--------|--------|--------|
+| Repeated-read (same file read >K times in W turns) | `toolLoopGuard` observation point (`tool_guard.go:113`) | Proposed, not implemented |
+| Loop-guard feedback frequency | `toolLoopGuard.Observe()` return value | Existing infrastructure |
+| Tool-output truncation density | `tool_output_truncated` trace event (bit 41) | Existing infrastructure |
+
+These reuse existing data paths. They are **not required for the initial
+implementation** — the economic threshold alone is sufficient to make handoff
+functional. Quality signals make it *smarter*.
+
+### 4.5 Hard底线 (safety net)
+
+The hard底线 forces handoff (bypassing LLM decision) when remaining context is
+insufficient for the handoff process itself (~20K tokens):
+
+| Context window | Hard底线 |
+|----------------|---------|
+| 200K | 150K used (75%) — leaves 50K, enough for handoff |
+| 1M | 200K used — absolute cap, because 1M windows fill slowly but handoff cost is fixed |
+
+> **Note:** The 150K value for 200K windows coincidentally equals 75%. This is
+> incidental — 150K is an **absolute token floor** derived from the handoff
+> process's ~20K working budget, not a percentage threshold. The §1.1 objection
+> to "75% full" targets *percentage-based* triggers that scale wrong; absolute
+> token floors do not have that problem.
+
+At the hard底线, the loop injects an urgent reminder. If the LLM still does not
+emit `<handoff_complete>` within 2 turns, the loop executes handoff
+automatically (Phase A uses a minimal prompt, skipping the LLM's judgment).
+
+### 4.6 Where triggers check in the loop
+
+The trigger check replaces the existing `performCompaction` call at
+`loop.go:198`:
+
+```
+// Current (legacy mode):
+state.savePreCompactionCheckpoint("pre_llm_threshold")
+compacted, _ := state.performCompaction(ctx, "pre_llm_threshold", true, false)
+
+// Handoff mode:
+state.maybeInjectHandoffReminder(agentCtx)  // checks soft/hard thresholds,
+                                            // injects <context_management> if needed
+```
+
+And in the LLM response processing, detect `<handoff_complete>` in the
+assistant message:
+
+```
+if hasHandoffMarker(msg) {
+    handoffDoc := extractHandoffDoc(msg)
+    state.performHandoff(ctx, handoffDoc)  // Phase B + C + D
+    continue  // next loop iteration uses fresh context
+}
+```
+
+---
+
+## 5. Session/Checkpoint Operations
+
+### 5.1 Resume
+
+Read `meta.json` → check `contextManagement.mode`. If `legacy`, use existing
+resume path (`pkg/agent/resume.go:LoadResumeState` — checkpoint snapshot + WAL
+replay). If `handoff`, read `current.txt` → load
+`checkpoints/<current>/messages.jsonl`. No parent-entry traversal needed.
+
+### 5.2 Fork
+
+Copy the entire session directory to a new session ID. The new session inherits
+all checkpoints, `current.txt`, `meta.json` (including mode), and the full
+history. This is a **new filesystem-level implementation** that replaces the
+existing message-level `Branch()` / `ForkSessionFrom` tree-walk for handoff-mode
+sessions. (Legacy-mode sessions continue to use `ForkSessionFrom` unchanged.)
+
+### 5.3 Rewind
+
+Operates **within the current checkpoint only**. The existing `leafID`
+tree-walk mechanism (`session.go:226`, `Branch()`) works unchanged within a
+single `messages.jsonl`. Cross-checkpoint rewind (going from `cp_003` back to
+`cp_002`) is **not supported** — the handoff document is the verified
+replacement for that history.
+
+### 5.4 /messages
+
+Displays messages from the **current checkpoint only**. Earlier checkpoints'
+content is accessible via `handoff.md` files (the verified summary). Users lose
+the ability to scroll through raw pre-handoff messages — this is intentional:
+pre-handoff context was degrading and unreliable; the handoff document is a
+*better* representation.
+
+### 5.5 Full history recovery
+
+Every checkpoint stores a `ParentCheckpoint` pointer in its `SessionHeader`.
+Following this chain (`cp_003 → cp_002 → cp_001`) reaches the original
+`messages.jsonl` with complete, unmodified conversation history. Nothing is ever
+lost. This satisfies the non-negotiable requirement: "regardless of how many
+handoffs occur, the full conversation history is always recoverable."
+
+---
+
+## 6. Legacy Code Disposition
+
+### 6.1 Configuration switch
+
+A new config field controls the mode:
+
+```json
+{
+  "contextManagement": {
+    "mode": "handoff"    // "legacy" | "handoff" (default: "handoff")
+  }
+}
+```
+
+- `legacy`: Current behavior — proactive compaction via `CompactionController`
+  (`pkg/agent/compaction_controller.go`) + `ContextManager`
+  (`pkg/compact/context_management.go`) + `context_mgmt` tools
+  (`pkg/tools/context_mgmt/`). LLM decides whether to compact; summary is
+  accepted without verification. Plus `checkpoint_%05d` crash-recovery.
+- `handoff`: All proactive compaction **disabled** (ContextManager,
+  CompactionController, context_mgmt tools not wired). Only reactive
+  `context_limit_recovery` remains. Handoff trigger + Q&A loop active.
+
+**The mode is persisted in `SessionMeta`** (`pkg/session/manager.go:17`) as a
+new `ContextManagementMode` field. This ensures resume knows which checkpoint
+system and loading code to use — the two layouts are never mixed within a
+session:
+
+```go
+type SessionMeta struct {
+    // ... existing fields ...
+    ContextManagementMode string `json:"contextManagementMode,omitempty"` // "legacy" | "handoff"
+}
+```
+
+### 6.2 Disposition table
+
+The table below covers **handoff-mode** behavior. In legacy mode, all components
+remain active and unchanged — handoff code is simply not wired.
+
+| Component | Location | Disposition (handoff mode) | Reason |
+|-----------|----------|---------------------------|--------|
+| `context_limit_recovery` | `loop.go:214` | **Retain** | Handoff cannot be reactive; safety net required |
+| `performCompaction` (method) | `pkg/agent/loop_state.go:129` | **Retain** (reactive only) | Backs the `context_limit_recovery` path |
+| `ContextManager` | `pkg/compact/context_management.go` | **Remove** from proactive path | Philosophy overlaps with handoff; unverified summary |
+| `context_mgmt` tools | `pkg/tools/context_mgmt/` | **Remove** from proactive path | Tied to ContextManager |
+| `CompactionController` | `pkg/agent/compaction_controller.go` | **Remove** from proactive path | Proactive trigger; superseded by handoff trigger |
+| `ShouldCompact` (percentage) | `pkg/compact/compact.go:460` | **Remove** from proactive path | Retain for reactive path check |
+| **Crash-recovery checkpoint system** | `pkg/context/checkpoint*.go`, `pkg/agent/checkpoint_manager.go`, `pkg/agent/resume.go` | **Inactive** (legacy only) | Snapshot+WAL recovery belongs to legacy mode; handoff mode uses frozen per-segment `messages.jsonl` + atomic `current.txt` switch for crash recovery. |
+| **`ForkSessionFrom` / `Branch()`** | `pkg/session/manager.go`, `pkg/session/session.go:226` | **Inactive** (legacy only) | Handoff mode uses directory-copy fork (§5.2) |
+| `toolLoopGuard` | `pkg/agent/tool_guard.go` | **Retain** | Loop safety + future quality signal source |
+| `performCompaction` (pre_llm call) | `loop.go:198` | **Replace** with `maybeInjectHandoffReminder` | Handoff trigger replaces blind compaction |
+
+> **Deletion timeline:** Legacy-mode components are retained until handoff mode
+> is validated in production. Once confirmed stable, legacy code
+> (`ContextManager`, `context_mgmt` tools, `checkpoint_%05d` system,
+> `ForkSessionFrom`) is deleted in a single cleanup commit.
+
+### 6.3 Migration
+
+- The `mode` switch defaults to `handoff` (for validation).
+- Existing sessions (flat `messages.jsonl`, no `checkpoints/` directory) are
+  loaded in a compatibility mode: treated as a single implicit checkpoint
+  (`cp_001`).
+- No automatic migration of old sessions. New sessions use the checkpoint
+  structure from creation.
+
+---
+
+## 7. Cache Verification (Implementation Gate)
+
+### 7.1 The critical assumption
+
+The economic model (§2.4) assumes **prefix cache is content-addressed (shared
+across sequential LLM calls in the same process)**, not per-call-scoped. If
+cache does not carry over between the Q&A turns and the first working turn of
+the new checkpoint, the cache-inheritance benefit disappears and thresholds must
+shift later.
+
+**⚠️ This is a gate, not a footnote.** The thresholds in §4.2 (40K/100K) are
+derived from the economic model, which depends on this assumption. If the
+assumption fails, the thresholds are invalid. The verification below must run
+**before** Phase 1 commits to concrete threshold numbers.
+
+### 7.2 What is already known
+
+- **`pkg/llm` response types have no cache-hit field.** Verified by grep: no
+  `cache_hit_tokens`, `cached_tokens`, `CacheHit`, or `prompt_cache` field
+  exists. A field must be added to capture this data.
+- **The handoff path is in-process sequential calls** (§3.1, loop-driven). The
+  cache scope question is specifically: does the provider's prefix cache persist
+  across sequential `llm.StreamLLM` calls within one process/connection? Not
+  cross-process.
+
+### 7.3 Verification plan
+
+1. Add a `CacheHitTokens` field to the LLM response type in `pkg/llm`.
+2. In a single `ai serve` process, make two sequential `llm.StreamLLM` calls
+   with an identical prefix (system prompt + same messages).
+3. Check whether the second call's response reports cache-hit tokens.
+
+If yes → cache persists across sequential calls → the economic model holds.
+If no → cache is per-call → the Q&A cache-inheritance benefit disappears, and
+the economic model must be recalculated (handoff becomes more expensive,
+thresholds shift later, or the Q&A cache-warmth argument is dropped from the
+justification entirely).
+
+---
+
+## 8. Open Questions Carried Forward
+
+1. **Threshold constants** (soft trigger 40K/100K, hard底线 150K/200K,
+   injection interval base/decay): all provisional. Require empirical tuning
+   from real traces once the counters exist.
+
+2. **Q&A round count** (currently 3): provisional. Real sessions may show that
+   1-2 rounds suffice for well-written handoff documents. Tune from data.
+
+3. **Session continuity across handoff**: the subagent (new checkpoint) is a
+   logically separate context. The `ParentCheckpoint` pointer preserves data,
+   but there is no "session merge" — if a user wants to reference a specific
+   pre-handoff message, they must follow the pointer chain manually. Future
+   enhancement: cross-checkpoint search.
+
+4. **Cache scope** (§7): must be verified before the economic model is trusted.
+
+5. **Quality signals** (§4.4): proposed but not implemented in the initial
+   version. The economic threshold is sufficient for v1.
+
+---
+
+## Appendix A: Implementation Phases
+
+### Phase 1: Config switch + disable proactive compaction
+- Add `contextManagement.mode` to `pkg/config/config.go`.
+- Add `ContextManagementMode` field to `SessionMeta` (`pkg/session/manager.go:17`).
+- In `rpc_setup.go:createCompactors`, skip ContextManager/CompactionController
+  when mode=handoff.
+- In `loop.go:198`, skip `performCompaction("pre_llm_threshold")` when
+  mode=handoff.
+- **Verify:** `go build` passes; handoff mode triggers no proactive compaction.
+
+### Phase 2: Checkpoint directory structure
+- Session directory: `checkpoints/cp_NNN/messages.jsonl` + `current.txt`.
+- `SessionHeader`: add `ParentCheckpoint` field.
+- Resume: read `current.txt` → load checkpoint.
+- Compatibility: old sessions (no `checkpoints/`) load as implicit `cp_001`.
+- **Verify:** new sessions use checkpoint structure; old sessions resume.
+
+### Phase 3: Reminder injection
+- `maybeInjectHandoffReminder()` replacing `performCompaction` at `loop.go:198`.
+- Soft threshold logic (40K/100K based on window size).
+- Dynamic injection interval (based on `ToolCallsSinceLastTrigger` + context usage).
+- Hard底线 check (urgent reminder + auto-execute after 2 turns).
+- **Verify:** reminders appear in context at the right thresholds.
+
+### Phase 4: performHandoff
+- Detect `<handoff_complete>` in LLM response.
+- Extract handoff document from LLM output.
+- Q&A loop (≤3 rounds) using `llm.StreamLLM`.
+- Write new checkpoint (`messages.jsonl` + `handoff.md`).
+- Update `current.txt`, reload `agentCtx`.
+- **Verify:** handoff produces new checkpoint; Q&A works; cache hits on first
+  post-handoff turn.
+
+### Phase 5: Integration cleanup
+- Fork = copy session directory (new implementation for handoff mode).
+- Rewind/messages scoped to current checkpoint.
+- Remove legacy proactive code (ContextManager, context_mgmt tools,
+  CompactionController) once handoff is validated. Remove legacy checkpoint
+  infrastructure (`checkpoint_%05d` system, `ForkSessionFrom`/`Branch()`)
+  at the same time.
+- Retain reactive `performCompaction` method and `context_limit_recovery`.
+- **Verify:** fork/rewind/messages work; `go test ./...` passes.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -644,6 +644,27 @@ func (a *Agent) Compact(compactor Compactor) error {
 	return nil
 }
 
+// Handoff manually triggers a context handoff. It generates a handoff document
+// from the current conversation, runs Q&A verification, creates a new
+// checkpoint, and switches to the fresh context.
+//
+// This is the entry point for the /handoff slash command. It constructs a
+// temporary loopState to reuse the same performHandoff / autoGenerateHandoffDoc
+// code paths as the automatic trigger.
+func (a *Agent) Handoff(ctx context.Context) error {
+	state := &loopState{
+		config:   &a.LoopConfig,
+		agentCtx: a.context,
+	}
+
+	doc, err := state.autoGenerateHandoffDoc(ctx)
+	if err != nil {
+		return fmt.Errorf("generate handoff doc: %w", err)
+	}
+
+	return state.performHandoff(ctx, doc)
+}
+
 // tryAutoCompact attempts automatic compression if thresholds exceeded.
 func (a *Agent) tryAutoCompact(ctx context.Context) {
 	if len(a.LoopConfig.Compactors) == 0 {

--- a/pkg/agent/handoff_detector.go
+++ b/pkg/agent/handoff_detector.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"strings"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+// handoffCompleteMarker is the sentinel string the LLM emits to signal that
+// the handoff document is complete.
+const handoffCompleteMarker = "<handoff_complete>"
+
+// hasHandoffMarker returns true if the assistant message contains
+// <handoff_complete> in any of its text content blocks.
+func hasHandoffMarker(msg *agentctx.AgentMessage) bool {
+	if msg == nil {
+		return false
+	}
+	for _, block := range msg.Content {
+		if tc, ok := block.(agentctx.TextContent); ok {
+			if strings.Contains(tc.Text, handoffCompleteMarker) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// extractHandoffDoc extracts the handoff document text from the assistant
+// message. The handoff doc is the text content BEFORE the
+// <handoff_complete> marker.
+//
+// If the marker is in a text block, everything before it in that block (plus
+// all prior text blocks) is the handoff doc. If the marker is not found an
+// empty string is returned.
+func extractHandoffDoc(msg *agentctx.AgentMessage) string {
+	if msg == nil {
+		return ""
+	}
+	var parts []string
+	for _, block := range msg.Content {
+		tc, ok := block.(agentctx.TextContent)
+		if !ok {
+			continue
+		}
+		if idx := strings.Index(tc.Text, handoffCompleteMarker); idx >= 0 {
+			parts = append(parts, tc.Text[:idx])
+			return strings.Join(parts, "\n")
+		}
+		parts = append(parts, tc.Text)
+	}
+	return strings.Join(parts, "\n")
+}

--- a/pkg/agent/handoff_detector.go
+++ b/pkg/agent/handoff_detector.go
@@ -10,6 +10,10 @@ import (
 // the handoff document is complete.
 const handoffCompleteMarker = "<handoff_complete>"
 
+// handoffCompleteEndMarker is the optional closing tag. When present, the
+// handoff document is the text enclosed between the opening and closing tags.
+const handoffCompleteEndMarker = "</handoff_complete>"
+
 // hasHandoffMarker returns true if the assistant message contains
 // <handoff_complete> in any of its text content blocks.
 func hasHandoffMarker(msg *agentctx.AgentMessage) bool {
@@ -27,27 +31,46 @@ func hasHandoffMarker(msg *agentctx.AgentMessage) bool {
 }
 
 // extractHandoffDoc extracts the handoff document text from the assistant
-// message. The handoff doc is the text content BEFORE the
-// <handoff_complete> marker.
+// message. The LLM places the handoff document INSIDE the
+// <handoff_complete>...</handoff_complete> tags.
 //
-// If the marker is in a text block, everything before it in that block (plus
-// all prior text blocks) is the handoff doc. If the marker is not found an
-// empty string is returned.
+// Extraction rules:
+//   - If <handoff_complete>...</handoff_complete> exists: extract the text
+//     between the opening and closing tags.
+//   - If only <handoff_complete> exists (no closing tag): extract everything
+//     after the opening marker.
+//   - If no marker is found: return "".
+//
+// The result is trimmed of leading/trailing whitespace.
 func extractHandoffDoc(msg *agentctx.AgentMessage) string {
 	if msg == nil {
 		return ""
 	}
+	// Combine all text content into a single string so that tags may span
+	// multiple content blocks.
 	var parts []string
 	for _, block := range msg.Content {
 		tc, ok := block.(agentctx.TextContent)
 		if !ok {
 			continue
 		}
-		if idx := strings.Index(tc.Text, handoffCompleteMarker); idx >= 0 {
-			parts = append(parts, tc.Text[:idx])
-			return strings.Join(parts, "\n")
-		}
 		parts = append(parts, tc.Text)
 	}
-	return strings.Join(parts, "\n")
+	combined := strings.Join(parts, "\n")
+
+	// Find the opening marker.
+	openIdx := strings.Index(combined, handoffCompleteMarker)
+	if openIdx < 0 {
+		return ""
+	}
+	contentStart := openIdx + len(handoffCompleteMarker)
+
+	// Look for a closing tag after the opening marker.
+	closeIdx := strings.Index(combined[contentStart:], handoffCompleteEndMarker)
+	if closeIdx >= 0 {
+		return strings.TrimSpace(combined[contentStart : contentStart+closeIdx])
+	}
+
+	// No closing tag — extract everything after the opening marker.
+	return strings.TrimSpace(combined[contentStart:])
 }

--- a/pkg/agent/handoff_detector_test.go
+++ b/pkg/agent/handoff_detector_test.go
@@ -87,29 +87,39 @@ func TestExtractHandoffDoc(t *testing.T) {
 		want string
 	}{
 		{
-			name: "marker at end of single block",
-			msg:  makeTextMessage("assistant", "Task: implement X\nStatus: done\n<handoff_complete>"),
-			want: "Task: implement X\nStatus: done\n",
+			name: "content inside tags",
+			msg:  makeTextMessage("assistant", "<handoff_complete>\nContent here\n</handoff_complete>"),
+			want: "Content here",
 		},
 		{
-			name: "marker in middle of text",
-			msg:  makeTextMessage("assistant", "Doc content <handoff_complete> trailing text"),
-			want: "Doc content ",
+			name: "content after open tag, no closing tag",
+			msg:  makeTextMessage("assistant", "<handoff_complete>\nContent here"),
+			want: "Content here",
 		},
 		{
-			name: "marker in second block — first block preserved",
-			msg: makeTextMessage("assistant",
-				"First block content",
-				"Second <handoff_complete> rest"),
-			want: "First block content\nSecond ",
+			name: "text before marker is not the doc",
+			msg:  makeTextMessage("assistant", "Some text\n<handoff_complete>\nReal content\n</handoff_complete>"),
+			want: "Real content",
 		},
 		{
-			name: "marker in first of three blocks",
-			msg: makeTextMessage("assistant",
-				"Alpha <handoff_complete>",
-				"Beta",
-				"Gamma"),
-			want: "Alpha ",
+			name: "no marker at all",
+			msg:  makeTextMessage("assistant", "No marker at all"),
+			want: "",
+		},
+		{
+			name: "content inside tags with surrounding text",
+			msg:  makeTextMessage("assistant", "Intro text\n<handoff_complete>\n## Handoff\nTask: X\n</handoff_complete>\nTrailing"),
+			want: "## Handoff\nTask: X",
+		},
+		{
+			name: "open tag only with nothing after",
+			msg:  makeTextMessage("assistant", "Task: implement X\n<handoff_complete>"),
+			want: "",
+		},
+		{
+			name: "multi-line doc between tags",
+			msg:  makeTextMessage("assistant", "<handoff_complete>\n## Status\n- Done: A\n- Pending: B\n</handoff_complete>"),
+			want: "## Status\n- Done: A\n- Pending: B",
 		},
 		{
 			name: "nil message returns empty",
@@ -117,23 +127,25 @@ func TestExtractHandoffDoc(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "no marker returns all text joined",
-			msg: makeTextMessage("assistant",
-				"Block A",
-				"Block B"),
-			want: "Block A\nBlock B",
-		},
-		{
-			name: "marker at very start",
-			msg:  makeTextMessage("assistant", "<handoff_complete>rest"),
+			name: "empty message returns empty",
+			msg:  &agentctx.AgentMessage{Role: "assistant", Content: []agentctx.ContentBlock{}},
 			want: "",
 		},
 		{
-			name: "empty blocks before marker",
+			name: "content spans multiple blocks inside tags",
 			msg: makeTextMessage("assistant",
-				"",
-				"<handoff_complete>"),
-			want: "\n",
+				"<handoff_complete>",
+				"Line one",
+				"Line two",
+				"</handoff_complete>"),
+			want: "Line one\nLine two",
+		},
+		{
+			name: "open and close in different blocks",
+			msg: makeTextMessage("assistant",
+				"<handoff_complete>Start content",
+				"more content</handoff_complete>"),
+			want: "Start content\nmore content",
 		},
 	}
 
@@ -151,7 +163,7 @@ func TestExtractHandoffDoc_RoundTripWithHasHandoffMarker(t *testing.T) {
 	// A message that has the marker should produce a non-nil doc when extracted,
 	// and the extracted doc should not contain the marker.
 	docText := "## Handoff\n\nTask complete.\nNext: run tests."
-	msg := makeTextMessage("assistant", docText+"<handoff_complete>")
+	msg := makeTextMessage("assistant", "<handoff_complete>\n"+docText+"\n</handoff_complete>")
 
 	if !hasHandoffMarker(msg) {
 		t.Fatal("expected hasHandoffMarker to return true")

--- a/pkg/agent/handoff_detector_test.go
+++ b/pkg/agent/handoff_detector_test.go
@@ -1,0 +1,167 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+func makeTextMessage(role string, texts ...string) *agentctx.AgentMessage {
+	msg := &agentctx.AgentMessage{
+		Role:    role,
+		Content: []agentctx.ContentBlock{},
+	}
+	for _, t := range texts {
+		msg.Content = append(msg.Content, agentctx.TextContent{Type: "text", Text: t})
+	}
+	return msg
+}
+
+func TestHasHandoffMarker(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *agentctx.AgentMessage
+		want bool
+	}{
+		{
+			name: "marker present at end",
+			msg:  makeTextMessage("assistant", "Here is the handoff doc.\n<handoff_complete>"),
+			want: true,
+		},
+		{
+			name: "marker in middle of text",
+			msg:  makeTextMessage("assistant", "Doc content <handoff_complete> trailing text"),
+			want: true,
+		},
+		{
+			name: "marker in second block",
+			msg: makeTextMessage("assistant",
+				"First block without marker",
+				"Second block <handoff_complete>"),
+			want: true,
+		},
+		{
+			name: "marker absent — plain text",
+			msg:  makeTextMessage("assistant", "Just a regular response"),
+			want: false,
+		},
+		{
+			name: "marker absent — multiple blocks",
+			msg: makeTextMessage("assistant",
+				"Block one",
+				"Block two"),
+			want: false,
+		},
+		{
+			name: "nil message",
+			msg:  nil,
+			want: false,
+		},
+		{
+			name: "empty content",
+			msg:  &agentctx.AgentMessage{Role: "assistant", Content: []agentctx.ContentBlock{}},
+			want: false,
+		},
+		{
+			name: "marker as user message",
+			msg:  makeTextMessage("user", "<handoff_complete>"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasHandoffMarker(tt.msg)
+			if got != tt.want {
+				t.Errorf("hasHandoffMarker() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractHandoffDoc(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *agentctx.AgentMessage
+		want string
+	}{
+		{
+			name: "marker at end of single block",
+			msg:  makeTextMessage("assistant", "Task: implement X\nStatus: done\n<handoff_complete>"),
+			want: "Task: implement X\nStatus: done\n",
+		},
+		{
+			name: "marker in middle of text",
+			msg:  makeTextMessage("assistant", "Doc content <handoff_complete> trailing text"),
+			want: "Doc content ",
+		},
+		{
+			name: "marker in second block — first block preserved",
+			msg: makeTextMessage("assistant",
+				"First block content",
+				"Second <handoff_complete> rest"),
+			want: "First block content\nSecond ",
+		},
+		{
+			name: "marker in first of three blocks",
+			msg: makeTextMessage("assistant",
+				"Alpha <handoff_complete>",
+				"Beta",
+				"Gamma"),
+			want: "Alpha ",
+		},
+		{
+			name: "nil message returns empty",
+			msg:  nil,
+			want: "",
+		},
+		{
+			name: "no marker returns all text joined",
+			msg: makeTextMessage("assistant",
+				"Block A",
+				"Block B"),
+			want: "Block A\nBlock B",
+		},
+		{
+			name: "marker at very start",
+			msg:  makeTextMessage("assistant", "<handoff_complete>rest"),
+			want: "",
+		},
+		{
+			name: "empty blocks before marker",
+			msg: makeTextMessage("assistant",
+				"",
+				"<handoff_complete>"),
+			want: "\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractHandoffDoc(tt.msg)
+			if got != tt.want {
+				t.Errorf("extractHandoffDoc() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractHandoffDoc_RoundTripWithHasHandoffMarker(t *testing.T) {
+	// A message that has the marker should produce a non-nil doc when extracted,
+	// and the extracted doc should not contain the marker.
+	docText := "## Handoff\n\nTask complete.\nNext: run tests."
+	msg := makeTextMessage("assistant", docText+"<handoff_complete>")
+
+	if !hasHandoffMarker(msg) {
+		t.Fatal("expected hasHandoffMarker to return true")
+	}
+
+	extracted := extractHandoffDoc(msg)
+	if extracted != docText {
+		t.Errorf("extracted doc mismatch:\n got=%q\nwant=%q", extracted, docText)
+	}
+	if strings.Contains(extracted, handoffCompleteMarker) {
+		t.Error("extracted doc should not contain the marker")
+	}
+}

--- a/pkg/agent/handoff_perform.go
+++ b/pkg/agent/handoff_perform.go
@@ -60,16 +60,11 @@ const handoffGenerateInstruction = `Below is a conversation transcript. Read it 
 func (s *loopState) performHandoff(ctx context.Context, handoffDoc string) error {
 	model := getEffectiveModel(s.config)
 	apiKey := getEffectiveAPIKey(s.config)
-	contextWindow := s.config.ContextWindow
 
 	startTime := time.Now()
 
 	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_start",
 		traceevent.Field{Key: "session_dir", Value: s.config.GetSessionDir()})
-
-	// Save old messages before Q&A (Q&A does not mutate RecentMessages, but
-	// we capture a snapshot for clarity).
-	oldMessages := s.agentCtx.RecentMessages
 
 	// Run Q&A verification. Failures here are non-fatal — we proceed with the
 	// checkpoint using whatever Q&A turns were collected.
@@ -87,7 +82,7 @@ func (s *loopState) performHandoff(ctx context.Context, handoffDoc string) error
 		}
 	}
 
-	qaTurns, err := runHandoffQA(ctx, model, apiKey, contextWindow, handoffDoc, oldMessages, handoffQADefaultRounds, qaSystemPrompt)
+	qaTurns, err := runHandoffQA(ctx, model, apiKey, handoffDoc, handoffQADefaultRounds, qaSystemPrompt)
 	if err != nil {
 		slog.Warn("[Handoff] Q&A verification failed, proceeding with checkpoint",
 			"error", err,

--- a/pkg/agent/handoff_perform.go
+++ b/pkg/agent/handoff_perform.go
@@ -9,6 +9,7 @@ import (
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
+	"github.com/tiancaiamao/ai/pkg/prompt"
 	"github.com/tiancaiamao/ai/pkg/session"
 	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
 
@@ -48,7 +49,19 @@ func (s *loopState) performHandoff(ctx context.Context, handoffDoc string) error
 	// checkpoint using whatever Q&A turns were collected.
 	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_qa_start",
 		traceevent.Field{Key: "max_rounds", Value: handoffQADefaultRounds})
-	qaTurns, err := runHandoffQA(ctx, model, apiKey, contextWindow, handoffDoc, oldMessages, handoffQADefaultRounds, s.agentCtx.SystemPrompt)
+	// Build the QA system prompt with the thinking-level instruction appended,
+	// matching how the main LLM stream loop builds its system prompt. This keeps
+	// the prefix identical so provider prefix caching is not invalidated.
+	qaSystemPrompt := s.agentCtx.SystemPrompt
+	if instruction := prompt.ThinkingInstruction(s.config.ThinkingLevel); instruction != "" {
+		if strings.TrimSpace(qaSystemPrompt) == "" {
+			qaSystemPrompt = instruction
+		} else {
+			qaSystemPrompt = qaSystemPrompt + "\n\n" + instruction
+		}
+	}
+
+	qaTurns, err := runHandoffQA(ctx, model, apiKey, contextWindow, handoffDoc, oldMessages, handoffQADefaultRounds, qaSystemPrompt)
 	if err != nil {
 		slog.Warn("[Handoff] Q&A verification failed, proceeding with checkpoint",
 			"error", err,
@@ -258,9 +271,16 @@ func (s *loopState) autoGenerateHandoffDoc(ctx context.Context) (string, error) 
 
 	oldMessages := s.agentCtx.RecentMessages
 
-	// Serialize old messages into conversation text.
-	var conversationText strings.Builder
-	for _, msg := range oldMessages {
+	// Serialize conversation into a text transcript. We use a single user
+	// message (not raw LLM messages) to avoid role-formatting issues — the
+	// raw conversation may have consecutive same-role messages or tool-only
+	// messages that violate API constraints.
+	const maxTranscriptBytes = 512 * 1024 // ~128K tokens
+
+	var lines []string
+	totalBytes := 0
+	for i := len(oldMessages) - 1; i >= 0; i-- {
+		msg := oldMessages[i]
 		if !msg.IsAgentVisible() {
 			continue
 		}
@@ -268,23 +288,35 @@ func (s *loopState) autoGenerateHandoffDoc(ctx context.Context) (string, error) 
 		if strings.TrimSpace(text) == "" {
 			continue
 		}
-		conversationText.WriteString(fmt.Sprintf("[%s]: %s\n\n", msg.Role, text))
+		line := fmt.Sprintf("[%s]: %s", msg.Role, text)
+		if totalBytes+len(line) > maxTranscriptBytes {
+			break
+		}
+		lines = append(lines, line)
+		totalBytes += len(line)
 	}
 
-	if conversationText.Len() == 0 {
+	// Reverse to chronological order (we walked backward).
+	for i, j := 0, len(lines)-1; i < j; i, j = i+1, j-1 {
+		lines[i], lines[j] = lines[j], lines[i]
+	}
+
+	if len(lines) == 0 {
 		return "", fmt.Errorf("no conversation content to generate handoff doc from")
 	}
 
+	conversationText := strings.Join(lines, "\n\n")
+
 	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_auto_generate_start",
-		traceevent.Field{Key: "conversation_length", Value: conversationText.Len()})
+		traceevent.Field{Key: "message_count", Value: len(lines)},
+		traceevent.Field{Key: "transcript_bytes", Value: totalBytes})
 
 	// Reuse the main agent system prompt to preserve provider prefix caching.
-	// Send the generation instruction as a user message.
 	llmCtx := llm.LLMContext{
 		SystemPrompt: s.agentCtx.SystemPrompt,
 		Messages: []llm.LLMMessage{
 			{Role: "user", Content: handoffGenerateInstruction},
-			{Role: "user", Content: conversationText.String()},
+			{Role: "user", Content: conversationText},
 		},
 	}
 

--- a/pkg/agent/handoff_perform.go
+++ b/pkg/agent/handoff_perform.go
@@ -1,0 +1,236 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/llm"
+	"github.com/tiancaiamao/ai/pkg/session"
+
+	"github.com/google/uuid"
+)
+
+// handoffGenerateSystemPrompt instructs the LLM to produce a handoff document
+// from the current conversation. Used by auto-execute.
+const handoffGenerateSystemPrompt = `Summarize the current task, key decisions, and pending work. Include file paths, error context, and next steps. Be thorough but concise.`
+
+// performHandoff executes the complete handoff process:
+//  1. Run Q&A verification on the handoff document.
+//  2. Create a new checkpoint.
+//  3. Write checkpoint messages + handoff document.
+//  4. Atomically switch to the new checkpoint.
+//  5. Reload agent context from the new checkpoint.
+//  6. Reset hard floor and compaction recovery state.
+//
+// On failure the old checkpoint is left untouched, so the loop can safely
+// continue with the existing context.
+func (s *loopState) performHandoff(ctx context.Context, handoffDoc string) error {
+	model := getEffectiveModel(s.config)
+	apiKey := getEffectiveAPIKey(s.config)
+	contextWindow := s.config.ContextWindow
+
+	// Save old messages before Q&A (Q&A does not mutate RecentMessages, but
+	// we capture a snapshot for clarity).
+	oldMessages := s.agentCtx.RecentMessages
+
+	// Run Q&A verification. Failures here are non-fatal — we proceed with the
+	// checkpoint using whatever Q&A turns were collected.
+	qaTurns, err := runHandoffQA(ctx, model, apiKey, contextWindow, handoffDoc, oldMessages, 3)
+	if err != nil {
+		slog.Warn("[Handoff] Q&A verification failed, proceeding with checkpoint",
+			"error", err,
+			"qa_turns", len(qaTurns),
+		)
+	}
+
+	return s.finalizeHandoff(handoffDoc, qaTurns)
+}
+
+// finalizeHandoff creates the checkpoint, writes messages, switches the active
+// checkpoint, and reloads context. It is separated from performHandoff so it
+// can be unit-tested without making LLM calls.
+func (s *loopState) finalizeHandoff(handoffDoc string, qaTurns []qaTurn) error {
+	sessionDir := s.config.GetSessionDir()
+	if sessionDir == "" {
+		return fmt.Errorf("handoff requires a session directory")
+	}
+
+	parentCheckpoint, err := session.GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		return fmt.Errorf("get current checkpoint: %w", err)
+	}
+
+	// Create new checkpoint directory.
+	checkpointName, err := session.CreateHandoffCheckpoint(sessionDir, parentCheckpoint)
+	if err != nil {
+		return fmt.Errorf("create handoff checkpoint: %w", err)
+	}
+
+	// Build checkpoint messages from handoff doc + Q&A turns.
+	entries := buildHandoffEntries(handoffDoc, qaTurns)
+
+	// Write messages to the new checkpoint.
+	if err := session.WriteHandoffMessages(sessionDir, checkpointName, entries); err != nil {
+		return fmt.Errorf("write handoff messages: %w", err)
+	}
+
+	// Write the handoff document as handoff.md.
+	if err := session.WriteHandoffDocument(sessionDir, checkpointName, handoffDoc); err != nil {
+		return fmt.Errorf("write handoff document: %w", err)
+	}
+
+	// Write the current AgentState so the resume path can restore CWD,
+	// token counts, etc. (P1-3). Failures are non-fatal — the checkpoint is
+	// still usable, just without restored agent state.
+	if s.agentCtx.AgentState != nil {
+		if err := session.WriteHandoffAgentState(sessionDir, checkpointName, s.agentCtx.AgentState); err != nil {
+			slog.Warn("[Handoff] Failed to write agent state to checkpoint", "error", err)
+		}
+	}
+
+	// Atomically switch current.txt to the new checkpoint.
+	if err := session.SwitchCheckpoint(sessionDir, checkpointName); err != nil {
+		return fmt.Errorf("switch checkpoint: %w", err)
+	}
+
+	// Reload agent context from the new checkpoint.
+	messages, err := session.LoadHandoffCheckpointMessages(sessionDir, checkpointName)
+	if err != nil {
+		return fmt.Errorf("load checkpoint messages: %w", err)
+	}
+	s.agentCtx.RecentMessages = messages
+
+	// Reset state counters — the new checkpoint starts fresh.
+	s.hardFloorCrossed = false
+	s.hardFloorTurns = 0
+	s.compactionRecs = 0
+	s.emptyRetries = 0
+	s.guardAbortRecovery = false
+
+	slog.Info("[Handoff] Handoff complete",
+		"checkpoint", checkpointName,
+		"parent", parentCheckpoint,
+		"messages", len(messages),
+		"qa_turns", len(qaTurns),
+	)
+
+	return nil
+}
+
+// buildHandoffEntries converts the handoff document and Q&A turns into session
+// entries for the new checkpoint's messages.jsonl.
+//
+// The structure is:
+//   - Handoff doc as a user message.
+//   - Each Q&A turn as: question (user) + answer (assistant).
+func buildHandoffEntries(handoffDoc string, qaTurns []qaTurn) []session.SessionEntry {
+	entries := make([]session.SessionEntry, 0, 1+len(qaTurns)*2)
+
+	// Handoff doc as a user message.
+	now := time.Now().UnixMilli()
+	entries = append(entries, session.SessionEntry{
+		Type:      session.EntryTypeMessage,
+		ID:        generateHandoffEntryID(),
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Message: &agentctx.AgentMessage{
+			Role: "user",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: handoffDoc},
+			},
+			Timestamp: now,
+		},
+	})
+
+	// Each Q&A turn as: question (user) + answer (assistant).
+	for _, turn := range qaTurns {
+		ts := time.Now().UTC().Format(time.RFC3339Nano)
+		ms := time.Now().UnixMilli()
+
+		entries = append(entries, session.SessionEntry{
+			Type:      session.EntryTypeMessage,
+			ID:        generateHandoffEntryID(),
+			Timestamp: ts,
+			Message: &agentctx.AgentMessage{
+				Role: "user",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: turn.Question},
+				},
+				Timestamp: ms,
+			},
+		})
+
+		entries = append(entries, session.SessionEntry{
+			Type:      session.EntryTypeMessage,
+			ID:        generateHandoffEntryID(),
+			Timestamp: ts,
+			Message: &agentctx.AgentMessage{
+				Role: "assistant",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: turn.Answer},
+				},
+				Timestamp: ms,
+			},
+		})
+	}
+
+	return entries
+}
+
+// generateHandoffEntryID returns a short unique ID for a session entry.
+func generateHandoffEntryID() string {
+	return strings.ReplaceAll(uuid.NewString(), "-", "")[:8]
+}
+
+// autoGenerateHandoffDoc generates a handoff document via a minimal LLM call
+// when auto-execute is triggered by the hard floor threshold.
+//
+// It serializes the current conversation and asks the LLM to produce a
+// handoff summary. The resulting document does NOT include the
+// <handoff_complete> marker — performHandoff handles checkpoint creation
+// directly.
+func (s *loopState) autoGenerateHandoffDoc(ctx context.Context) (string, error) {
+	model := getEffectiveModel(s.config)
+	apiKey := getEffectiveAPIKey(s.config)
+
+	oldMessages := s.agentCtx.RecentMessages
+
+	// Serialize old messages into conversation text.
+	var conversationText strings.Builder
+	for _, msg := range oldMessages {
+		if !msg.IsAgentVisible() {
+			continue
+		}
+		text := msg.ExtractText()
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		conversationText.WriteString(fmt.Sprintf("[%s]: %s\n\n", msg.Role, text))
+	}
+
+	if conversationText.Len() == 0 {
+		return "", fmt.Errorf("no conversation content to generate handoff doc from")
+	}
+
+	llmCtx := llm.LLMContext{
+		SystemPrompt: handoffGenerateSystemPrompt,
+		Messages: []llm.LLMMessage{
+			{Role: "user", Content: conversationText.String()},
+		},
+	}
+
+	doc, err := streamLLMText(ctx, model, llmCtx, apiKey)
+	if err != nil {
+		return "", fmt.Errorf("auto-generate handoff doc: %w", err)
+	}
+
+	doc = strings.TrimSpace(doc)
+	if doc == "" {
+		return "", fmt.Errorf("auto-generated handoff doc is empty")
+	}
+
+	return doc, nil
+}

--- a/pkg/agent/handoff_perform.go
+++ b/pkg/agent/handoff_perform.go
@@ -10,13 +10,15 @@ import (
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
 	"github.com/tiancaiamao/ai/pkg/session"
+	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
 
 	"github.com/google/uuid"
 )
 
-// handoffGenerateSystemPrompt instructs the LLM to produce a handoff document
-// from the current conversation. Used by auto-execute.
-const handoffGenerateSystemPrompt = `Summarize the current task, key decisions, and pending work. Include file paths, error context, and next steps. Be thorough but concise.`
+// handoffGenerateInstruction instructs the LLM to produce a handoff document
+// from the current conversation. Sent as a role:"user" message to preserve
+// provider prefix caching with the main agent system prompt.
+const handoffGenerateInstruction = `Summarize the current task, key decisions, and pending work. Include file paths, error context, and next steps. Be thorough but concise.`
 
 // performHandoff executes the complete handoff process:
 //  1. Run Q&A verification on the handoff document.
@@ -33,27 +35,59 @@ func (s *loopState) performHandoff(ctx context.Context, handoffDoc string) error
 	apiKey := getEffectiveAPIKey(s.config)
 	contextWindow := s.config.ContextWindow
 
+	startTime := time.Now()
+
+	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_start",
+		traceevent.Field{Key: "session_dir", Value: s.config.GetSessionDir()})
+
 	// Save old messages before Q&A (Q&A does not mutate RecentMessages, but
 	// we capture a snapshot for clarity).
 	oldMessages := s.agentCtx.RecentMessages
 
 	// Run Q&A verification. Failures here are non-fatal — we proceed with the
 	// checkpoint using whatever Q&A turns were collected.
-	qaTurns, err := runHandoffQA(ctx, model, apiKey, contextWindow, handoffDoc, oldMessages, 3)
+	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_qa_start",
+		traceevent.Field{Key: "max_rounds", Value: handoffQADefaultRounds})
+	qaTurns, err := runHandoffQA(ctx, model, apiKey, contextWindow, handoffDoc, oldMessages, handoffQADefaultRounds, s.agentCtx.SystemPrompt)
 	if err != nil {
 		slog.Warn("[Handoff] Q&A verification failed, proceeding with checkpoint",
 			"error", err,
 			"qa_turns", len(qaTurns),
 		)
 	}
+	totalQuestions := 0
+	totalAnswers := 0
+	for _, t := range qaTurns {
+		totalQuestions += len(t.Question)
+		totalAnswers += len(t.Answer)
+	}
+	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_qa_complete",
+		traceevent.Field{Key: "rounds_completed", Value: len(qaTurns)},
+		traceevent.Field{Key: "total_questions", Value: totalQuestions},
+		traceevent.Field{Key: "total_answers", Value: totalAnswers})
 
-	return s.finalizeHandoff(handoffDoc, qaTurns)
+	if err := s.finalizeHandoff(ctx, handoffDoc, qaTurns); err != nil {
+		traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_failed",
+			traceevent.Field{Key: "error", Value: err.Error()},
+			traceevent.Field{Key: "phase", Value: "checkpoint"})
+		s.handoffPending = false
+		return err
+	}
+
+	durationMs := time.Since(startTime).Milliseconds()
+	checkpoint, _ := session.GetCurrentCheckpoint(s.config.GetSessionDir())
+	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_complete",
+		traceevent.Field{Key: "checkpoint_name", Value: checkpoint},
+		traceevent.Field{Key: "duration_ms", Value: durationMs})
+
+	s.handoffPending = false
+	return nil
 }
 
 // finalizeHandoff creates the checkpoint, writes messages, switches the active
 // checkpoint, and reloads context. It is separated from performHandoff so it
 // can be unit-tested without making LLM calls.
-func (s *loopState) finalizeHandoff(handoffDoc string, qaTurns []qaTurn) error {
+func (s *loopState) finalizeHandoff(ctx context.Context, handoffDoc string, qaTurns []qaTurn) error {
 	sessionDir := s.config.GetSessionDir()
 	if sessionDir == "" {
 		return fmt.Errorf("handoff requires a session directory")
@@ -64,10 +98,22 @@ func (s *loopState) finalizeHandoff(handoffDoc string, qaTurns []qaTurn) error {
 		return fmt.Errorf("get current checkpoint: %w", err)
 	}
 
+	// Read checkpoint count from meta, compute next checkpoint number.
+	checkpointCount, err := session.ReadCheckpointCount(sessionDir)
+	if err != nil {
+		return fmt.Errorf("read checkpoint count: %w", err)
+	}
+	checkpointNum := checkpointCount + 1
+
 	// Create new checkpoint directory.
-	checkpointName, err := session.CreateHandoffCheckpoint(sessionDir, parentCheckpoint)
+	checkpointName, err := session.CreateHandoffCheckpoint(sessionDir, checkpointNum, parentCheckpoint)
 	if err != nil {
 		return fmt.Errorf("create handoff checkpoint: %w", err)
+	}
+
+	// Persist the updated checkpoint count.
+	if err := session.WriteCheckpointCount(sessionDir, checkpointNum); err != nil {
+		return fmt.Errorf("write checkpoint count: %w", err)
 	}
 
 	// Build checkpoint messages from handoff doc + Q&A turns.
@@ -77,6 +123,11 @@ func (s *loopState) finalizeHandoff(handoffDoc string, qaTurns []qaTurn) error {
 	if err := session.WriteHandoffMessages(sessionDir, checkpointName, entries); err != nil {
 		return fmt.Errorf("write handoff messages: %w", err)
 	}
+
+	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_checkpoint_created",
+		traceevent.Field{Key: "checkpoint_name", Value: checkpointName},
+		traceevent.Field{Key: "checkpoint_num", Value: checkpointNum},
+		traceevent.Field{Key: "messages_written", Value: len(entries)})
 
 	// Write the handoff document as handoff.md.
 	if err := session.WriteHandoffDocument(sessionDir, checkpointName, handoffDoc); err != nil {
@@ -92,6 +143,9 @@ func (s *loopState) finalizeHandoff(handoffDoc string, qaTurns []qaTurn) error {
 		}
 	}
 
+	// Capture old message count before switching.
+	oldMessagesCount := len(s.agentCtx.RecentMessages)
+
 	// Atomically switch current.txt to the new checkpoint.
 	if err := session.SwitchCheckpoint(sessionDir, checkpointName); err != nil {
 		return fmt.Errorf("switch checkpoint: %w", err)
@@ -104,9 +158,15 @@ func (s *loopState) finalizeHandoff(handoffDoc string, qaTurns []qaTurn) error {
 	}
 	s.agentCtx.RecentMessages = messages
 
+	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_context_switched",
+		traceevent.Field{Key: "new_checkpoint", Value: checkpointName},
+		traceevent.Field{Key: "old_messages_count", Value: oldMessagesCount},
+		traceevent.Field{Key: "new_messages_count", Value: len(messages)})
+
 	// Reset state counters — the new checkpoint starts fresh.
 	s.hardFloorCrossed = false
 	s.hardFloorTurns = 0
+	s.handoffPending = false
 	s.compactionRecs = 0
 	s.emptyRetries = 0
 	s.guardAbortRecovery = false
@@ -215,22 +275,35 @@ func (s *loopState) autoGenerateHandoffDoc(ctx context.Context) (string, error) 
 		return "", fmt.Errorf("no conversation content to generate handoff doc from")
 	}
 
+	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_auto_generate_start",
+		traceevent.Field{Key: "conversation_length", Value: conversationText.Len()})
+
+	// Reuse the main agent system prompt to preserve provider prefix caching.
+	// Send the generation instruction as a user message.
 	llmCtx := llm.LLMContext{
-		SystemPrompt: handoffGenerateSystemPrompt,
+		SystemPrompt: s.agentCtx.SystemPrompt,
 		Messages: []llm.LLMMessage{
+			{Role: "user", Content: handoffGenerateInstruction},
 			{Role: "user", Content: conversationText.String()},
 		},
 	}
 
 	doc, err := streamLLMText(ctx, model, llmCtx, apiKey)
 	if err != nil {
+		traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_auto_generate_failed",
+			traceevent.Field{Key: "error", Value: err.Error()})
 		return "", fmt.Errorf("auto-generate handoff doc: %w", err)
 	}
 
 	doc = strings.TrimSpace(doc)
 	if doc == "" {
+		traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_auto_generate_failed",
+			traceevent.Field{Key: "error", Value: "empty doc"})
 		return "", fmt.Errorf("auto-generated handoff doc is empty")
 	}
+
+	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_auto_generate_complete",
+		traceevent.Field{Key: "doc_length", Value: len(doc)})
 
 	return doc, nil
 }

--- a/pkg/agent/handoff_perform.go
+++ b/pkg/agent/handoff_perform.go
@@ -16,10 +16,36 @@ import (
 	"github.com/google/uuid"
 )
 
+// handoffGenerateSystemPrompt is a focused system prompt for handoff document
+// generation. It replaces the main agent system prompt to avoid confusing the
+// model — a coding assistant prompt and a summarization task are incompatible.
+const handoffGenerateSystemPrompt = `You are a context handoff document generator. Your job is to read the conversation transcript and produce a comprehensive handoff document that allows a fresh agent to continue the work without losing context.
+
+The document MUST include these sections:
+
+## Current Task
+What is being worked on right now. What was the original goal.
+
+## Key Decisions
+Important decisions made, alternatives considered, and why.
+
+## Completed Work
+What has been done so far. File paths modified, commands run, results obtained.
+
+## Pending Work
+What remains to be done. Specific next steps.
+
+## Important Context
+File paths, error messages, API constraints, environment details, or anything a fresh agent would need to know.
+
+## Open Questions
+Unresolved issues or questions that need clarification.
+
+Be specific. Include exact file paths, error messages, and code snippets. A fresh agent reading this document should be able to continue the work immediately.`
+
 // handoffGenerateInstruction instructs the LLM to produce a handoff document
-// from the current conversation. Sent as a role:"user" message to preserve
-// provider prefix caching with the main agent system prompt.
-const handoffGenerateInstruction = `Summarize the current task, key decisions, and pending work. Include file paths, error context, and next steps. Be thorough but concise.`
+// from the current conversation transcript.
+const handoffGenerateInstruction = `Below is a conversation transcript. Read it carefully and write a handoff document using the format specified in your instructions. The document must be detailed enough for a fresh agent to continue the work.`
 
 // performHandoff executes the complete handoff process:
 //  1. Run Q&A verification on the handoff document.
@@ -311,9 +337,11 @@ func (s *loopState) autoGenerateHandoffDoc(ctx context.Context) (string, error) 
 		traceevent.Field{Key: "message_count", Value: len(lines)},
 		traceevent.Field{Key: "transcript_bytes", Value: totalBytes})
 
-	// Reuse the main agent system prompt to preserve provider prefix caching.
+	// Use a dedicated system prompt for handoff generation. The main agent
+	// system prompt (coding assistant) confuses the model into trying to
+	// respond as a coding assistant rather than writing a summary.
 	llmCtx := llm.LLMContext{
-		SystemPrompt: s.agentCtx.SystemPrompt,
+		SystemPrompt: handoffGenerateSystemPrompt,
 		Messages: []llm.LLMMessage{
 			{Role: "user", Content: handoffGenerateInstruction},
 			{Role: "user", Content: conversationText},

--- a/pkg/agent/handoff_perform.go
+++ b/pkg/agent/handoff_perform.go
@@ -16,10 +16,11 @@ import (
 	"github.com/google/uuid"
 )
 
-// handoffGenerateSystemPrompt is a focused system prompt for handoff document
-// generation. It replaces the main agent system prompt to avoid confusing the
-// model — a coding assistant prompt and a summarization task are incompatible.
-const handoffGenerateSystemPrompt = `You are a context handoff document generator. Your job is to read the conversation transcript and produce a comprehensive handoff document that allows a fresh agent to continue the work without losing context.
+// handoffGenerateInstruction is appended as a user message to the existing
+// conversation to instruct the model to generate a handoff document. It reuses
+// the original session context (system prompt + messages) so provider prefix
+// cache is preserved — only this instruction is new.
+const handoffGenerateInstruction = `Based on the conversation above, generate a comprehensive handoff document so that a fresh agent can continue the work without losing context.
 
 The document MUST include these sections:
 
@@ -42,10 +43,6 @@ File paths, error messages, API constraints, environment details, or anything a 
 Unresolved issues or questions that need clarification.
 
 Be specific. Include exact file paths, error messages, and code snippets. A fresh agent reading this document should be able to continue the work immediately.`
-
-// handoffGenerateInstruction instructs the LLM to produce a handoff document
-// from the current conversation transcript.
-const handoffGenerateInstruction = `Below is a conversation transcript. Read it carefully and write a handoff document using the format specified in your instructions. The document must be detailed enough for a fresh agent to continue the work.`
 
 // performHandoff executes the complete handoff process:
 //  1. Run Q&A verification on the handoff document.
@@ -290,57 +287,34 @@ func (s *loopState) autoGenerateHandoffDoc(ctx context.Context) (string, error) 
 	model := getEffectiveModel(s.config)
 	apiKey := getEffectiveAPIKey(s.config)
 
-	oldMessages := s.agentCtx.RecentMessages
-
-	// Serialize conversation into a text transcript. We use a single user
-	// message (not raw LLM messages) to avoid role-formatting issues — the
-	// raw conversation may have consecutive same-role messages or tool-only
-	// messages that violate API constraints.
-	const maxTranscriptBytes = 512 * 1024 // ~128K tokens
-
-	var lines []string
-	totalBytes := 0
-	for i := len(oldMessages) - 1; i >= 0; i-- {
-		msg := oldMessages[i]
-		if !msg.IsAgentVisible() {
-			continue
-		}
-		text := msg.ExtractText()
-		if strings.TrimSpace(text) == "" {
-			continue
-		}
-		line := fmt.Sprintf("[%s]: %s", msg.Role, text)
-		if totalBytes+len(line) > maxTranscriptBytes {
-			break
-		}
-		lines = append(lines, line)
-		totalBytes += len(line)
-	}
-
-	// Reverse to chronological order (we walked backward).
-	for i, j := 0, len(lines)-1; i < j; i, j = i+1, j-1 {
-		lines[i], lines[j] = lines[j], lines[i]
-	}
-
-	if len(lines) == 0 {
+	if len(s.agentCtx.RecentMessages) == 0 {
 		return "", fmt.Errorf("no conversation content to generate handoff doc from")
 	}
 
-	conversationText := strings.Join(lines, "\n\n")
+	// Reuse the original session's system prompt and messages to maximize
+	// provider prefix cache hits. The entire conversation prefix is identical
+	// to a normal LLM turn — only the appended instruction is new.
+	systemPrompt := s.agentCtx.SystemPrompt
+	if instruction := prompt.ThinkingInstruction(s.config.ThinkingLevel); instruction != "" {
+		if strings.TrimSpace(systemPrompt) == "" {
+			systemPrompt = instruction
+		} else {
+			systemPrompt = systemPrompt + "\n\n" + instruction
+		}
+	}
+
+	messages := ConvertMessagesToLLM(ctx, s.agentCtx.RecentMessages)
+	messages = append(messages, llm.LLMMessage{
+		Role:    "user",
+		Content: handoffGenerateInstruction,
+	})
 
 	traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_auto_generate_start",
-		traceevent.Field{Key: "message_count", Value: len(lines)},
-		traceevent.Field{Key: "transcript_bytes", Value: totalBytes})
+		traceevent.Field{Key: "message_count", Value: len(messages)})
 
-	// Use a dedicated system prompt for handoff generation. The main agent
-	// system prompt (coding assistant) confuses the model into trying to
-	// respond as a coding assistant rather than writing a summary.
 	llmCtx := llm.LLMContext{
-		SystemPrompt: handoffGenerateSystemPrompt,
-		Messages: []llm.LLMMessage{
-			{Role: "user", Content: handoffGenerateInstruction},
-			{Role: "user", Content: conversationText},
-		},
+		SystemPrompt: systemPrompt,
+		Messages:     messages,
 	}
 
 	doc, err := streamLLMText(ctx, model, llmCtx, apiKey)

--- a/pkg/agent/handoff_perform_test.go
+++ b/pkg/agent/handoff_perform_test.go
@@ -1,0 +1,361 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/session"
+)
+
+// makeTextMsg builds an agent-visible text message for testing.
+func makeTextMsg(role, text string) agentctx.AgentMessage {
+	return agentctx.AgentMessage{
+		Role: role,
+		Content: []agentctx.ContentBlock{
+			agentctx.TextContent{Type: "text", Text: text},
+		},
+	}
+}
+
+// newHandoffTestLoopState creates a loopState suitable for testing finalizeHandoff.
+func newHandoffTestLoopState(sessionDir string) *loopState {
+	cfg := &LoopConfig{
+		GetSessionDir: func() string { return sessionDir },
+	}
+	agentCtx := agentctx.NewAgentContext("test system prompt")
+	return &loopState{
+		config:   cfg,
+		agentCtx: agentCtx,
+	}
+}
+
+func TestFinalizeHandoff_CreatesCheckpoint(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	// The initial checkpoint should be cp_001.
+	initialCp, err := session.GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint: %v", err)
+	}
+	if initialCp != "cp_001" {
+		t.Fatalf("expected initial checkpoint cp_001, got %s", initialCp)
+	}
+
+	state := newHandoffTestLoopState(sessionDir)
+	state.agentCtx.RecentMessages = []agentctx.AgentMessage{
+		makeTextMsg("user", "old context message"),
+	}
+	// Simulate that the hard floor was crossed.
+	state.hardFloorCrossed = true
+	state.hardFloorTurns = 3
+	state.compactionRecs = 1
+
+	handoffDoc := "# Handoff\n\nTask: implement feature X\nStatus: in progress\nNext: write tests"
+	qaTurns := []qaTurn{
+		{Question: "What files were modified?", Answer: "main.go and utils.go"},
+		{Question: "Any errors?", Answer: "No errors encountered"},
+	}
+
+	if err := state.finalizeHandoff(handoffDoc, qaTurns); err != nil {
+		t.Fatalf("finalizeHandoff: %v", err)
+	}
+
+	// Verify current.txt now points to cp_002.
+	currentCp, err := session.GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint after handoff: %v", err)
+	}
+	if currentCp != "cp_002" {
+		t.Errorf("expected checkpoint cp_002, got %s", currentCp)
+	}
+
+	// Verify handoff.md exists in the new checkpoint.
+	handoffPath := filepath.Join(sessionDir, "checkpoints", "cp_002", "handoff.md")
+	if _, err := os.Stat(handoffPath); os.IsNotExist(err) {
+		t.Error("handoff.md was not created")
+	}
+
+	// Verify messages.jsonl exists.
+	msgsPath := filepath.Join(sessionDir, "checkpoints", "cp_002", "messages.jsonl")
+	if _, err := os.Stat(msgsPath); os.IsNotExist(err) {
+		t.Error("messages.jsonl was not created")
+	}
+}
+
+func TestFinalizeHandoff_ReloadsContext(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	state := newHandoffTestLoopState(sessionDir)
+	state.agentCtx.RecentMessages = []agentctx.AgentMessage{
+		makeTextMsg("user", "this should be replaced"),
+	}
+
+	handoffDoc := "Fresh context after handoff"
+	qaTurns := []qaTurn{
+		{Question: "Q1?", Answer: "A1"},
+	}
+
+	if err := state.finalizeHandoff(handoffDoc, qaTurns); err != nil {
+		t.Fatalf("finalizeHandoff: %v", err)
+	}
+
+	// After reload, RecentMessages should come from the new checkpoint.
+	// Expected: 1 handoff doc (user) + 1 Q (user) + 1 A (assistant) = 3 messages.
+	msgs := state.agentCtx.RecentMessages
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages after reload, got %d", len(msgs))
+	}
+
+	// First message should be the handoff doc.
+	if msgs[0].Role != "user" {
+		t.Errorf("expected first msg role 'user', got %q", msgs[0].Role)
+	}
+	if text := msgs[0].ExtractText(); text != handoffDoc {
+		t.Errorf("expected first msg text=%q, got %q", handoffDoc, text)
+	}
+
+	// Second message should be the question.
+	if msgs[1].Role != "user" {
+		t.Errorf("expected second msg role 'user', got %q", msgs[1].Role)
+	}
+
+	// Third message should be the answer.
+	if msgs[2].Role != "assistant" {
+		t.Errorf("expected third msg role 'assistant', got %q", msgs[2].Role)
+	}
+}
+
+func TestFinalizeHandoff_ResetsState(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	state := newHandoffTestLoopState(sessionDir)
+	state.hardFloorCrossed = true
+	state.hardFloorTurns = 5
+	state.compactionRecs = 2
+	state.emptyRetries = 1
+	state.guardAbortRecovery = true
+
+	if err := state.finalizeHandoff("test doc", nil); err != nil {
+		t.Fatalf("finalizeHandoff: %v", err)
+	}
+
+	if state.hardFloorCrossed {
+		t.Error("hardFloorCrossed should be reset to false")
+	}
+	if state.hardFloorTurns != 0 {
+		t.Errorf("hardFloorTurns should be 0, got %d", state.hardFloorTurns)
+	}
+	if state.compactionRecs != 0 {
+		t.Errorf("compactionRecs should be 0, got %d", state.compactionRecs)
+	}
+	if state.emptyRetries != 0 {
+		t.Errorf("emptyRetries should be 0, got %d", state.emptyRetries)
+	}
+	if state.guardAbortRecovery {
+		t.Error("guardAbortRecovery should be reset to false")
+	}
+}
+
+func TestFinalizeHandoff_NoSessionDir(t *testing.T) {
+	state := newHandoffTestLoopState("")
+	err := state.finalizeHandoff("test doc", nil)
+	if err == nil {
+		t.Fatal("expected error for empty session dir")
+	}
+}
+
+func TestFinalizeHandoff_HandoffDocWritten(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	state := newHandoffTestLoopState(sessionDir)
+
+	handoffDoc := "# Detailed Handoff\n\n## Task\nImplement feature Y\n## Files\n- a.go\n- b.go"
+	if err := state.finalizeHandoff(handoffDoc, nil); err != nil {
+		t.Fatalf("finalizeHandoff: %v", err)
+	}
+
+	currentCp, _ := session.GetCurrentCheckpoint(sessionDir)
+	handoffPath := filepath.Join(sessionDir, "checkpoints", currentCp, "handoff.md")
+
+	data, err := os.ReadFile(handoffPath)
+	if err != nil {
+		t.Fatalf("reading handoff.md: %v", err)
+	}
+
+	if string(data) != handoffDoc {
+		t.Errorf("handoff.md content mismatch:\n got=%q\nwant=%q", string(data), handoffDoc)
+	}
+}
+
+func TestFinalizeHandoff_MultipleChainedHandoffs(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	state := newHandoffTestLoopState(sessionDir)
+
+	// Perform three chained handoffs.
+	for i := 0; i < 3; i++ {
+		doc := "Handoff round " + string(rune('A'+i))
+		if err := state.finalizeHandoff(doc, []qaTurn{
+			{Question: "Q" + string(rune('A'+i)), Answer: "A" + string(rune('A'+i))},
+		}); err != nil {
+			t.Fatalf("finalizeHandoff round %d: %v", i, err)
+		}
+	}
+
+	// After 3 handoffs: cp_001 (init) → cp_002 → cp_003 → cp_004.
+	currentCp, err := session.GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint: %v", err)
+	}
+	if currentCp != "cp_004" {
+		t.Errorf("expected checkpoint cp_004, got %s", currentCp)
+	}
+
+	// All 4 checkpoint directories should exist.
+	for i := 1; i <= 4; i++ {
+		cpDir := filepath.Join(sessionDir, "checkpoints", "cp_"+padZero(i))
+		if _, err := os.Stat(cpDir); os.IsNotExist(err) {
+			t.Errorf("checkpoint directory %s does not exist", cpDir)
+		}
+	}
+
+	// RecentMessages should have 3 messages from the last checkpoint
+	// (1 handoff doc + 1 Q + 1 A).
+	if len(state.agentCtx.RecentMessages) != 3 {
+		t.Errorf("expected 3 messages after final handoff, got %d",
+			len(state.agentCtx.RecentMessages))
+	}
+}
+
+// padZero converts an int to a zero-padded 3-digit string (1 → "001").
+func padZero(n int) string {
+	if n < 10 {
+		return "00" + string(rune('0'+n))
+	}
+	if n < 100 {
+		return "0" + string(rune('0'+n/10)) + string(rune('0'+n%10))
+	}
+	return string(rune('0'+n/100)) + string(rune('0'+(n/10)%10)) + string(rune('0'+n%10))
+}
+
+func TestBuildHandoffEntries(t *testing.T) {
+	handoffDoc := "The handoff doc text"
+	qaTurns := []qaTurn{
+		{Question: "Question 1", Answer: "Answer 1"},
+		{Question: "Question 2", Answer: "Answer 2"},
+	}
+
+	entries := buildHandoffEntries(handoffDoc, qaTurns)
+
+	// Expected: 1 handoff doc + 2 * 2 Q&A = 5 entries.
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
+	}
+
+	// First entry is the handoff doc as a user message.
+	if entries[0].Type != session.EntryTypeMessage {
+		t.Errorf("expected type %q, got %q", session.EntryTypeMessage, entries[0].Type)
+	}
+	if entries[0].Message.Role != "user" {
+		t.Errorf("expected first msg role 'user', got %q", entries[0].Message.Role)
+	}
+	if entries[0].Message.ExtractText() != handoffDoc {
+		t.Errorf("expected first msg text=%q, got %q",
+			handoffDoc, entries[0].Message.ExtractText())
+	}
+
+	// Second entry is Q1 (user).
+	if entries[1].Message.Role != "user" {
+		t.Errorf("expected Q1 role 'user', got %q", entries[1].Message.Role)
+	}
+	if entries[1].Message.ExtractText() != "Question 1" {
+		t.Errorf("expected Q1 text, got %q", entries[1].Message.ExtractText())
+	}
+
+	// Third entry is A1 (assistant).
+	if entries[2].Message.Role != "assistant" {
+		t.Errorf("expected A1 role 'assistant', got %q", entries[2].Message.Role)
+	}
+	if entries[2].Message.ExtractText() != "Answer 1" {
+		t.Errorf("expected A1 text, got %q", entries[2].Message.ExtractText())
+	}
+
+	// All entries should have unique IDs.
+	seen := make(map[string]bool)
+	for _, e := range entries {
+		if seen[e.ID] {
+			t.Errorf("duplicate entry ID: %s", e.ID)
+		}
+		seen[e.ID] = true
+	}
+}
+
+func TestBuildHandoffEntries_NoQA(t *testing.T) {
+	handoffDoc := "Just the doc"
+	entries := buildHandoffEntries(handoffDoc, nil)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry with no Q&A, got %d", len(entries))
+	}
+	if entries[0].Message.ExtractText() != handoffDoc {
+		t.Errorf("expected handoff doc text, got %q",
+			entries[0].Message.ExtractText())
+	}
+}
+
+// TestFinalizeHandoff_AgentStateWritten verifies that finalizeHandoff writes
+// agent_state.json to the new checkpoint (P1-3).
+func TestFinalizeHandoff_AgentStateWritten(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	state := newHandoffTestLoopState(sessionDir)
+	// Set up meaningful agent state.
+	state.agentCtx.AgentState.WorkspaceRoot = "/project"
+	state.agentCtx.AgentState.CurrentWorkingDir = "/project/src"
+	state.agentCtx.AgentState.TotalTurns = 10
+
+	if err := state.finalizeHandoff("test doc", nil); err != nil {
+		t.Fatalf("finalizeHandoff: %v", err)
+	}
+
+	currentCp, _ := session.GetCurrentCheckpoint(sessionDir)
+
+	// Read back agent_state.json from the new checkpoint.
+	loaded, err := session.LoadHandoffCheckpointAgentState(sessionDir, currentCp)
+	if err != nil {
+		t.Fatalf("LoadHandoffCheckpointAgentState: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil agent state")
+	}
+	if loaded.WorkspaceRoot != "/project" {
+		t.Errorf("expected WorkspaceRoot /project, got %q", loaded.WorkspaceRoot)
+	}
+	if loaded.CurrentWorkingDir != "/project/src" {
+		t.Errorf("expected CurrentWorkingDir /project/src, got %q", loaded.CurrentWorkingDir)
+	}
+	if loaded.TotalTurns != 10 {
+		t.Errorf("expected TotalTurns 10, got %d", loaded.TotalTurns)
+	}
+}

--- a/pkg/agent/handoff_perform_test.go
+++ b/pkg/agent/handoff_perform_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,7 +63,7 @@ func TestFinalizeHandoff_CreatesCheckpoint(t *testing.T) {
 		{Question: "Any errors?", Answer: "No errors encountered"},
 	}
 
-	if err := state.finalizeHandoff(handoffDoc, qaTurns); err != nil {
+	if err := state.finalizeHandoff(context.Background(), handoffDoc, qaTurns); err != nil {
 		t.Fatalf("finalizeHandoff: %v", err)
 	}
 
@@ -104,7 +105,7 @@ func TestFinalizeHandoff_ReloadsContext(t *testing.T) {
 		{Question: "Q1?", Answer: "A1"},
 	}
 
-	if err := state.finalizeHandoff(handoffDoc, qaTurns); err != nil {
+	if err := state.finalizeHandoff(context.Background(), handoffDoc, qaTurns); err != nil {
 		t.Fatalf("finalizeHandoff: %v", err)
 	}
 
@@ -147,7 +148,7 @@ func TestFinalizeHandoff_ResetsState(t *testing.T) {
 	state.emptyRetries = 1
 	state.guardAbortRecovery = true
 
-	if err := state.finalizeHandoff("test doc", nil); err != nil {
+	if err := state.finalizeHandoff(context.Background(), "test doc", nil); err != nil {
 		t.Fatalf("finalizeHandoff: %v", err)
 	}
 
@@ -170,7 +171,7 @@ func TestFinalizeHandoff_ResetsState(t *testing.T) {
 
 func TestFinalizeHandoff_NoSessionDir(t *testing.T) {
 	state := newHandoffTestLoopState("")
-	err := state.finalizeHandoff("test doc", nil)
+	err := state.finalizeHandoff(context.Background(), "test doc", nil)
 	if err == nil {
 		t.Fatal("expected error for empty session dir")
 	}
@@ -185,7 +186,7 @@ func TestFinalizeHandoff_HandoffDocWritten(t *testing.T) {
 	state := newHandoffTestLoopState(sessionDir)
 
 	handoffDoc := "# Detailed Handoff\n\n## Task\nImplement feature Y\n## Files\n- a.go\n- b.go"
-	if err := state.finalizeHandoff(handoffDoc, nil); err != nil {
+	if err := state.finalizeHandoff(context.Background(), handoffDoc, nil); err != nil {
 		t.Fatalf("finalizeHandoff: %v", err)
 	}
 
@@ -213,7 +214,7 @@ func TestFinalizeHandoff_MultipleChainedHandoffs(t *testing.T) {
 	// Perform three chained handoffs.
 	for i := 0; i < 3; i++ {
 		doc := "Handoff round " + string(rune('A'+i))
-		if err := state.finalizeHandoff(doc, []qaTurn{
+		if err := state.finalizeHandoff(context.Background(), doc, []qaTurn{
 			{Question: "Q" + string(rune('A'+i)), Answer: "A" + string(rune('A'+i))},
 		}); err != nil {
 			t.Fatalf("finalizeHandoff round %d: %v", i, err)
@@ -335,7 +336,7 @@ func TestFinalizeHandoff_AgentStateWritten(t *testing.T) {
 	state.agentCtx.AgentState.CurrentWorkingDir = "/project/src"
 	state.agentCtx.AgentState.TotalTurns = 10
 
-	if err := state.finalizeHandoff("test doc", nil); err != nil {
+	if err := state.finalizeHandoff(context.Background(), "test doc", nil); err != nil {
 		t.Fatalf("finalizeHandoff: %v", err)
 	}
 

--- a/pkg/agent/handoff_qa.go
+++ b/pkg/agent/handoff_qa.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
 	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
 )
@@ -25,7 +24,7 @@ const (
 	// handoffQAChunkTimeout is the inter-chunk timeout passed to StreamLLM.
 	handoffQAChunkTimeout = 2 * time.Minute
 	// handoffQADefaultRounds is the default number of Q&A rounds.
-	handoffQADefaultRounds = 3
+	handoffQADefaultRounds = 1
 )
 
 // qaAskUserMessage instructs the LLM to identify gaps in the handoff document.
@@ -68,14 +67,23 @@ func hasNoGaps(text string) bool {
 }
 
 // streamLLMText is a helper that calls llm.StreamLLM and collects the full text
-// response. It applies a bounded timeout via context.WithTimeout.
+// response. It applies a bounded timeout via context.WithTimeout and includes
+// repetition detection to prevent the model from getting stuck in a loop.
 func streamLLMText(ctx context.Context, model llm.Model, llmCtx llm.LLMContext, apiKey string) (string, error) {
 	callCtx, cancel := context.WithTimeout(ctx, handoffQATimeout)
 	defer cancel()
 
 	llmStream := llm.StreamLLM(callCtx, model, llmCtx, apiKey, handoffQAChunkTimeout)
 
+	const (
+		maxRepeats     = 20        // consecutive identical deltas → circuit breaker
+		maxOutputChars = 64 * 1024 // hard cap (~16K tokens) to bound runaway output
+	)
+
 	var text strings.Builder
+	var lastDelta string
+	repeatCount := 0
+
 	for event := range llmStream.Iterator(callCtx) {
 		if event.Done {
 			break
@@ -83,6 +91,27 @@ func streamLLMText(ctx context.Context, model llm.Model, llmCtx llm.LLMContext, 
 		switch e := event.Value.(type) {
 		case llm.LLMTextDeltaEvent:
 			text.WriteString(e.Delta)
+
+			// Repetition detection: identical chunks streamed consecutively
+			// indicate the model is stuck (observed during handoff Q&A).
+			if e.Delta == lastDelta {
+				repeatCount++
+				if repeatCount >= maxRepeats {
+					slog.Warn("[Handoff] streamLLMText: repetition detected, breaking",
+						"repeats", repeatCount, "delta_len", len(e.Delta))
+					break
+				}
+			} else {
+				repeatCount = 0
+			}
+			lastDelta = e.Delta
+
+			// Hard cap to bound runaway output even if chunk boundaries vary.
+			if text.Len() > maxOutputChars {
+				slog.Warn("[Handoff] streamLLMText: output cap exceeded, breaking",
+					"len", text.Len(), "cap", maxOutputChars)
+				break
+			}
 		case llm.LLMErrorEvent:
 			return "", e.Error
 		}
@@ -97,8 +126,8 @@ func streamLLMText(ctx context.Context, model llm.Model, llmCtx llm.LLMContext, 
 //  1. Ask questions: send the handoff doc to the LLM (without old context) to
 //     identify gaps.
 //  2. If no gaps found → break early.
-//  3. Answer questions: send old context messages plus the questions to the
-//     LLM and collect the answer.
+//  3. Answer questions: send the handoff doc plus the questions to the LLM
+//     and collect the answer.
 //  4. Store the question-answer pair as a qaTurn and augment the handoff doc
 //     with the Q&A for the next round.
 //
@@ -107,9 +136,7 @@ func runHandoffQA(
 	ctx context.Context,
 	model llm.Model,
 	apiKey string,
-	contextWindow int,
 	handoffDoc string,
-	oldMessages []agentctx.AgentMessage,
 	maxRounds int,
 	systemPrompt string,
 ) ([]qaTurn, error) {
@@ -141,41 +168,17 @@ func runHandoffQA(
 		if hasNoGaps(questions) {
 			slog.Info("[Handoff] QA verification complete — no gaps found",
 				"round", round)
+			span.End()
 			break
 		}
 
-		// --- Answer questions: send old context + questions to LLM.
-		// Serialize conversation into a text transcript (same approach as
-		// autoGenerateHandoffDoc) to avoid role-formatting issues with raw
-		// messages (toolResult role, consecutive same-role, etc.).
-		const maxTranscriptBytes = 512 * 1024 // ~128K tokens
-		var lines []string
-		totalBytes := 0
-		for i := len(oldMessages) - 1; i >= 0; i-- {
-			msg := oldMessages[i]
-			if !msg.IsAgentVisible() {
-				continue
-			}
-			text := msg.ExtractText()
-			if strings.TrimSpace(text) == "" {
-				continue
-			}
-			line := fmt.Sprintf("[%s]: %s", msg.Role, text)
-			if totalBytes+len(line) > maxTranscriptBytes {
-				break
-			}
-			lines = append(lines, line)
-			totalBytes += len(line)
-		}
-		for i, j := 0, len(lines)-1; i < j; i, j = i+1, j-1 {
-			lines[i], lines[j] = lines[j], lines[i]
-		}
-		conversationText := strings.Join(lines, "\n\n")
-
+		// --- Answer questions: send handoff doc + questions to LLM.
+		// Use the handoff doc as context (not the raw conversation) — it's
+		// already a focused summary and avoids resending 100K+ of raw messages.
 		answerCtx := llm.LLMContext{
 			SystemPrompt: systemPrompt,
 			Messages: []llm.LLMMessage{
-				{Role: "user", Content: conversationText},
+				{Role: "user", Content: handoffDoc},
 				{Role: "user", Content: fmt.Sprintf(qaAnswerUserMessageTemplate, questions)},
 			},
 		}

--- a/pkg/agent/handoff_qa.go
+++ b/pkg/agent/handoff_qa.go
@@ -145,8 +145,14 @@ func runHandoffQA(
 		}
 
 		// --- Answer questions: send old context + questions to LLM.
-		answerMessages := make([]llm.LLMMessage, 0, len(oldMessages)+1)
-		for _, msg := range oldMessages {
+		// Serialize conversation into a text transcript (same approach as
+		// autoGenerateHandoffDoc) to avoid role-formatting issues with raw
+		// messages (toolResult role, consecutive same-role, etc.).
+		const maxTranscriptBytes = 512 * 1024 // ~128K tokens
+		var lines []string
+		totalBytes := 0
+		for i := len(oldMessages) - 1; i >= 0; i-- {
+			msg := oldMessages[i]
 			if !msg.IsAgentVisible() {
 				continue
 			}
@@ -154,22 +160,24 @@ func runHandoffQA(
 			if strings.TrimSpace(text) == "" {
 				continue
 			}
-			answerMessages = append(answerMessages, llm.LLMMessage{
-				Role:    msg.Role,
-				Content: text,
-			})
+			line := fmt.Sprintf("[%s]: %s", msg.Role, text)
+			if totalBytes+len(line) > maxTranscriptBytes {
+				break
+			}
+			lines = append(lines, line)
+			totalBytes += len(line)
 		}
-		answerMessages = append(answerMessages, llm.LLMMessage{
-			Role: "user",
-			Content: fmt.Sprintf(
-				qaAnswerUserMessageTemplate,
-				questions,
-			),
-		})
+		for i, j := 0, len(lines)-1; i < j; i, j = i+1, j-1 {
+			lines[i], lines[j] = lines[j], lines[i]
+		}
+		conversationText := strings.Join(lines, "\n\n")
 
 		answerCtx := llm.LLMContext{
 			SystemPrompt: systemPrompt,
-			Messages:     answerMessages,
+			Messages: []llm.LLMMessage{
+				{Role: "user", Content: conversationText},
+				{Role: "user", Content: fmt.Sprintf(qaAnswerUserMessageTemplate, questions)},
+			},
 		}
 		answer, err := streamLLMText(ctx, model, answerCtx, apiKey)
 		if err != nil {

--- a/pkg/agent/handoff_qa.go
+++ b/pkg/agent/handoff_qa.go
@@ -9,6 +9,7 @@ import (
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
+	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
 )
 
 // qaTurn represents a single question-answer exchange during handoff
@@ -27,12 +28,16 @@ const (
 	handoffQADefaultRounds = 3
 )
 
-// qaAskSystemPrompt instructs the LLM to identify gaps in the handoff document.
-const qaAskSystemPrompt = `You are reviewing a handoff document. Identify any critical information that is missing or unclear. Ask specific questions to fill the gaps. Focus on: current task state, key decisions, pending work, file paths, error context. If the document is complete and has no gaps, respond with exactly "no gaps found".`
+// qaAskUserMessage instructs the LLM to identify gaps in the handoff document.
+// Sent as a role:"user" message so the system prompt prefix is preserved for
+// provider prefix caching.
+const qaAskUserMessage = `You are being asked to review a handoff document for completeness. Identify any critical information that is missing or unclear. Ask specific questions. If the document is complete, respond with 'COMPLETE'. Focus on: current task state, key decisions, pending work, file paths, error context.`
 
 // qaAnswerSystemPrompt instructs the LLM to answer questions from conversation
 // history.
-const qaAnswerSystemPrompt = `Answer the following questions based on the conversation history. Be concise and specific. If the information is not available in the history, say so.`
+// qaAnswerUserMessage is the template for requesting answers about the handoff
+// document from conversation history. Sent as a role:"user" message.
+const qaAnswerUserMessageTemplate = `Answer these questions about the handoff document based on the conversation history: %s`
 
 // noGapsIndicators are substrings that signal the LLM found no gaps. The check
 // is case-insensitive.
@@ -106,6 +111,7 @@ func runHandoffQA(
 	handoffDoc string,
 	oldMessages []agentctx.AgentMessage,
 	maxRounds int,
+	systemPrompt string,
 ) ([]qaTurn, error) {
 	if maxRounds <= 0 {
 		maxRounds = handoffQADefaultRounds
@@ -114,10 +120,16 @@ func runHandoffQA(
 	var turns []qaTurn
 
 	for round := 0; round < maxRounds; round++ {
-		// --- Ask questions: send handoff doc to LLM without old context.
+		// --- Ask questions: send handoff doc + QA instructions as user messages.
+		// The system prompt is reused from the main agent loop to preserve
+		// provider prefix caching.
+		span := traceevent.StartSpan(ctx, "handoff_qa_round", traceevent.CategoryEvent,
+			traceevent.Field{Key: "round", Value: round})
+
 		askCtx := llm.LLMContext{
-			SystemPrompt: qaAskSystemPrompt,
+			SystemPrompt: systemPrompt,
 			Messages: []llm.LLMMessage{
+				{Role: "user", Content: qaAskUserMessage},
 				{Role: "user", Content: handoffDoc},
 			},
 		}
@@ -150,13 +162,13 @@ func runHandoffQA(
 		answerMessages = append(answerMessages, llm.LLMMessage{
 			Role: "user",
 			Content: fmt.Sprintf(
-				"Please answer these questions about the handoff document:\n\n%s",
+				qaAnswerUserMessageTemplate,
 				questions,
 			),
 		})
 
 		answerCtx := llm.LLMContext{
-			SystemPrompt: qaAnswerSystemPrompt,
+			SystemPrompt: systemPrompt,
 			Messages:     answerMessages,
 		}
 		answer, err := streamLLMText(ctx, model, answerCtx, apiKey)
@@ -181,6 +193,8 @@ func runHandoffQA(
 			"%s\n\n## Q&A Round %d\n\n**Q:** %s\n\n**A:** %s",
 			handoffDoc, round+1, questions, answer,
 		)
+
+		span.End()
 	}
 
 	return turns, nil

--- a/pkg/agent/handoff_qa.go
+++ b/pkg/agent/handoff_qa.go
@@ -1,0 +1,187 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/llm"
+)
+
+// qaTurn represents a single question-answer exchange during handoff
+// verification.
+type qaTurn struct {
+	Question string
+	Answer   string
+}
+
+const (
+	// handoffQATimeout is the per-call timeout for each Q&A LLM call.
+	handoffQATimeout = 5 * time.Minute
+	// handoffQAChunkTimeout is the inter-chunk timeout passed to StreamLLM.
+	handoffQAChunkTimeout = 2 * time.Minute
+	// handoffQADefaultRounds is the default number of Q&A rounds.
+	handoffQADefaultRounds = 3
+)
+
+// qaAskSystemPrompt instructs the LLM to identify gaps in the handoff document.
+const qaAskSystemPrompt = `You are reviewing a handoff document. Identify any critical information that is missing or unclear. Ask specific questions to fill the gaps. Focus on: current task state, key decisions, pending work, file paths, error context. If the document is complete and has no gaps, respond with exactly "no gaps found".`
+
+// qaAnswerSystemPrompt instructs the LLM to answer questions from conversation
+// history.
+const qaAnswerSystemPrompt = `Answer the following questions based on the conversation history. Be concise and specific. If the information is not available in the history, say so.`
+
+// noGapsIndicators are substrings that signal the LLM found no gaps. The check
+// is case-insensitive.
+var noGapsIndicators = []string{
+	"no gaps",
+	"no questions",
+	"no missing",
+	"looks complete",
+	"document is complete",
+	"nothing missing",
+	"no further questions",
+	"no gaps found",
+}
+
+// hasNoGaps returns true if the text indicates no gaps were found (either
+// empty or containing a no-gaps indicator phrase).
+func hasNoGaps(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if lower == "" {
+		return true
+	}
+	for _, indicator := range noGapsIndicators {
+		if strings.Contains(lower, indicator) {
+			return true
+		}
+	}
+	return false
+}
+
+// streamLLMText is a helper that calls llm.StreamLLM and collects the full text
+// response. It applies a bounded timeout via context.WithTimeout.
+func streamLLMText(ctx context.Context, model llm.Model, llmCtx llm.LLMContext, apiKey string) (string, error) {
+	callCtx, cancel := context.WithTimeout(ctx, handoffQATimeout)
+	defer cancel()
+
+	llmStream := llm.StreamLLM(callCtx, model, llmCtx, apiKey, handoffQAChunkTimeout)
+
+	var text strings.Builder
+	for event := range llmStream.Iterator(callCtx) {
+		if event.Done {
+			break
+		}
+		switch e := event.Value.(type) {
+		case llm.LLMTextDeltaEvent:
+			text.WriteString(e.Delta)
+		case llm.LLMErrorEvent:
+			return "", e.Error
+		}
+	}
+
+	return text.String(), nil
+}
+
+// runHandoffQA runs a bounded Q&A verification loop.
+//
+// For each round (up to maxRounds):
+//  1. Ask questions: send the handoff doc to the LLM (without old context) to
+//     identify gaps.
+//  2. If no gaps found → break early.
+//  3. Answer questions: send old context messages plus the questions to the
+//     LLM and collect the answer.
+//  4. Store the question-answer pair as a qaTurn and augment the handoff doc
+//     with the Q&A for the next round.
+//
+// Returns the collected Q&A turns and any error.
+func runHandoffQA(
+	ctx context.Context,
+	model llm.Model,
+	apiKey string,
+	contextWindow int,
+	handoffDoc string,
+	oldMessages []agentctx.AgentMessage,
+	maxRounds int,
+) ([]qaTurn, error) {
+	if maxRounds <= 0 {
+		maxRounds = handoffQADefaultRounds
+	}
+
+	var turns []qaTurn
+
+	for round := 0; round < maxRounds; round++ {
+		// --- Ask questions: send handoff doc to LLM without old context.
+		askCtx := llm.LLMContext{
+			SystemPrompt: qaAskSystemPrompt,
+			Messages: []llm.LLMMessage{
+				{Role: "user", Content: handoffDoc},
+			},
+		}
+		questions, err := streamLLMText(ctx, model, askCtx, apiKey)
+		if err != nil {
+			return turns, fmt.Errorf("handoff QA round %d ask: %w", round, err)
+		}
+
+		if hasNoGaps(questions) {
+			slog.Info("[Handoff] QA verification complete — no gaps found",
+				"round", round)
+			break
+		}
+
+		// --- Answer questions: send old context + questions to LLM.
+		answerMessages := make([]llm.LLMMessage, 0, len(oldMessages)+1)
+		for _, msg := range oldMessages {
+			if !msg.IsAgentVisible() {
+				continue
+			}
+			text := msg.ExtractText()
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
+			answerMessages = append(answerMessages, llm.LLMMessage{
+				Role:    msg.Role,
+				Content: text,
+			})
+		}
+		answerMessages = append(answerMessages, llm.LLMMessage{
+			Role: "user",
+			Content: fmt.Sprintf(
+				"Please answer these questions about the handoff document:\n\n%s",
+				questions,
+			),
+		})
+
+		answerCtx := llm.LLMContext{
+			SystemPrompt: qaAnswerSystemPrompt,
+			Messages:     answerMessages,
+		}
+		answer, err := streamLLMText(ctx, model, answerCtx, apiKey)
+		if err != nil {
+			return turns, fmt.Errorf("handoff QA round %d answer: %w", round, err)
+		}
+
+		turns = append(turns, qaTurn{
+			Question: questions,
+			Answer:   answer,
+		})
+
+		slog.Info("[Handoff] QA round completed",
+			"round", round,
+			"questions_len", len(questions),
+			"answer_len", len(answer),
+		)
+
+		// Augment handoff doc with Q&A for the next round so the LLM can
+		// verify the gaps are now addressed.
+		handoffDoc = fmt.Sprintf(
+			"%s\n\n## Q&A Round %d\n\n**Q:** %s\n\n**A:** %s",
+			handoffDoc, round+1, questions, answer,
+		)
+	}
+
+	return turns, nil
+}

--- a/pkg/agent/handoff_reminder.go
+++ b/pkg/agent/handoff_reminder.go
@@ -1,12 +1,14 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
 )
 
 // estimateContextTokens returns the total context token count from the last
@@ -129,7 +131,7 @@ func newContextManagementMessage(text string) agentctx.AgentMessage {
 // auto-executed.
 //
 // The method is a no-op when ContextManagementMode != contextModeHandoff.
-func (s *loopState) maybeInjectHandoffReminder(agentCtx *agentctx.AgentContext) (autoExecute bool) {
+func (s *loopState) maybeInjectHandoffReminder(ctx context.Context, agentCtx *agentctx.AgentContext) (autoExecute bool) {
 	if s.config.ContextManagementMode != contextModeHandoff {
 		return false
 	}
@@ -142,6 +144,7 @@ func (s *loopState) maybeInjectHandoffReminder(agentCtx *agentctx.AgentContext) 
 	if currentTokens < soft {
 		s.hardFloorCrossed = false
 		s.hardFloorTurns = 0
+		s.handoffPending = false
 		return false
 	}
 
@@ -151,11 +154,17 @@ func (s *loopState) maybeInjectHandoffReminder(agentCtx *agentctx.AgentContext) 
 		agentCtx.RecentMessages = append(agentCtx.RecentMessages, reminder)
 		s.newMessages = append(s.newMessages, reminder)
 		agentCtx.AgentState.ToolCallsSinceLastTrigger = 0
+		s.handoffPending = true
 		slog.Info("[Loop] Handoff reminder injected (soft threshold)",
 			"tokens", currentTokens,
 			"soft", soft,
 			"hard", hard,
 		)
+		traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_reminder_injected",
+			traceevent.Field{Key: "tokens", Value: currentTokens},
+			traceevent.Field{Key: "soft", Value: soft},
+			traceevent.Field{Key: "hard", Value: hard},
+			traceevent.Field{Key: "urgency", Value: "soft"})
 	}
 
 	// At or above hard threshold — urgent reminder every turn.
@@ -168,13 +177,22 @@ func (s *loopState) maybeInjectHandoffReminder(agentCtx *agentctx.AgentContext) 
 		agentCtx.RecentMessages = append(agentCtx.RecentMessages, urgent)
 		s.newMessages = append(s.newMessages, urgent)
 		s.hardFloorTurns++
+		s.handoffPending = true
 		slog.Warn("[Loop] Urgent handoff reminder injected (hard threshold)",
 			"tokens", currentTokens,
 			"soft", soft,
 			"hard", hard,
 			"hardFloorTurns", s.hardFloorTurns,
 		)
+		traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_reminder_injected",
+			traceevent.Field{Key: "tokens", Value: currentTokens},
+			traceevent.Field{Key: "soft", Value: soft},
+			traceevent.Field{Key: "hard", Value: hard},
+			traceevent.Field{Key: "urgency", Value: "hard"})
 		if s.hardFloorTurns > 2 {
+			traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_auto_execute_triggered",
+				traceevent.Field{Key: "tokens", Value: currentTokens},
+				traceevent.Field{Key: "hard", Value: hard})
 			return true
 		}
 	} else {

--- a/pkg/agent/handoff_reminder.go
+++ b/pkg/agent/handoff_reminder.go
@@ -1,0 +1,187 @@
+package agent
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+// estimateContextTokens returns the total context token count from the last
+// assistant message that has valid Usage information. It walks messages
+// backward to find the most recent agent-visible assistant message with a
+// non-zero token count, skipping messages with aborted/error stop reasons.
+// Returns 0 if no message carries usage information.
+func estimateContextTokens(messages []agentctx.AgentMessage) int {
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if !msg.IsAgentVisible() {
+			continue
+		}
+		if msg.Role != "assistant" || msg.Usage == nil {
+			continue
+		}
+		stopReason := strings.ToLower(strings.TrimSpace(msg.StopReason))
+		if stopReason == "aborted" || stopReason == "error" {
+			continue
+		}
+		tokens := handoffUsageTotalTokens(msg.Usage)
+		if tokens > 0 {
+			return tokens
+		}
+	}
+	return 0
+}
+
+// handoffUsageTotalTokens extracts the total token count from a Usage struct,
+// mirroring the pattern in pkg/compact/compact.go's usageTotalTokens.
+func handoffUsageTotalTokens(usage *agentctx.Usage) int {
+	if usage == nil {
+		return 0
+	}
+	if usage.TotalTokens > 0 {
+		return usage.TotalTokens
+	}
+	return usage.InputTokens + usage.OutputTokens + usage.CacheRead + usage.CacheWrite
+}
+
+// handoffThresholds returns the soft and hard token thresholds for handoff
+// reminders based on the model's context window size.
+//
+//   - Windows >= 500000 (1M-class): soft=100000, hard=200000
+//   - Smaller windows (200K-class, the default): soft=40000, hard=150000
+func handoffThresholds(contextWindow int) (soft, hard int) {
+	if contextWindow >= 500000 {
+		return 100000, 200000
+	}
+	return 40000, 150000
+}
+
+// injectionInterval calculates the dynamic interval (in tool calls) between
+// reminder injections. As token usage approaches the soft threshold, the
+// interval shrinks, making reminders more frequent.
+//
+// The base interval is 10. For each full ratio of currentTokens/softThreshold
+// (integer division), the interval decreases by 1, with a minimum of 1.
+func injectionInterval(currentTokens, softThreshold int) int {
+	const baseInterval = 10
+	if softThreshold == 0 {
+		return baseInterval
+	}
+	decay := currentTokens / softThreshold
+	n := baseInterval - decay
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// effectiveContextWindow returns the effective context window, defaulting to
+// 200000 when the configured value is 0 or unset.
+func effectiveContextWindow(contextWindow int) int {
+	if contextWindow > 0 {
+		return contextWindow
+	}
+	return 200000
+}
+
+// handoffReminderText formats the standard reminder message body.
+func handoffReminderText(tokens, contextWindow, soft, hard int) string {
+	return fmt.Sprintf(`<context_management>
+Context usage: %d tokens of %d window.
+Soft threshold: %d. Hard limit: %d.
+Consider performing a context handoff to refresh your context.
+Review your progress, key decisions, pending tasks, and current state.
+When ready, write the handoff document and end with <handoff_complete>.
+</context_management>`, tokens, contextWindow, soft, hard)
+}
+
+// urgentHandoffReminderText formats the urgent (hard-limit) reminder message body.
+func urgentHandoffReminderText(tokens, contextWindow, soft, hard int) string {
+	return fmt.Sprintf(`<context_management>
+Context usage: %d tokens of %d window.
+Soft threshold: %d. Hard limit: %d.
+URGENT: Context usage has reached the hard limit. Handoff is mandatory.
+Review your progress, key decisions, pending tasks, and current state.
+When ready, write the handoff document and end with <handoff_complete>.
+</context_management>`, tokens, contextWindow, soft, hard)
+}
+
+// newContextManagementMessage creates a user message with a context_management
+// reminder. The message is agent-visible so the LLM sees it.
+func newContextManagementMessage(text string) agentctx.AgentMessage {
+	msg := agentctx.NewUserMessage(text)
+	if msg.Metadata == nil {
+		msg.Metadata = &agentctx.MessageMetadata{}
+	}
+	msg.Metadata.Kind = "context_management"
+	msg.Timestamp = time.Now().UnixMilli()
+	return msg
+}
+
+// maybeInjectHandoffReminder monitors context token usage in handoff mode and
+// injects <context_management> reminder messages when thresholds are crossed.
+//
+// Returns autoExecute=true when the hard threshold has been exceeded for more
+// than 2 consecutive turns, signaling that a mandatory handoff should be
+// auto-executed.
+//
+// The method is a no-op when ContextManagementMode != contextModeHandoff.
+func (s *loopState) maybeInjectHandoffReminder(agentCtx *agentctx.AgentContext) (autoExecute bool) {
+	if s.config.ContextManagementMode != contextModeHandoff {
+		return false
+	}
+
+	currentTokens := estimateContextTokens(agentCtx.RecentMessages)
+	soft, hard := handoffThresholds(s.config.ContextWindow)
+	window := effectiveContextWindow(s.config.ContextWindow)
+
+	// Below soft threshold — nothing to do, reset hard floor state.
+	if currentTokens < soft {
+		s.hardFloorCrossed = false
+		s.hardFloorTurns = 0
+		return false
+	}
+
+	// At or above soft threshold — interval-based reminder injection.
+	if agentCtx.AgentState.ToolCallsSinceLastTrigger >= injectionInterval(currentTokens, soft) {
+		reminder := newContextManagementMessage(handoffReminderText(currentTokens, window, soft, hard))
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages, reminder)
+		s.newMessages = append(s.newMessages, reminder)
+		agentCtx.AgentState.ToolCallsSinceLastTrigger = 0
+		slog.Info("[Loop] Handoff reminder injected (soft threshold)",
+			"tokens", currentTokens,
+			"soft", soft,
+			"hard", hard,
+		)
+	}
+
+	// At or above hard threshold — urgent reminder every turn.
+	if currentTokens >= hard {
+		if !s.hardFloorCrossed {
+			s.hardFloorCrossed = true
+			s.hardFloorTurns = 0
+		}
+		urgent := newContextManagementMessage(urgentHandoffReminderText(currentTokens, window, soft, hard))
+		agentCtx.RecentMessages = append(agentCtx.RecentMessages, urgent)
+		s.newMessages = append(s.newMessages, urgent)
+		s.hardFloorTurns++
+		slog.Warn("[Loop] Urgent handoff reminder injected (hard threshold)",
+			"tokens", currentTokens,
+			"soft", soft,
+			"hard", hard,
+			"hardFloorTurns", s.hardFloorTurns,
+		)
+		if s.hardFloorTurns > 2 {
+			return true
+		}
+	} else {
+		// Below hard threshold — reset hard floor tracking.
+		s.hardFloorCrossed = false
+		s.hardFloorTurns = 0
+	}
+
+	return false
+}

--- a/pkg/agent/handoff_reminder.go
+++ b/pkg/agent/handoff_reminder.go
@@ -53,12 +53,25 @@ func handoffUsageTotalTokens(usage *agentctx.Usage) int {
 // reminders based on the model's context window size.
 //
 //   - Windows >= 500000 (1M-class): soft=100000, hard=200000
-//   - Smaller windows (200K-class, the default): soft=40000, hard=150000
+//   - Smaller windows (e.g. 200K): proportional thresholds with soft at 35%
+//     and hard at 75%, clamped to reasonable minimums.
 func handoffThresholds(contextWindow int) (soft, hard int) {
 	if contextWindow >= 500000 {
 		return 100000, 200000
 	}
-	return 40000, 150000
+	// For smaller windows (e.g. 200K), use proportional thresholds.
+	// Soft at 35% triggers reminders before context pressure gets severe.
+	// Hard at 75% forces mandatory handoff.
+	soft = contextWindow * 35 / 100
+	hard = contextWindow * 75 / 100
+	// Clamp to reasonable minimums.
+	if soft < 20000 {
+		soft = 20000
+	}
+	if hard < 80000 {
+		hard = 80000
+	}
+	return soft, hard
 }
 
 // injectionInterval calculates the dynamic interval (in tool calls) between

--- a/pkg/agent/handoff_reminder_test.go
+++ b/pkg/agent/handoff_reminder_test.go
@@ -1,0 +1,462 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+// --- estimateContextTokens tests ---
+
+func TestEstimateContextTokens_EmptyMessages(t *testing.T) {
+	assert.Equal(t, 0, estimateContextTokens(nil))
+	assert.Equal(t, 0, estimateContextTokens([]agentctx.AgentMessage{}))
+}
+
+func TestEstimateContextTokens_NoUsage(t *testing.T) {
+	msgs := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("hello"),
+		agentctx.NewAssistantMessage(),
+	}
+	assert.Equal(t, 0, estimateContextTokens(msgs))
+}
+
+func TestEstimateContextTokens_LastAssistantWithUsage(t *testing.T) {
+	msg1 := agentctx.NewAssistantMessage()
+	msg1.Usage = &agentctx.Usage{TotalTokens: 50000}
+	msg1.StopReason = "stop"
+
+	msg2 := agentctx.NewUserMessage("thanks")
+	msg3 := agentctx.NewAssistantMessage()
+	msg3.Usage = &agentctx.Usage{TotalTokens: 80000}
+	msg3.StopReason = "stop"
+
+	msgs := []agentctx.AgentMessage{msg1, msg2, msg3}
+	assert.Equal(t, 80000, estimateContextTokens(msgs))
+}
+
+func TestEstimateContextTokens_SkipsAbortedOrError(t *testing.T) {
+	msg1 := agentctx.NewAssistantMessage()
+	msg1.Usage = &agentctx.Usage{TotalTokens: 40000}
+	msg1.StopReason = "stop"
+
+	msg2 := agentctx.NewAssistantMessage()
+	msg2.Usage = &agentctx.Usage{TotalTokens: 90000}
+	msg2.StopReason = "aborted"
+
+	msgs := []agentctx.AgentMessage{msg1, msg2}
+	// The aborted message should be skipped; fall back to msg1
+	assert.Equal(t, 40000, estimateContextTokens(msgs))
+}
+
+func TestEstimateContextTokens_SkipsErrorStopReason(t *testing.T) {
+	msg1 := agentctx.NewAssistantMessage()
+	msg1.Usage = &agentctx.Usage{TotalTokens: 40000}
+	msg1.StopReason = "stop"
+
+	msg2 := agentctx.NewAssistantMessage()
+	msg2.Usage = &agentctx.Usage{TotalTokens: 90000}
+	msg2.StopReason = "error"
+
+	msgs := []agentctx.AgentMessage{msg1, msg2}
+	assert.Equal(t, 40000, estimateContextTokens(msgs))
+}
+
+func TestEstimateContextTokens_TotalTokensZeroFallsBack(t *testing.T) {
+	msg := agentctx.NewAssistantMessage()
+	msg.Usage = &agentctx.Usage{
+		InputTokens:  10000,
+		OutputTokens: 5000,
+	}
+	msg.StopReason = "stop"
+	// TotalTokens is 0; should fall back to input + output
+	assert.Equal(t, 15000, estimateContextTokens([]agentctx.AgentMessage{msg}))
+}
+
+func TestEstimateContextTokens_SkipsNonAgentVisible(t *testing.T) {
+	msg := agentctx.NewAssistantMessage()
+	msg.Usage = &agentctx.Usage{TotalTokens: 70000}
+	msg.StopReason = "stop"
+	hiddenMsg := msg.WithVisibility(false, false)
+
+	assert.Equal(t, 0, estimateContextTokens([]agentctx.AgentMessage{hiddenMsg}))
+}
+
+func TestEstimateContextTokens_AllZeroUsage(t *testing.T) {
+	msg := agentctx.NewAssistantMessage()
+	msg.Usage = &agentctx.Usage{}
+	msg.StopReason = "stop"
+	assert.Equal(t, 0, estimateContextTokens([]agentctx.AgentMessage{msg}))
+}
+
+// --- handoffThresholds tests ---
+
+func TestHandoffThresholds_DefaultWindow(t *testing.T) {
+	soft, hard := handoffThresholds(0)
+	assert.Equal(t, 40000, soft)
+	assert.Equal(t, 150000, hard)
+}
+
+func TestHandoffThresholds_128KWindow(t *testing.T) {
+	soft, hard := handoffThresholds(128000)
+	assert.Equal(t, 40000, soft)
+	assert.Equal(t, 150000, hard)
+}
+
+func TestHandoffThresholds_200KWindow(t *testing.T) {
+	soft, hard := handoffThresholds(200000)
+	assert.Equal(t, 40000, soft)
+	assert.Equal(t, 150000, hard)
+}
+
+func TestHandoffThresholds_500KWindow(t *testing.T) {
+	soft, hard := handoffThresholds(500000)
+	assert.Equal(t, 100000, soft)
+	assert.Equal(t, 200000, hard)
+}
+
+func TestHandoffThresholds_1MWindow(t *testing.T) {
+	soft, hard := handoffThresholds(1000000)
+	assert.Equal(t, 100000, soft)
+	assert.Equal(t, 200000, hard)
+}
+
+// --- injectionInterval tests ---
+
+func TestInjectionInterval_ZeroSoftThreshold(t *testing.T) {
+	assert.Equal(t, 10, injectionInterval(50000, 0))
+}
+
+func TestInjectionInterval_BelowSoft(t *testing.T) {
+	// currentTokens=30000, soft=40000 → decay=0 → interval=10
+	assert.Equal(t, 10, injectionInterval(30000, 40000))
+}
+
+func TestInjectionInterval_AtSoft(t *testing.T) {
+	// currentTokens=40000, soft=40000 → decay=1 → interval=9
+	assert.Equal(t, 9, injectionInterval(40000, 40000))
+}
+
+func TestInjectionInterval_DecreasesWithTokens(t *testing.T) {
+	// currentTokens=80000, soft=40000 → decay=2 → interval=8
+	assert.Equal(t, 8, injectionInterval(80000, 40000))
+	// currentTokens=120000, soft=40000 → decay=3 → interval=7
+	assert.Equal(t, 7, injectionInterval(120000, 40000))
+	// currentTokens=360000, soft=40000 → decay=9 → interval=1
+	assert.Equal(t, 1, injectionInterval(360000, 40000))
+}
+
+func TestInjectionInterval_MinimumOne(t *testing.T) {
+	// decay >= 10 → interval clamped to 1
+	assert.Equal(t, 1, injectionInterval(400000, 40000))
+	assert.Equal(t, 1, injectionInterval(1000000, 40000))
+}
+
+// --- maybeInjectHandoffReminder tests ---
+
+// newTestLoopState creates a minimal loopState for testing
+// maybeInjectHandoffReminder.
+func newTestLoopState(config *LoopConfig, agentCtx *agentctx.AgentContext) *loopState {
+	return &loopState{
+		config:      config,
+		agentCtx:    agentCtx,
+		newMessages: []agentctx.AgentMessage{},
+	}
+}
+
+func newHandoffTestAgentCtx(tokens int) *agentctx.AgentContext {
+	ctx := &agentctx.AgentContext{
+		RecentMessages: []agentctx.AgentMessage{
+			func() agentctx.AgentMessage {
+				m := agentctx.NewAssistantMessage()
+				if tokens > 0 {
+					m.Usage = &agentctx.Usage{TotalTokens: tokens}
+					m.StopReason = "stop"
+				}
+				return m
+			}(),
+		},
+		AgentState: agentctx.NewAgentState("test", "/tmp"),
+	}
+	return ctx
+}
+
+func TestMaybeInjectHandoffReminder_NotHandoffMode(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "legacy"}
+	agentCtx := newHandoffTestAgentCtx(100000)
+	state := newTestLoopState(config, agentCtx)
+
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+	assert.Equal(t, 1, len(agentCtx.RecentMessages), "no injection in legacy mode")
+}
+
+func TestMaybeInjectHandoffReminder_BelowSoftThreshold(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := newHandoffTestAgentCtx(30000) // below soft=40000
+	state := newTestLoopState(config, agentCtx)
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+	assert.Equal(t, 1, len(agentCtx.RecentMessages), "no injection below soft threshold")
+	// Hard floor state should be reset
+	assert.False(t, state.hardFloorCrossed)
+	assert.Equal(t, 0, state.hardFloorTurns)
+}
+
+func TestMaybeInjectHandoffReminder_AboveSoftIntervalNotMet(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := newHandoffTestAgentCtx(50000) // above soft=40000
+	state := newTestLoopState(config, agentCtx)
+	// interval = 10 - (50000/40000) = 10 - 1 = 9
+	// ToolCallsSinceLastTrigger = 5, which is < 9
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 5
+
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+	assert.Equal(t, 1, len(agentCtx.RecentMessages), "no injection when interval not met")
+}
+
+func TestMaybeInjectHandoffReminder_AboveSoftIntervalMet(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := newHandoffTestAgentCtx(50000) // above soft=40000
+	state := newTestLoopState(config, agentCtx)
+	// interval = 9, ToolCallsSinceLastTrigger = 10 >= 9
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 10
+
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+	assert.Equal(t, 2, len(agentCtx.RecentMessages), "should inject one reminder")
+
+	// Verify the injected message content
+	injected := agentCtx.RecentMessages[1]
+	assert.Equal(t, "user", injected.Role)
+	text := injected.ExtractText()
+	assert.Contains(t, text, "<context_management>")
+	assert.Contains(t, text, "Context usage: 50000 tokens of 200000 window.")
+	assert.Contains(t, text, "Soft threshold: 40000. Hard limit: 150000.")
+	assert.Contains(t, text, "handoff_complete")
+
+	// Counter should be reset
+	assert.Equal(t, 0, agentCtx.AgentState.ToolCallsSinceLastTrigger)
+}
+
+func TestMaybeInjectHandoffReminder_AboveHardInjectsUrgent(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := newHandoffTestAgentCtx(160000) // above hard=150000
+	state := newTestLoopState(config, agentCtx)
+	// Set high enough to trigger soft injection too
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	// First call above hard → hardFloorTurns becomes 1, not > 2 yet
+	assert.False(t, autoExecute)
+
+	// Should have injected 2 messages: soft reminder + urgent reminder
+	assert.Equal(t, 3, len(agentCtx.RecentMessages), "should inject soft + urgent reminders")
+
+	// Verify the last message is urgent
+	urgentMsg := agentCtx.RecentMessages[2]
+	text := urgentMsg.ExtractText()
+	assert.Contains(t, text, "URGENT")
+	assert.Contains(t, text, "Handoff is mandatory")
+
+	assert.True(t, state.hardFloorCrossed)
+	assert.Equal(t, 1, state.hardFloorTurns)
+}
+
+func TestMaybeInjectHandoffReminder_AutoExecuteAfterThreeCalls(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := newHandoffTestAgentCtx(160000)
+	state := newTestLoopState(config, agentCtx)
+
+	// Call 1: hardFloorTurns goes 0 → 1
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+	assert.Equal(t, 1, state.hardFloorTurns)
+
+	// Call 2: hardFloorTurns goes 1 → 2
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+	autoExecute = state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+	assert.Equal(t, 2, state.hardFloorTurns)
+
+	// Call 3: hardFloorTurns goes 2 → 3, which is > 2 → auto-execute
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+	autoExecute = state.maybeInjectHandoffReminder(agentCtx)
+	assert.True(t, autoExecute)
+	assert.Equal(t, 3, state.hardFloorTurns)
+}
+
+func TestMaybeInjectHandoffReminder_ResetWhenBelowSoft(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := newHandoffTestAgentCtx(160000)
+	state := newTestLoopState(config, agentCtx)
+
+	// First go above hard to set hardFloorCrossed
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+	state.maybeInjectHandoffReminder(agentCtx)
+	assert.True(t, state.hardFloorCrossed)
+	assert.Equal(t, 1, state.hardFloorTurns)
+
+	// Now drop below soft — should reset
+	agentCtx2 := newHandoffTestAgentCtx(30000)
+	// Keep the same AgentState
+	agentCtx2.AgentState = agentCtx.AgentState
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx2)
+	assert.False(t, autoExecute)
+	assert.False(t, state.hardFloorCrossed)
+	assert.Equal(t, 0, state.hardFloorTurns)
+}
+
+func TestMaybeInjectHandoffReminder_ResetWhenBetweenSoftAndHard(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+
+	// First go above hard
+	agentCtx := newHandoffTestAgentCtx(160000)
+	state := newTestLoopState(config, agentCtx)
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+	state.maybeInjectHandoffReminder(agentCtx)
+	assert.True(t, state.hardFloorCrossed)
+
+	// Now drop to between soft and hard (e.g. 80000)
+	agentCtx2 := newHandoffTestAgentCtx(80000)
+	agentCtx2.AgentState = agentCtx.AgentState
+	agentCtx2.AgentState.ToolCallsSinceLastTrigger = 100
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx2)
+	assert.False(t, autoExecute)
+	assert.False(t, state.hardFloorCrossed, "hard floor should reset when below hard")
+	assert.Equal(t, 0, state.hardFloorTurns)
+}
+
+func TestMaybeInjectHandoffReminder_LargeWindowThresholds(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 1000000}
+	// soft=100000, hard=200000
+	agentCtx := newHandoffTestAgentCtx(120000) // above soft=100000
+	state := newTestLoopState(config, agentCtx)
+	// interval = 10 - (120000/100000) = 10 - 1 = 9
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 10
+
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+	assert.Equal(t, 2, len(agentCtx.RecentMessages), "should inject one reminder")
+
+	injected := agentCtx.RecentMessages[1]
+	text := injected.ExtractText()
+	assert.Contains(t, text, "Soft threshold: 100000. Hard limit: 200000.")
+}
+
+func TestMaybeInjectHandoffReminder_DefaultContextWindow(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 0}
+	// Default window = 200000, soft=40000, hard=150000
+	agentCtx := newHandoffTestAgentCtx(50000)
+	state := newTestLoopState(config, agentCtx)
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+
+	injected := agentCtx.RecentMessages[1]
+	text := injected.ExtractText()
+	// Should use 200000 as default window
+	assert.Contains(t, text, "tokens of 200000 window.")
+}
+
+func TestMaybeInjectHandoffReminder_MessageMetadata(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := newHandoffTestAgentCtx(50000)
+	state := newTestLoopState(config, agentCtx)
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+
+	state.maybeInjectHandoffReminder(agentCtx)
+
+	injected := agentCtx.RecentMessages[1]
+	assert.Equal(t, "user", injected.Role)
+	assert.NotNil(t, injected.Metadata)
+	assert.Equal(t, "context_management", injected.Metadata.Kind)
+	// Should be agent-visible
+	assert.True(t, injected.IsAgentVisible())
+}
+
+func TestMaybeInjectHandoffReminder_NoUsageReturnsFalse(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := &agentctx.AgentContext{
+		RecentMessages: []agentctx.AgentMessage{
+			agentctx.NewUserMessage("hello"),
+		},
+		AgentState: agentctx.NewAgentState("test", "/tmp"),
+	}
+	state := newTestLoopState(config, agentCtx)
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+
+	// No assistant message with usage → tokens = 0, below soft → no injection
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+	assert.Equal(t, 1, len(agentCtx.RecentMessages))
+}
+
+func TestMaybeInjectHandoffReminder_SoftCounterResetsAfterInjection(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := newHandoffTestAgentCtx(50000)
+	state := newTestLoopState(config, agentCtx)
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 10
+
+	state.maybeInjectHandoffReminder(agentCtx)
+	assert.Equal(t, 0, agentCtx.AgentState.ToolCallsSinceLastTrigger,
+		"ToolCallsSinceLastTrigger should reset after injection")
+
+	// Second call immediately: interval=9, counter=0 → 0 < 9 → no injection
+	before := len(agentCtx.RecentMessages)
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 0
+	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	assert.False(t, autoExecute)
+	assert.Equal(t, before, len(agentCtx.RecentMessages),
+		"no injection when counter just reset")
+}
+
+func TestMaybeInjectHandoffReminder_AboveHardEveryCall(t *testing.T) {
+	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
+	agentCtx := newHandoffTestAgentCtx(160000)
+	state := newTestLoopState(config, agentCtx)
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+
+	// Each call above hard should inject urgent
+	state.maybeInjectHandoffReminder(agentCtx)
+	msgsAfterCall1 := len(agentCtx.RecentMessages)
+
+	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
+	state.maybeInjectHandoffReminder(agentCtx)
+	msgsAfterCall2 := len(agentCtx.RecentMessages)
+
+	// Each call should add at least 1 message (urgent)
+	assert.Greater(t, msgsAfterCall2, msgsAfterCall1,
+		"each call above hard should inject at least one message")
+}
+
+func TestHandoffReminderText_Format(t *testing.T) {
+	text := handoffReminderText(123456, 200000, 40000, 150000)
+	assert.Contains(t, text, "<context_management>")
+	assert.Contains(t, text, "</context_management>")
+	assert.Contains(t, text, "123456 tokens of 200000 window")
+	assert.Contains(t, text, "Soft threshold: 40000")
+	assert.Contains(t, text, "Hard limit: 150000")
+	assert.Contains(t, text, "handoff_complete")
+}
+
+func TestUrgentHandoffReminderText_Format(t *testing.T) {
+	text := urgentHandoffReminderText(160000, 200000, 40000, 150000)
+	assert.Contains(t, text, "<context_management>")
+	assert.Contains(t, text, "URGENT")
+	assert.Contains(t, text, "Handoff is mandatory")
+	assert.Contains(t, text, "160000 tokens of 200000 window")
+}
+
+func TestHandoffReminderText_NoUrgentInStandard(t *testing.T) {
+	text := handoffReminderText(50000, 200000, 40000, 150000)
+	assert.False(t, strings.Contains(text, "URGENT"),
+		"standard reminder should not contain URGENT")
+}

--- a/pkg/agent/handoff_reminder_test.go
+++ b/pkg/agent/handoff_reminder_test.go
@@ -94,21 +94,24 @@ func TestEstimateContextTokens_AllZeroUsage(t *testing.T) {
 
 // --- handoffThresholds tests ---
 
-func TestHandoffThresholds_DefaultWindow(t *testing.T) {
+func TestHandoffThresholds_ZeroWindow(t *testing.T) {
+	// contextWindow=0: proportional gives 0, clamped to minimums.
 	soft, hard := handoffThresholds(0)
-	assert.Equal(t, 40000, soft)
-	assert.Equal(t, 150000, hard)
+	assert.Equal(t, 20000, soft)
+	assert.Equal(t, 80000, hard)
 }
 
 func TestHandoffThresholds_128KWindow(t *testing.T) {
+	// 128000 * 0.35 = 44800; 128000 * 0.75 = 96000
 	soft, hard := handoffThresholds(128000)
-	assert.Equal(t, 40000, soft)
-	assert.Equal(t, 150000, hard)
+	assert.Equal(t, 44800, soft)
+	assert.Equal(t, 96000, hard)
 }
 
 func TestHandoffThresholds_200KWindow(t *testing.T) {
+	// 200000 * 0.35 = 70000; 200000 * 0.75 = 150000
 	soft, hard := handoffThresholds(200000)
-	assert.Equal(t, 40000, soft)
+	assert.Equal(t, 70000, soft)
 	assert.Equal(t, 150000, hard)
 }
 
@@ -196,7 +199,7 @@ func TestMaybeInjectHandoffReminder_NotHandoffMode(t *testing.T) {
 
 func TestMaybeInjectHandoffReminder_BelowSoftThreshold(t *testing.T) {
 	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
-	agentCtx := newHandoffTestAgentCtx(30000) // below soft=40000
+	agentCtx := newHandoffTestAgentCtx(30000) // below soft=70000
 	state := newTestLoopState(config, agentCtx)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
 
@@ -210,9 +213,9 @@ func TestMaybeInjectHandoffReminder_BelowSoftThreshold(t *testing.T) {
 
 func TestMaybeInjectHandoffReminder_AboveSoftIntervalNotMet(t *testing.T) {
 	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
-	agentCtx := newHandoffTestAgentCtx(50000) // above soft=40000
+	agentCtx := newHandoffTestAgentCtx(80000) // above soft=70000
 	state := newTestLoopState(config, agentCtx)
-	// interval = 10 - (50000/40000) = 10 - 1 = 9
+	// interval = 10 - (80000/70000) = 10 - 1 = 9
 	// ToolCallsSinceLastTrigger = 5, which is < 9
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 5
 
@@ -223,7 +226,7 @@ func TestMaybeInjectHandoffReminder_AboveSoftIntervalNotMet(t *testing.T) {
 
 func TestMaybeInjectHandoffReminder_AboveSoftIntervalMet(t *testing.T) {
 	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
-	agentCtx := newHandoffTestAgentCtx(50000) // above soft=40000
+	agentCtx := newHandoffTestAgentCtx(80000) // above soft=70000
 	state := newTestLoopState(config, agentCtx)
 	// interval = 9, ToolCallsSinceLastTrigger = 10 >= 9
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 10
@@ -237,8 +240,8 @@ func TestMaybeInjectHandoffReminder_AboveSoftIntervalMet(t *testing.T) {
 	assert.Equal(t, "user", injected.Role)
 	text := injected.ExtractText()
 	assert.Contains(t, text, "<context_management>")
-	assert.Contains(t, text, "Context usage: 50000 tokens of 200000 window.")
-	assert.Contains(t, text, "Soft threshold: 40000. Hard limit: 150000.")
+	assert.Contains(t, text, "Context usage: 80000 tokens of 200000 window.")
+	assert.Contains(t, text, "Soft threshold: 70000. Hard limit: 150000.")
 	assert.Contains(t, text, "handoff_complete")
 
 	// Counter should be reset
@@ -353,8 +356,9 @@ func TestMaybeInjectHandoffReminder_LargeWindowThresholds(t *testing.T) {
 
 func TestMaybeInjectHandoffReminder_DefaultContextWindow(t *testing.T) {
 	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 0}
-	// Default window = 200000, soft=40000, hard=150000
-	agentCtx := newHandoffTestAgentCtx(50000)
+	// handoffThresholds(0): soft=20000 (clamped), hard=80000 (clamped)
+	// effectiveContextWindow(0) = 200000
+	agentCtx := newHandoffTestAgentCtx(50000) // above soft=20000
 	state := newTestLoopState(config, agentCtx)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
 
@@ -369,7 +373,7 @@ func TestMaybeInjectHandoffReminder_DefaultContextWindow(t *testing.T) {
 
 func TestMaybeInjectHandoffReminder_MessageMetadata(t *testing.T) {
 	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
-	agentCtx := newHandoffTestAgentCtx(50000)
+	agentCtx := newHandoffTestAgentCtx(80000) // above soft=70000
 	state := newTestLoopState(config, agentCtx)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
 
@@ -402,7 +406,7 @@ func TestMaybeInjectHandoffReminder_NoUsageReturnsFalse(t *testing.T) {
 
 func TestMaybeInjectHandoffReminder_SoftCounterResetsAfterInjection(t *testing.T) {
 	config := &LoopConfig{ContextManagementMode: "handoff", ContextWindow: 200000}
-	agentCtx := newHandoffTestAgentCtx(50000)
+	agentCtx := newHandoffTestAgentCtx(80000) // above soft=70000
 	state := newTestLoopState(config, agentCtx)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 10
 

--- a/pkg/agent/handoff_reminder_test.go
+++ b/pkg/agent/handoff_reminder_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -188,7 +189,7 @@ func TestMaybeInjectHandoffReminder_NotHandoffMode(t *testing.T) {
 	agentCtx := newHandoffTestAgentCtx(100000)
 	state := newTestLoopState(config, agentCtx)
 
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 	assert.Equal(t, 1, len(agentCtx.RecentMessages), "no injection in legacy mode")
 }
@@ -199,7 +200,7 @@ func TestMaybeInjectHandoffReminder_BelowSoftThreshold(t *testing.T) {
 	state := newTestLoopState(config, agentCtx)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
 
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 	assert.Equal(t, 1, len(agentCtx.RecentMessages), "no injection below soft threshold")
 	// Hard floor state should be reset
@@ -215,7 +216,7 @@ func TestMaybeInjectHandoffReminder_AboveSoftIntervalNotMet(t *testing.T) {
 	// ToolCallsSinceLastTrigger = 5, which is < 9
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 5
 
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 	assert.Equal(t, 1, len(agentCtx.RecentMessages), "no injection when interval not met")
 }
@@ -227,7 +228,7 @@ func TestMaybeInjectHandoffReminder_AboveSoftIntervalMet(t *testing.T) {
 	// interval = 9, ToolCallsSinceLastTrigger = 10 >= 9
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 10
 
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 	assert.Equal(t, 2, len(agentCtx.RecentMessages), "should inject one reminder")
 
@@ -251,7 +252,7 @@ func TestMaybeInjectHandoffReminder_AboveHardInjectsUrgent(t *testing.T) {
 	// Set high enough to trigger soft injection too
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
 
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	// First call above hard → hardFloorTurns becomes 1, not > 2 yet
 	assert.False(t, autoExecute)
 
@@ -275,19 +276,19 @@ func TestMaybeInjectHandoffReminder_AutoExecuteAfterThreeCalls(t *testing.T) {
 
 	// Call 1: hardFloorTurns goes 0 → 1
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 	assert.Equal(t, 1, state.hardFloorTurns)
 
 	// Call 2: hardFloorTurns goes 1 → 2
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
-	autoExecute = state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute = state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 	assert.Equal(t, 2, state.hardFloorTurns)
 
 	// Call 3: hardFloorTurns goes 2 → 3, which is > 2 → auto-execute
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
-	autoExecute = state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute = state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.True(t, autoExecute)
 	assert.Equal(t, 3, state.hardFloorTurns)
 }
@@ -299,7 +300,7 @@ func TestMaybeInjectHandoffReminder_ResetWhenBelowSoft(t *testing.T) {
 
 	// First go above hard to set hardFloorCrossed
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
-	state.maybeInjectHandoffReminder(agentCtx)
+	state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.True(t, state.hardFloorCrossed)
 	assert.Equal(t, 1, state.hardFloorTurns)
 
@@ -307,7 +308,7 @@ func TestMaybeInjectHandoffReminder_ResetWhenBelowSoft(t *testing.T) {
 	agentCtx2 := newHandoffTestAgentCtx(30000)
 	// Keep the same AgentState
 	agentCtx2.AgentState = agentCtx.AgentState
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx2)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx2)
 	assert.False(t, autoExecute)
 	assert.False(t, state.hardFloorCrossed)
 	assert.Equal(t, 0, state.hardFloorTurns)
@@ -320,14 +321,14 @@ func TestMaybeInjectHandoffReminder_ResetWhenBetweenSoftAndHard(t *testing.T) {
 	agentCtx := newHandoffTestAgentCtx(160000)
 	state := newTestLoopState(config, agentCtx)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
-	state.maybeInjectHandoffReminder(agentCtx)
+	state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.True(t, state.hardFloorCrossed)
 
 	// Now drop to between soft and hard (e.g. 80000)
 	agentCtx2 := newHandoffTestAgentCtx(80000)
 	agentCtx2.AgentState = agentCtx.AgentState
 	agentCtx2.AgentState.ToolCallsSinceLastTrigger = 100
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx2)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx2)
 	assert.False(t, autoExecute)
 	assert.False(t, state.hardFloorCrossed, "hard floor should reset when below hard")
 	assert.Equal(t, 0, state.hardFloorTurns)
@@ -341,7 +342,7 @@ func TestMaybeInjectHandoffReminder_LargeWindowThresholds(t *testing.T) {
 	// interval = 10 - (120000/100000) = 10 - 1 = 9
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 10
 
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 	assert.Equal(t, 2, len(agentCtx.RecentMessages), "should inject one reminder")
 
@@ -357,7 +358,7 @@ func TestMaybeInjectHandoffReminder_DefaultContextWindow(t *testing.T) {
 	state := newTestLoopState(config, agentCtx)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
 
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 
 	injected := agentCtx.RecentMessages[1]
@@ -372,7 +373,7 @@ func TestMaybeInjectHandoffReminder_MessageMetadata(t *testing.T) {
 	state := newTestLoopState(config, agentCtx)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
 
-	state.maybeInjectHandoffReminder(agentCtx)
+	state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 
 	injected := agentCtx.RecentMessages[1]
 	assert.Equal(t, "user", injected.Role)
@@ -394,7 +395,7 @@ func TestMaybeInjectHandoffReminder_NoUsageReturnsFalse(t *testing.T) {
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
 
 	// No assistant message with usage → tokens = 0, below soft → no injection
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 	assert.Equal(t, 1, len(agentCtx.RecentMessages))
 }
@@ -405,14 +406,14 @@ func TestMaybeInjectHandoffReminder_SoftCounterResetsAfterInjection(t *testing.T
 	state := newTestLoopState(config, agentCtx)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 10
 
-	state.maybeInjectHandoffReminder(agentCtx)
+	state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.Equal(t, 0, agentCtx.AgentState.ToolCallsSinceLastTrigger,
 		"ToolCallsSinceLastTrigger should reset after injection")
 
 	// Second call immediately: interval=9, counter=0 → 0 < 9 → no injection
 	before := len(agentCtx.RecentMessages)
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 0
-	autoExecute := state.maybeInjectHandoffReminder(agentCtx)
+	autoExecute := state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	assert.False(t, autoExecute)
 	assert.Equal(t, before, len(agentCtx.RecentMessages),
 		"no injection when counter just reset")
@@ -425,11 +426,11 @@ func TestMaybeInjectHandoffReminder_AboveHardEveryCall(t *testing.T) {
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
 
 	// Each call above hard should inject urgent
-	state.maybeInjectHandoffReminder(agentCtx)
+	state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	msgsAfterCall1 := len(agentCtx.RecentMessages)
 
 	agentCtx.AgentState.ToolCallsSinceLastTrigger = 100
-	state.maybeInjectHandoffReminder(agentCtx)
+	state.maybeInjectHandoffReminder(context.Background(), agentCtx)
 	msgsAfterCall2 := len(agentCtx.RecentMessages)
 
 	// Each call should add at least 1 message (urgent)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -24,6 +24,12 @@ const (
 	defaultRuntimeMetaHeartbeatTurns   = 6
 	defaultLLMTotalTimeout             = 10 * time.Minute // Total timeout for LLM request
 	defaultLLMFirstResponseTimeout     = 2 * time.Minute  // Timeout between streaming chunks (2min)
+
+	// Context management mode constants. These mirror pkg/config.ContextModeLegacy
+	// and pkg/config.ContextModeHandoff. Defined locally to avoid a circular
+	// import (config imports agent).
+	contextModeLegacy  = "legacy"
+	contextModeHandoff = "handoff"
 )
 
 type LoopConfig struct {
@@ -85,6 +91,9 @@ type LoopConfig struct {
 	// Merging into one message and placing it in the prefix maximizes provider
 	// prefix cache hits — both skills and instructions are stable within a session.
 	AgentContextPrefix string
+	// ContextManagementMode controls proactive context management behavior.
+	// contextModeHandoff disables proactive compaction; contextModeLegacy enables it.
+	ContextManagementMode string
 }
 
 // getEffectiveModel returns the current model, using GetModel callback if available.
@@ -194,10 +203,27 @@ func runInnerLoop(
 		// Pre-LLM compaction: check thresholds and compact if needed.
 		// Save checkpoint BEFORE compaction so progress is preserved if the
 		// compaction LLM call crashes the process.
-		state.savePreCompactionCheckpoint("pre_llm_threshold")
-		compacted, _ := state.performCompaction(ctx, "pre_llm_threshold", true, false)
-		if compacted != nil {
-			saveCheckpointAfterCompaction(state.checkpointMgr, agentCtx, compacted.LLMContextUpdated, state.turnCount, "pre_llm_threshold")
+		// In handoff mode, proactive compaction is disabled — only reactive
+		// recovery (context_limit_recovery) remains active.
+		if config.ContextManagementMode != contextModeHandoff {
+			state.savePreCompactionCheckpoint("pre_llm_threshold")
+			compacted, _ := state.performCompaction(ctx, "pre_llm_threshold", true, false)
+			if compacted != nil {
+				saveCheckpointAfterCompaction(state.checkpointMgr, agentCtx, compacted.LLMContextUpdated, state.turnCount, "pre_llm_threshold")
+			}
+		} else {
+			// Handoff mode: inject reminders instead of proactive compaction.
+			if autoExecute := state.maybeInjectHandoffReminder(agentCtx); autoExecute {
+				slog.Info("[Handoff] Auto-execute triggered")
+				doc, err := state.autoGenerateHandoffDoc(ctx)
+				if err != nil {
+					slog.Error("[Handoff] Auto handoff doc generation failed", "error", err)
+				} else if err := state.performHandoff(ctx, doc); err != nil {
+					slog.Error("[Handoff] Auto handoff failed", "error", err)
+				} else {
+					continue
+				}
+			}
 		}
 
 		// Run BeforeModel hooks: fan-out, inject additional messages before LLM call.
@@ -267,6 +293,20 @@ func runInnerLoop(
 				traceevent.Field{Key: "stopReason", Value: msg.StopReason})
 			agentCtx.RecentMessages[len(agentCtx.RecentMessages)-1] = *msg
 			state.newMessages[len(state.newMessages)-1] = *msg
+		}
+
+		// Check for handoff marker in LLM response.
+		// If detected, run the handoff process: Q&A verification, checkpoint
+		// creation, context reload. On success, continue the loop with fresh
+		// context. On failure, fall through to normal tool processing.
+		if hasHandoffMarker(msg) {
+			handoffDoc := extractHandoffDoc(msg)
+			if err := state.performHandoff(ctx, handoffDoc); err != nil {
+				slog.Error("[Handoff] Handoff failed", "error", err)
+			} else {
+				stream.Push(NewTurnEndEvent(msg, nil))
+				continue
+			}
 		}
 
 		hasMore, toolResults := state.processToolCalls(ctx, msg)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -213,7 +213,7 @@ func runInnerLoop(
 			}
 		} else {
 			// Handoff mode: inject reminders instead of proactive compaction.
-			if autoExecute := state.maybeInjectHandoffReminder(agentCtx); autoExecute {
+			if autoExecute := state.maybeInjectHandoffReminder(ctx, agentCtx); autoExecute {
 				slog.Info("[Handoff] Auto-execute triggered")
 				doc, err := state.autoGenerateHandoffDoc(ctx)
 				if err != nil {
@@ -296,11 +296,14 @@ func runInnerLoop(
 		}
 
 		// Check for handoff marker in LLM response.
+		// Only scan when a reminder was recently injected (handoffPending).
 		// If detected, run the handoff process: Q&A verification, checkpoint
 		// creation, context reload. On success, continue the loop with fresh
 		// context. On failure, fall through to normal tool processing.
-		if hasHandoffMarker(msg) {
+		if state.handoffPending && hasHandoffMarker(msg) {
 			handoffDoc := extractHandoffDoc(msg)
+			traceevent.Log(ctx, traceevent.CategoryEvent, "handoff_marker_detected",
+				traceevent.Field{Key: "doc_length", Value: len(handoffDoc)})
 			if err := state.performHandoff(ctx, handoffDoc); err != nil {
 				slog.Error("[Handoff] Handoff failed", "error", err)
 			} else {

--- a/pkg/agent/loop_state.go
+++ b/pkg/agent/loop_state.go
@@ -37,6 +37,11 @@ type loopState struct {
 	// hardFloorTurns counts turns since the hard threshold was crossed.
 	// After exceeding 2, auto-execute handoff is triggered.
 	hardFloorTurns int
+	// handoffPending is true when a handoff reminder was recently injected,
+	// false after handoff completes or fails. Used to optimize the marker
+	// detection check — we only scan for <handoff_complete> when a reminder
+	// was recently sent.
+	handoffPending bool
 }
 
 func newLoopState(

--- a/pkg/agent/loop_state.go
+++ b/pkg/agent/loop_state.go
@@ -30,6 +30,13 @@ type loopState struct {
 	// recovery turn after a loop guard hard abort. Prevents re-triggering
 	// if the LLM continues the loop.
 	guardAbortRecovery bool
+
+	// hardFloorCrossed is true once the hard threshold is crossed in handoff mode.
+	// Used to track when we first enter the critical zone.
+	hardFloorCrossed bool
+	// hardFloorTurns counts turns since the hard threshold was crossed.
+	// After exceeding 2, auto-execute handoff is triggered.
+	hardFloorTurns int
 }
 
 func newLoopState(

--- a/pkg/agent/resume.go
+++ b/pkg/agent/resume.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"fmt"
+	"log/slog"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/session"
 )
 
 // LoadResumeState loads the most up-to-date agent context state from a session
@@ -32,6 +34,12 @@ func LoadResumeState(sessionDir string, fallbackMessages []agentctx.AgentMessage
 	agentState *agentctx.AgentState,
 	err error,
 ) {
+	// Handoff-mode sessions use a separate checkpoint/resume path.
+	if session.IsHandoffSession(sessionDir) {
+		msgs, agentState, herr := LoadHandoffResumeState(sessionDir)
+		return msgs, "", agentState, herr
+	}
+
 	if sessionDir == "" {
 		return fallbackMessages, "", nil, nil
 	}
@@ -70,4 +78,72 @@ func LoadResumeState(sessionDir string, fallbackMessages []agentctx.AgentMessage
 	}
 
 	return snapshot.RecentMessages, snapshot.LLMContext, snapshot.AgentState, nil
+}
+
+// LoadHandoffResumeState loads the conversation state for a handoff-mode
+// session. It reads current.txt to find the active checkpoint, then loads
+// messages from that checkpoint's messages.jsonl.
+//
+// After loading the checkpoint messages, it replays entries from the ROOT
+// messages.jsonl that were written AFTER the checkpoint was created (using the
+// checkpoint header's timestamp as the cutoff). This ensures post-handoff
+// conversation is preserved on resume (P0-1).
+//
+// It also loads the checkpoint's agent_state.json to restore AgentState
+// (CWD, token counts, etc.) if present (P1-3).
+//
+// If sessionDir is empty or is not a handoff session, returns (nil, nil, nil).
+func LoadHandoffResumeState(sessionDir string) (
+	messages []agentctx.AgentMessage,
+	agentState *agentctx.AgentState,
+	err error,
+) {
+	if sessionDir == "" || !session.IsHandoffSession(sessionDir) {
+		return nil, nil, nil
+	}
+
+	checkpointName, err := session.GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read current checkpoint: %w", err)
+	}
+	if checkpointName == "" {
+		return nil, nil, nil
+	}
+
+	msgs, err := session.LoadHandoffCheckpointMessages(sessionDir, checkpointName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load checkpoint %s messages: %w", checkpointName, err)
+	}
+
+	// P0-1: Replay root messages.jsonl entries written AFTER the checkpoint
+	// was created. The session writer writes ALL messages to the root
+	// messages.jsonl, so post-handoff conversation lives there and must be
+	// picked up on resume.
+	if header, herr := session.ReadHandoffCheckpointHeader(sessionDir, checkpointName); herr != nil {
+		slog.Warn("[Handoff] Failed to read checkpoint header, skipping root journal replay",
+			"checkpoint", checkpointName, "error", herr)
+	} else {
+		rootMsgs, rerr := session.ReadRootMessagesAfter(sessionDir, header.Timestamp)
+		if rerr != nil {
+			slog.Warn("[Handoff] Failed to read root journal for replay", "error", rerr)
+		} else if len(rootMsgs) > 0 {
+			msgs = append(msgs, rootMsgs...)
+			slog.Info("[Handoff] Replayed root journal messages after checkpoint",
+				"checkpoint", checkpointName,
+				"checkpoint_messages", len(msgs)-len(rootMsgs),
+				"replayed", len(rootMsgs))
+		}
+	}
+
+	// P1-3: Load AgentState from the checkpoint if it exists.
+	agentState, _ = session.LoadHandoffCheckpointAgentState(sessionDir, checkpointName)
+	if agentState != nil {
+		slog.Info("[Handoff] Restored agent state from checkpoint",
+			"checkpoint", checkpointName,
+			"turns", agentState.TotalTurns,
+			"tokens", agentState.TokensUsed,
+			"cwd", agentState.CurrentWorkingDir)
+	}
+
+	return msgs, agentState, nil
 }

--- a/pkg/agent/resume.go
+++ b/pkg/agent/resume.go
@@ -37,7 +37,16 @@ func LoadResumeState(sessionDir string, fallbackMessages []agentctx.AgentMessage
 	// Handoff-mode sessions use a separate checkpoint/resume path.
 	if session.IsHandoffSession(sessionDir) {
 		msgs, agentState, herr := LoadHandoffResumeState(sessionDir)
-		return msgs, "", agentState, herr
+		if herr != nil {
+			return fallbackMessages, "", nil, herr
+		}
+		// If LoadHandoffResumeState returned no messages (e.g. a legacy
+		// session whose meta.json defaults to handoff mode but has no
+		// checkpoint structure), fall back to session messages.
+		if len(msgs) == 0 {
+			return fallbackMessages, "", nil, nil
+		}
+		return msgs, "", agentState, nil
 	}
 
 	if sessionDir == "" {

--- a/pkg/agent/resume_handoff_test.go
+++ b/pkg/agent/resume_handoff_test.go
@@ -1,0 +1,451 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/session"
+)
+
+func makeMessageEntry(id, role, text string) session.SessionEntry {
+	return session.SessionEntry{
+		Type: session.EntryTypeMessage,
+		ID:   id,
+		Message: &agentctx.AgentMessage{
+			Role: role,
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: text},
+			},
+		},
+	}
+}
+
+// TestLoadHandoffResumeState tests the handoff resume path: it reads
+// current.txt → loads the checkpoint messages.
+func TestLoadHandoffResumeState(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	// Initialize handoff session
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	// Write messages to cp_001
+	entries := []session.SessionEntry{
+		makeMessageEntry("m1", "user", "hello world"),
+		makeMessageEntry("m2", "assistant", "hi there"),
+	}
+	if err := session.WriteHandoffMessages(sessionDir, "cp_001", entries); err != nil {
+		t.Fatalf("WriteHandoffMessages: %v", err)
+	}
+
+	// Resume should load these messages
+	msgs, agentState, err := LoadHandoffResumeState(sessionDir)
+	if err != nil {
+		t.Fatalf("LoadHandoffResumeState: %v", err)
+	}
+	if agentState != nil {
+		t.Error("expected nil agentState in handoff mode")
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Role != "user" {
+		t.Errorf("expected first message role 'user', got %q", msgs[0].Role)
+	}
+}
+
+// TestLoadHandoffResumeState_AfterSwitch tests resume after switching
+// to a second checkpoint.
+func TestLoadHandoffResumeState_AfterSwitch(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	// Write to cp_001
+	entries1 := []session.SessionEntry{
+		makeMessageEntry("m1", "user", "first checkpoint"),
+	}
+	if err := session.WriteHandoffMessages(sessionDir, "cp_001", entries1); err != nil {
+		t.Fatalf("WriteHandoffMessages cp_001: %v", err)
+	}
+
+	// Create cp_002, write to it, switch
+	cp2, err := session.CreateHandoffCheckpoint(sessionDir, "cp_001")
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint: %v", err)
+	}
+	entries2 := []session.SessionEntry{
+		makeMessageEntry("m2", "user", "second checkpoint"),
+	}
+	if err := session.WriteHandoffMessages(sessionDir, cp2, entries2); err != nil {
+		t.Fatalf("WriteHandoffMessages cp_002: %v", err)
+	}
+	if err := session.SwitchCheckpoint(sessionDir, cp2); err != nil {
+		t.Fatalf("SwitchCheckpoint: %v", err)
+	}
+
+	// Resume should load cp_002's messages
+	msgs, _, err := LoadHandoffResumeState(sessionDir)
+	if err != nil {
+		t.Fatalf("LoadHandoffResumeState: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message from cp_002, got %d", len(msgs))
+	}
+	if msgs[0].ExtractText() != "second checkpoint" {
+		t.Errorf("expected 'second checkpoint', got %q", msgs[0].ExtractText())
+	}
+}
+
+// TestLoadHandoffResumeState_NotHandoff verifies that non-handoff sessions
+// return nil, nil, nil.
+func TestLoadHandoffResumeState_NotHandoff(t *testing.T) {
+	// Empty dir
+	msgs, agentState, err := LoadHandoffResumeState("")
+	if err != nil {
+		t.Fatalf("expected no error for empty dir: %v", err)
+	}
+	if msgs != nil {
+		t.Error("expected nil messages for empty dir")
+	}
+	if agentState != nil {
+		t.Error("expected nil agentState for empty dir")
+	}
+
+	// Temp dir with no checkpoints/
+	dir := t.TempDir()
+	msgs, agentState, err = LoadHandoffResumeState(dir)
+	if err != nil {
+		t.Fatalf("expected no error for non-handoff dir: %v", err)
+	}
+	if msgs != nil {
+		t.Error("expected nil messages for non-handoff dir")
+	}
+	if agentState != nil {
+		t.Error("expected nil agentState for non-handoff dir")
+	}
+}
+
+// TestLoadResumeState_HandoffPath verifies that LoadResumeState delegates to
+// the handoff path for handoff sessions.
+func TestLoadResumeState_HandoffPath(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	entries := []session.SessionEntry{
+		makeMessageEntry("m1", "user", "handoff message"),
+	}
+	if err := session.WriteHandoffMessages(sessionDir, "cp_001", entries); err != nil {
+		t.Fatalf("WriteHandoffMessages: %v", err)
+	}
+
+	// LoadResumeState should detect handoff and load checkpoint messages
+	msgs, llmCtx, agentState, err := LoadResumeState(sessionDir, nil)
+	if err != nil {
+		t.Fatalf("LoadResumeState: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if llmCtx != "" {
+		t.Errorf("expected empty llmContext in handoff mode, got %q", llmCtx)
+	}
+	if agentState != nil {
+		t.Error("expected nil agentState in handoff mode")
+	}
+}
+
+// TestLoadResumeState_OldSessionCompat verifies that old sessions (no
+// checkpoints/ directory, no current.txt) fall through to the legacy path.
+func TestLoadResumeState_OldSessionCompat(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	// Create a plain messages.jsonl without any checkpoint structure
+	// The legacy LoadResumeState will try to load the latest checkpoint and
+	// find none, falling back to fallbackMessages.
+	fallback := []agentctx.AgentMessage{
+		{
+			Role: "user",
+			Content: []agentctx.ContentBlock{
+				agentctx.TextContent{Type: "text", Text: "legacy"},
+			},
+		},
+	}
+
+	msgs, llmCtx, agentState, err := LoadResumeState(sessionDir, fallback)
+	if err != nil {
+		t.Fatalf("LoadResumeState should not error: %v", err)
+	}
+	// Legacy path with no checkpoint → returns fallback messages
+	if len(msgs) != len(fallback) {
+		t.Errorf("expected %d fallback messages, got %d", len(fallback), len(msgs))
+	}
+	if llmCtx != "" {
+		t.Errorf("expected empty llmContext for legacy, got %q", llmCtx)
+	}
+	if agentState != nil {
+		t.Error("expected nil agentState for legacy")
+	}
+
+	// Verify it's NOT detected as handoff
+	if session.IsHandoffSession(sessionDir) {
+		t.Error("legacy session should not be detected as handoff")
+	}
+}
+
+// TestLoadResumeState_EmptySessionDir verifies behavior with empty sessionDir.
+func TestLoadResumeState_EmptySessionDir(t *testing.T) {
+	fallback := []agentctx.AgentMessage{
+		{Role: "user", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "x"}}},
+	}
+	msgs, _, _, err := LoadResumeState("", fallback)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Errorf("expected fallback, got %d messages", len(msgs))
+	}
+}
+
+// TestLoadResumeState_HandoffCheckpointFiles verifies the actual file
+// structure on disk matches the design (checkpoints/cp_NNN/messages.jsonl +
+// current.txt).
+func TestLoadResumeState_HandoffCheckpointFiles(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	// Verify file structure
+	cp001Msgs := filepath.Join(sessionDir, "checkpoints", "cp_001", "messages.jsonl")
+	if _, err := os.Stat(cp001Msgs); err != nil {
+		t.Errorf("cp_001/messages.jsonl should exist: %v", err)
+	}
+
+	currentTxt := filepath.Join(sessionDir, "current.txt")
+	data, err := os.ReadFile(currentTxt)
+	if err != nil {
+		t.Fatalf("current.txt should exist: %v", err)
+	}
+	if string(data) != "cp_001" {
+		t.Errorf("current.txt should contain 'cp_001', got %q", string(data))
+	}
+}
+
+// --- P0-1: Post-handoff conversation replayed on resume ---
+
+// writeRootMessages writes SessionEntry lines to the root messages.jsonl.
+// The first line is a SessionHeader, followed by message entries. All entries
+// use the given timestamp.
+func writeRootMessages(t *testing.T, sessionDir string, entries []session.SessionEntry, headerTimestamp string) {
+	t.Helper()
+	rootPath := filepath.Join(sessionDir, "messages.jsonl")
+	f, err := os.Create(rootPath)
+	if err != nil {
+		t.Fatalf("create root messages.jsonl: %v", err)
+	}
+	defer f.Close()
+
+	header := session.SessionHeader{
+		Type:      session.EntryTypeSession,
+		Version:   session.CurrentSessionVersion,
+		ID:        "test-session",
+		Timestamp: headerTimestamp,
+	}
+	headerData, _ := json.Marshal(header)
+	if _, err := f.Write(append(headerData, '\n')); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+
+	enc := json.NewEncoder(f)
+	for _, e := range entries {
+		if err := enc.Encode(&e); err != nil {
+			t.Fatalf("encode entry: %v", err)
+		}
+	}
+}
+
+// TestLoadHandoffResumeState_RootJournalReplay verifies that post-handoff
+// conversation from the root messages.jsonl is replayed on resume (P0-1).
+func TestLoadHandoffResumeState_RootJournalReplay(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	// Read the checkpoint header timestamp (created just now).
+	cpName, err := session.GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint: %v", err)
+	}
+	header, err := session.ReadHandoffCheckpointHeader(sessionDir, cpName)
+	if err != nil {
+		t.Fatalf("ReadHandoffCheckpointHeader: %v", err)
+	}
+	cpTime, err := time.Parse(time.RFC3339Nano, header.Timestamp)
+	if err != nil {
+		t.Fatalf("parse checkpoint timestamp: %v", err)
+	}
+
+	// Write checkpoint messages.
+	cpEntries := []session.SessionEntry{
+		makeMessageEntry("cp_m1", "user", "handoff doc content"),
+	}
+	if err := session.WriteHandoffMessages(sessionDir, cpName, cpEntries); err != nil {
+		t.Fatalf("WriteHandoffMessages: %v", err)
+	}
+
+	// Write root messages.jsonl with entries BEFORE and AFTER the checkpoint.
+	beforeTime := cpTime.Add(-1 * time.Second).UTC().Format(time.RFC3339Nano)
+	afterTime := cpTime.Add(1 * time.Second).UTC().Format(time.RFC3339Nano)
+
+	rootEntries := []session.SessionEntry{
+		// This entry is BEFORE the checkpoint — should NOT be replayed.
+		{
+			Type:      session.EntryTypeMessage,
+			ID:        "root_before",
+			Timestamp: beforeTime,
+			Message:   &agentctx.AgentMessage{Role: "user", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "old pre-handoff message"}}},
+		},
+		// This entry is AFTER the checkpoint — SHOULD be replayed.
+		{
+			Type:      session.EntryTypeMessage,
+			ID:        "root_after_1",
+			Timestamp: afterTime,
+			Message:   &agentctx.AgentMessage{Role: "user", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "post-handoff question"}}},
+		},
+		// Another entry AFTER the checkpoint.
+		{
+			Type:      session.EntryTypeMessage,
+			ID:        "root_after_2",
+			Timestamp: afterTime,
+			Message:   &agentctx.AgentMessage{Role: "assistant", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "post-handoff answer"}}},
+		},
+	}
+	writeRootMessages(t, sessionDir, rootEntries, beforeTime)
+
+	// Resume should return checkpoint messages + replayed root messages.
+	msgs, _, err := LoadHandoffResumeState(sessionDir)
+	if err != nil {
+		t.Fatalf("LoadHandoffResumeState: %v", err)
+	}
+
+	// Should be 1 checkpoint message + 2 replayed root messages = 3 total.
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages (1 checkpoint + 2 replayed), got %d", len(msgs))
+	}
+
+	// First message should be from checkpoint.
+	if msgs[0].ExtractText() != "handoff doc content" {
+		t.Errorf("expected checkpoint message first, got %q", msgs[0].ExtractText())
+	}
+
+	// Remaining should be replayed root messages.
+	if msgs[1].ExtractText() != "post-handoff question" {
+		t.Errorf("expected 'post-handoff question', got %q", msgs[1].ExtractText())
+	}
+	if msgs[2].ExtractText() != "post-handoff answer" {
+		t.Errorf("expected 'post-handoff answer', got %q", msgs[2].ExtractText())
+	}
+}
+
+// --- P1-3: AgentState restored on handoff resume ---
+
+// TestLoadHandoffResumeState_AgentState verifies that agent_state.json in the
+// checkpoint is loaded and returned by LoadHandoffResumeState (P1-3).
+func TestLoadHandoffResumeState_AgentState(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	cpName, err := session.GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint: %v", err)
+	}
+
+	// Write some messages so the checkpoint isn't empty.
+	if err := session.WriteHandoffMessages(sessionDir, cpName, []session.SessionEntry{
+		makeMessageEntry("m1", "user", "hello"),
+	}); err != nil {
+		t.Fatalf("WriteHandoffMessages: %v", err)
+	}
+
+	// Write agent_state.json to the checkpoint.
+	expectedState := &agentctx.AgentState{
+		WorkspaceRoot:     "/workspace",
+		CurrentWorkingDir: "/workspace/subdir",
+		TotalTurns:        42,
+		TokensUsed:        12345,
+	}
+	if err := session.WriteHandoffAgentState(sessionDir, cpName, expectedState); err != nil {
+		t.Fatalf("WriteHandoffAgentState: %v", err)
+	}
+
+	msgs, agentState, err := LoadHandoffResumeState(sessionDir)
+	if err != nil {
+		t.Fatalf("LoadHandoffResumeState: %v", err)
+	}
+
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	if agentState == nil {
+		t.Fatal("expected agentState to be non-nil")
+	}
+	if agentState.WorkspaceRoot != expectedState.WorkspaceRoot {
+		t.Errorf("expected WorkspaceRoot %q, got %q", expectedState.WorkspaceRoot, agentState.WorkspaceRoot)
+	}
+	if agentState.CurrentWorkingDir != expectedState.CurrentWorkingDir {
+		t.Errorf("expected CurrentWorkingDir %q, got %q", expectedState.CurrentWorkingDir, agentState.CurrentWorkingDir)
+	}
+	if agentState.TotalTurns != expectedState.TotalTurns {
+		t.Errorf("expected TotalTurns %d, got %d", expectedState.TotalTurns, agentState.TotalTurns)
+	}
+	if agentState.TokensUsed != expectedState.TokensUsed {
+		t.Errorf("expected TokensUsed %d, got %d", expectedState.TokensUsed, agentState.TokensUsed)
+	}
+}
+
+// TestLoadHandoffResumeState_NoAgentState verifies that when agent_state.json
+// does not exist, the returned agentState is nil (no error).
+func TestLoadHandoffResumeState_NoAgentState(t *testing.T) {
+	sessionDir := t.TempDir()
+
+	if err := session.InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	cpName, err := session.GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint: %v", err)
+	}
+
+	if err := session.WriteHandoffMessages(sessionDir, cpName, []session.SessionEntry{
+		makeMessageEntry("m1", "user", "hello"),
+	}); err != nil {
+		t.Fatalf("WriteHandoffMessages: %v", err)
+	}
+
+	_, agentState, err := LoadHandoffResumeState(sessionDir)
+	if err != nil {
+		t.Fatalf("LoadHandoffResumeState: %v", err)
+	}
+	if agentState != nil {
+		t.Errorf("expected nil agentState when no agent_state.json, got %+v", agentState)
+	}
+}

--- a/pkg/agent/resume_handoff_test.go
+++ b/pkg/agent/resume_handoff_test.go
@@ -77,7 +77,7 @@ func TestLoadHandoffResumeState_AfterSwitch(t *testing.T) {
 	}
 
 	// Create cp_002, write to it, switch
-	cp2, err := session.CreateHandoffCheckpoint(sessionDir, "cp_001")
+	cp2, err := session.CreateHandoffCheckpoint(sessionDir, 2, "cp_001")
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint: %v", err)
 	}

--- a/pkg/config/config.example.json
+++ b/pkg/config/config.example.json
@@ -25,7 +25,9 @@
     "maxChars": 10000
   },
   "taskTracking": true,
-  "contextManagement": true,
+    "contextManagement": {
+    "mode": "handoff"
+  },
   "log": {
     "level": "info",
     "file": "~/.ai/ai-{pid}.log",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,52 @@ type Config struct {
 
 	// Logging configuration
 	Log *LogConfig `json:"log,omitempty"`
+
+	// Context management configuration
+	ContextManagement *ContextManagementConfig `json:"contextManagement,omitempty"`
+}
+
+// Context management mode constants.
+const (
+	// ContextModeLegacy is the traditional compaction-based context management.
+	ContextModeLegacy = "legacy"
+	// ContextModeHandoff uses checkpoint-based context handoff.
+	ContextModeHandoff = "handoff"
+)
+
+// ContextManagementConfig controls which context management strategy is used.
+type ContextManagementConfig struct {
+	Mode string `json:"mode,omitempty"` // ContextModeLegacy | ContextModeHandoff (default: ContextModeLegacy)
+}
+
+// UnmarshalJSON accepts both the legacy boolean format
+// ("contextManagement": true/false) and the new object format
+// ("contextManagement": {"mode": "handoff"}). A legacy boolean maps to
+// ContextModeLegacy so existing users stay on the proven compaction path.
+func (c *ContextManagementConfig) UnmarshalJSON(data []byte) error {
+	// Try bool first (legacy format: "contextManagement": true/false).
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		c.Mode = ContextModeLegacy
+		return nil
+	}
+	// Try object (new format: "contextManagement": {"mode": "handoff"}).
+	// Use a type alias to avoid infinite recursion on UnmarshalJSON.
+	type alias ContextManagementConfig
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return fmt.Errorf("contextManagement: expected bool or object, got %s: %w", string(data), err)
+	}
+	*c = ContextManagementConfig(a)
+	return nil
+}
+
+// ContextManagementMode returns the configured mode, defaulting to ContextModeLegacy.
+func (c *Config) ContextManagementMode() string {
+	if c.ContextManagement != nil && c.ContextManagement.Mode != "" {
+		return c.ContextManagement.Mode
+	}
+	return ContextModeLegacy
 }
 
 // LogConfig contains logging configuration.
@@ -274,6 +320,9 @@ func (c *Config) ToLoopConfig(opts ...LoopConfigOption) *agent.LoopConfig {
 			MaxChars: c.ToolOutput.MaxChars,
 		}
 	}
+
+	// Propagate context management mode.
+	loopCfg.ContextManagementMode = c.ContextManagementMode()
 
 	// Apply options last (they can override config values)
 	for _, opt := range opts {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,7 +47,7 @@ const (
 
 // ContextManagementConfig controls which context management strategy is used.
 type ContextManagementConfig struct {
-	Mode string `json:"mode,omitempty"` // ContextModeLegacy | ContextModeHandoff (default: ContextModeLegacy)
+	Mode string `json:"mode,omitempty"` // ContextModeLegacy | ContextModeHandoff (default: ContextModeHandoff)
 }
 
 // UnmarshalJSON accepts both the legacy boolean format
@@ -72,12 +72,12 @@ func (c *ContextManagementConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// ContextManagementMode returns the configured mode, defaulting to ContextModeLegacy.
+// ContextManagementMode returns the configured mode, defaulting to ContextModeHandoff.
 func (c *Config) ContextManagementMode() string {
 	if c.ContextManagement != nil && c.ContextManagement.Mode != "" {
 		return c.ContextManagement.Mode
 	}
-	return ContextModeLegacy
+	return ContextModeHandoff
 }
 
 // LogConfig contains logging configuration.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -510,17 +510,17 @@ func TestContextManagementConfig_ObjectLegacy(t *testing.T) {
 	}
 }
 
-// --- P1-2: Default mode should be "legacy" ---
+// --- P1-2: Default mode should be "handoff" ---
 
 // TestContextManagementMode_Default verifies that when contextManagement is
-// absent, the default mode is ContextModeLegacy (not handoff).
+// absent, the default mode is ContextModeHandoff.
 func TestContextManagementMode_Default(t *testing.T) {
 	jsonStr := `{"model": {"id": "test", "provider": "zai"}}`
 	var cfg Config
 	if err := json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if mode := cfg.ContextManagementMode(); mode != ContextModeLegacy {
-		t.Errorf("expected default ContextManagementMode() %q, got %q", ContextModeLegacy, mode)
+	if mode := cfg.ContextManagementMode(); mode != ContextModeHandoff {
+		t.Errorf("expected default ContextManagementMode() %q, got %q", ContextModeHandoff, mode)
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -437,5 +438,89 @@ func TestCompactorDefaults(t *testing.T) {
 	}
 	if compactorConfig.ToolSummaryAutomation != "off" {
 		t.Errorf("Expected ToolSummaryAutomation off, got %q", compactorConfig.ToolSummaryAutomation)
+	}
+}
+
+// --- P1-1: Config migration (bool → struct) ---
+
+// TestContextManagementConfig_LegacyBoolTrue verifies that the legacy boolean
+// "contextManagement": true maps to ContextModeLegacy.
+func TestContextManagementConfig_LegacyBoolTrue(t *testing.T) {
+	jsonStr := `{"model": {"id": "test", "provider": "zai"}, "contextManagement": true}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
+		t.Fatalf("unmarshal with legacy bool true: %v", err)
+	}
+	if cfg.ContextManagement == nil {
+		t.Fatal("expected ContextManagement to be non-nil")
+	}
+	if cfg.ContextManagement.Mode != ContextModeLegacy {
+		t.Errorf("expected mode %q for legacy bool, got %q", ContextModeLegacy, cfg.ContextManagement.Mode)
+	}
+	if mode := cfg.ContextManagementMode(); mode != ContextModeLegacy {
+		t.Errorf("expected ContextManagementMode() %q, got %q", ContextModeLegacy, mode)
+	}
+}
+
+// TestContextManagementConfig_LegacyBoolFalse verifies that the legacy boolean
+// "contextManagement": false also maps to ContextModeLegacy.
+func TestContextManagementConfig_LegacyBoolFalse(t *testing.T) {
+	jsonStr := `{"model": {"id": "test", "provider": "zai"}, "contextManagement": false}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
+		t.Fatalf("unmarshal with legacy bool false: %v", err)
+	}
+	if cfg.ContextManagement == nil {
+		t.Fatal("expected ContextManagement to be non-nil")
+	}
+	if cfg.ContextManagement.Mode != ContextModeLegacy {
+		t.Errorf("expected mode %q for legacy bool false, got %q", ContextModeLegacy, cfg.ContextManagement.Mode)
+	}
+}
+
+// TestContextManagementConfig_ObjectHandoff verifies that the new object format
+// "contextManagement": {"mode": "handoff"} works correctly.
+func TestContextManagementConfig_ObjectHandoff(t *testing.T) {
+	jsonStr := `{"model": {"id": "test", "provider": "zai"}, "contextManagement": {"mode": "handoff"}}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
+		t.Fatalf("unmarshal with object: %v", err)
+	}
+	if cfg.ContextManagement == nil {
+		t.Fatal("expected ContextManagement to be non-nil")
+	}
+	if cfg.ContextManagement.Mode != ContextModeHandoff {
+		t.Errorf("expected mode %q, got %q", ContextModeHandoff, cfg.ContextManagement.Mode)
+	}
+	if mode := cfg.ContextManagementMode(); mode != ContextModeHandoff {
+		t.Errorf("expected ContextManagementMode() %q, got %q", ContextModeHandoff, mode)
+	}
+}
+
+// TestContextManagementConfig_ObjectLegacy verifies that the new object format
+// "contextManagement": {"mode": "legacy"} works correctly.
+func TestContextManagementConfig_ObjectLegacy(t *testing.T) {
+	jsonStr := `{"model": {"id": "test", "provider": "zai"}, "contextManagement": {"mode": "legacy"}}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
+		t.Fatalf("unmarshal with object: %v", err)
+	}
+	if mode := cfg.ContextManagementMode(); mode != ContextModeLegacy {
+		t.Errorf("expected ContextManagementMode() %q, got %q", ContextModeLegacy, mode)
+	}
+}
+
+// --- P1-2: Default mode should be "legacy" ---
+
+// TestContextManagementMode_Default verifies that when contextManagement is
+// absent, the default mode is ContextModeLegacy (not handoff).
+func TestContextManagementMode_Default(t *testing.T) {
+	jsonStr := `{"model": {"id": "test", "provider": "zai"}}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if mode := cfg.ContextManagementMode(); mode != ContextModeLegacy {
+		t.Errorf("expected default ContextManagementMode() %q, got %q", ContextModeLegacy, mode)
 	}
 }

--- a/pkg/session/entries.go
+++ b/pkg/session/entries.go
@@ -37,6 +37,10 @@ type SessionHeader struct {
 	// Resume optimization fields
 	LastCompactionID string `json:"lastCompactionId,omitempty"` // Most recent compaction entry ID
 
+	// ParentCheckpoint points to the parent checkpoint directory (e.g., "cp_002").
+	// Only used in handoff mode. Empty for the first checkpoint.
+	ParentCheckpoint string `json:"parentCheckpoint,omitempty"`
+
 	// Git commit hash of the ai binary that created this session
 	GitCommit string `json:"gitCommit,omitempty"`
 	// Git version/tag of the ai binary

--- a/pkg/session/handoff_checkpoint.go
+++ b/pkg/session/handoff_checkpoint.go
@@ -90,6 +90,36 @@ func WriteCheckpointCount(sessionDir string, count int) error {
 	return nil
 }
 
+// writeSessionMode sets the ContextManagementMode field in the session's
+// meta.json, preserving all other existing fields. If meta.json does not yet
+// exist it is created.
+func writeSessionMode(sessionDir, mode string) error {
+	metaPath := metaFilePath(sessionDir)
+	var meta SessionMeta
+
+	if data, err := os.ReadFile(metaPath); err == nil {
+		if err := json.Unmarshal(data, &meta); err != nil {
+			return fmt.Errorf("unmarshal meta.json: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read meta.json: %w", err)
+	}
+
+	meta.ContextManagementMode = mode
+
+	data, err := json.MarshalIndent(&meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal meta.json: %w", err)
+	}
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		return fmt.Errorf("create session dir: %w", err)
+	}
+	if err := os.WriteFile(metaPath, data, 0644); err != nil {
+		return fmt.Errorf("write meta.json: %w", err)
+	}
+	return nil
+}
+
 // newHandoffSessionHeader builds a SessionHeader for a checkpoint's
 // messages.jsonl. The header records the parent checkpoint for chain traversal.
 func newHandoffSessionHeader(parentCheckpoint string) SessionHeader {
@@ -314,7 +344,47 @@ func InitHandoffSession(sessionDir string) error {
 		return fmt.Errorf("write checkpoint count: %w", err)
 	}
 
+	// Persist the context management mode so resume/other paths know this
+	// is a handoff-mode session.
+	if err := writeSessionMode(sessionDir, "handoff"); err != nil {
+		return fmt.Errorf("write session mode: %w", err)
+	}
+
 	// Point current.txt at it.
+	if err := SwitchCheckpoint(sessionDir, checkpointName); err != nil {
+		return fmt.Errorf("switch to initial checkpoint: %w", err)
+	}
+
+	return nil
+}
+
+// InitHandoffFromExisting initializes handoff checkpoint structure for a
+// session that already has messages (e.g. a legacy session being switched to
+// handoff mode). It creates cp_001 and writes the given entries into it.
+//
+// If the session already has a checkpoint structure (current.txt exists),
+// this is a no-op.
+func InitHandoffFromExisting(sessionDir string, entries []SessionEntry) error {
+	curPath := filepath.Join(sessionDir, handoffCurrentFile)
+	if _, err := os.Stat(curPath); err == nil {
+		return nil // already initialized
+	}
+
+	checkpointName, err := CreateHandoffCheckpoint(sessionDir, 1, "")
+	if err != nil {
+		return fmt.Errorf("create initial checkpoint: %w", err)
+	}
+
+	if len(entries) > 0 {
+		if err := WriteHandoffMessages(sessionDir, checkpointName, entries); err != nil {
+			return fmt.Errorf("write initial checkpoint messages: %w", err)
+		}
+	}
+
+	if err := WriteCheckpointCount(sessionDir, 1); err != nil {
+		return fmt.Errorf("write checkpoint count: %w", err)
+	}
+
 	if err := SwitchCheckpoint(sessionDir, checkpointName); err != nil {
 		return fmt.Errorf("switch to initial checkpoint: %w", err)
 	}

--- a/pkg/session/handoff_checkpoint.go
+++ b/pkg/session/handoff_checkpoint.go
@@ -1,0 +1,393 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"time"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+// Handoff checkpoint directory utilities.
+//
+// A handoff-mode session stores conversation history in a chain of
+// context-segment checkpoints under checkpoints/cp_NNN/. Each checkpoint has
+// its own messages.jsonl (reusing the existing SessionEntry format) plus an
+// optional handoff.md document. current.txt points to the active segment.
+//
+// The functions here are intentionally low-level directory/file utilities —
+// they do NOT manage the in-memory Session struct. The caller (agent loop,
+// resume path) is responsible for coordinating when checkpoints are created,
+// populated, and switched.
+
+const (
+	// handoffCheckpointsDir is the sub-directory holding all handoff segments.
+	handoffCheckpointsDir = "checkpoints"
+	// handoffCurrentFile records the name of the active checkpoint segment.
+	handoffCurrentFile = "current.txt"
+	// handoffMessagesFile is the per-checkpoint message log.
+	handoffMessagesFile = "messages.jsonl"
+	// handoffDocumentFile is the per-checkpoint handoff document.
+	handoffDocumentFile = "handoff.md"
+)
+
+// checkpointNamePattern matches checkpoint directory names like cp_001, cp_042.
+var checkpointNamePattern = regexp.MustCompile(`^cp_(\d+)$`)
+
+// handoffCheckpointDir returns the directory path for a named checkpoint.
+func handoffCheckpointDir(sessionDir, checkpointName string) string {
+	return filepath.Join(sessionDir, handoffCheckpointsDir, checkpointName)
+}
+
+// listExistingCheckpoints returns the sorted checkpoint directory names found
+// under sessionDir/checkpoints/. Only directories matching cp_NNN are returned.
+func listExistingCheckpoints(sessionDir string) ([]string, error) {
+	cpDir := filepath.Join(sessionDir, handoffCheckpointsDir)
+	entries, err := os.ReadDir(cpDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if checkpointNamePattern.MatchString(e.Name()) {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// nextCheckpointName determines the next sequential checkpoint name based on
+// existing checkpoint directories. Returns "cp_001" if none exist yet.
+func nextCheckpointName(sessionDir string) (string, error) {
+	names, err := listExistingCheckpoints(sessionDir)
+	if err != nil {
+		return "", fmt.Errorf("list checkpoints: %w", err)
+	}
+	maxNum := 0
+	for _, name := range names {
+		m := checkpointNamePattern.FindStringSubmatch(name)
+		if len(m) < 2 {
+			continue
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		if n > maxNum {
+			maxNum = n
+		}
+	}
+	return fmt.Sprintf("cp_%03d", maxNum+1), nil
+}
+
+// newHandoffSessionHeader builds a SessionHeader for a checkpoint's
+// messages.jsonl. The header records the parent checkpoint for chain traversal.
+func newHandoffSessionHeader(parentCheckpoint string) SessionHeader {
+	return SessionHeader{
+		Type:             EntryTypeSession,
+		Version:          CurrentSessionVersion,
+		ID:               fmt.Sprintf("handoff-%d", time.Now().UnixNano()),
+		Timestamp:        time.Now().UTC().Format(time.RFC3339Nano),
+		ParentCheckpoint: parentCheckpoint,
+	}
+}
+
+// CreateHandoffCheckpoint creates a new checkpoint directory (cp_NNN) under
+// sessionDir/checkpoints/ and initializes messages.jsonl with a SessionHeader.
+// It does NOT update current.txt — that is done by SwitchCheckpoint after the
+// checkpoint data has been fully written.
+//
+// Returns the checkpoint name (e.g. "cp_002").
+func CreateHandoffCheckpoint(sessionDir, parentCheckpoint string) (string, error) {
+	checkpointName, err := nextCheckpointName(sessionDir)
+	if err != nil {
+		return "", err
+	}
+
+	cpDir := handoffCheckpointDir(sessionDir, checkpointName)
+	if err := os.MkdirAll(cpDir, 0755); err != nil {
+		return "", fmt.Errorf("create checkpoint dir %s: %w", cpDir, err)
+	}
+
+	header := newHandoffSessionHeader(parentCheckpoint)
+	msgsPath := filepath.Join(cpDir, handoffMessagesFile)
+	data, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("marshal header: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(msgsPath, data, 0644); err != nil {
+		return "", fmt.Errorf("write header to %s: %w", msgsPath, err)
+	}
+
+	return checkpointName, nil
+}
+
+// WriteHandoffMessages appends the given entries to the checkpoint's
+// messages.jsonl, after the header line.
+func WriteHandoffMessages(sessionDir, checkpointName string, entries []SessionEntry) error {
+	msgsPath := filepath.Join(handoffCheckpointDir(sessionDir, checkpointName), handoffMessagesFile)
+	file, err := os.OpenFile(msgsPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", msgsPath, err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	for i := range entries {
+		if err := encoder.Encode(&entries[i]); err != nil {
+			return fmt.Errorf("encode entry %d: %w", i, err)
+		}
+	}
+	return file.Sync()
+}
+
+// WriteHandoffDocument writes handoff.md into the checkpoint directory with the
+// given content.
+func WriteHandoffDocument(sessionDir, checkpointName, content string) error {
+	docPath := filepath.Join(handoffCheckpointDir(sessionDir, checkpointName), handoffDocumentFile)
+	if err := os.WriteFile(docPath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("write handoff doc %s: %w", docPath, err)
+	}
+	return nil
+}
+
+// SwitchCheckpoint atomically writes current.txt with the checkpoint name.
+// It uses a write-temp + rename pattern to guarantee atomicity.
+func SwitchCheckpoint(sessionDir, checkpointName string) error {
+	tmpPath := filepath.Join(sessionDir, ".current.txt.tmp")
+	if err := os.WriteFile(tmpPath, []byte(checkpointName), 0644); err != nil {
+		return fmt.Errorf("write temp current.txt: %w", err)
+	}
+	if err := os.Rename(tmpPath, filepath.Join(sessionDir, handoffCurrentFile)); err != nil {
+		return fmt.Errorf("rename current.txt: %w", err)
+	}
+	return nil
+}
+
+// GetCurrentCheckpoint reads current.txt and returns the checkpoint name.
+// Returns ("", nil) if current.txt does not exist (compatibility case).
+func GetCurrentCheckpoint(sessionDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(sessionDir, handoffCurrentFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read current.txt: %w", err)
+	}
+	return string(data), nil
+}
+
+// LoadHandoffCheckpointMessages reads checkpoints/<checkpointName>/messages.jsonl,
+// parses SessionEntry lines, extracts messages from EntryTypeMessage entries,
+// and returns them in order. The SessionHeader line (EntryTypeSession) is
+// skipped.
+func LoadHandoffCheckpointMessages(sessionDir, checkpointName string) ([]agentctx.AgentMessage, error) {
+	msgsPath := filepath.Join(handoffCheckpointDir(sessionDir, checkpointName), handoffMessagesFile)
+	f, err := os.Open(msgsPath)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", msgsPath, err)
+	}
+	defer f.Close()
+
+	var messages []agentctx.AgentMessage
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		entry, err := decodeSessionEntry(line)
+		if err != nil || entry == nil {
+			// Skip header line (decodeSessionEntry returns nil for type="session")
+			// and unparseable lines.
+			continue
+		}
+		if entry.Type == EntryTypeMessage && entry.Message != nil {
+			msg := *entry.Message
+			msg.EntryID = entry.ID
+			messages = append(messages, msg)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan %s: %w", msgsPath, err)
+	}
+	return messages, nil
+}
+
+// IsHandoffSession returns true if sessionDir has both a checkpoints/ directory
+// and a current.txt file. This distinguishes handoff-mode sessions from legacy
+// sessions that use the old checkpoint_%05d recovery system.
+func IsHandoffSession(sessionDir string) bool {
+	if sessionDir == "" {
+		return false
+	}
+	cpDir := filepath.Join(sessionDir, handoffCheckpointsDir)
+	if info, err := os.Stat(cpDir); err != nil || !info.IsDir() {
+		return false
+	}
+	curPath := filepath.Join(sessionDir, handoffCurrentFile)
+	if info, err := os.Stat(curPath); err != nil || info.IsDir() {
+		return false
+	}
+	return true
+}
+
+// InitHandoffSession initializes the checkpoint structure for a new handoff-mode
+// session. It creates checkpoints/cp_001/ with a SessionHeader (ParentCheckpoint
+// empty) and writes current.txt pointing to "cp_001".
+//
+// If the session is already initialized (IsHandoffSession returns true), this
+// is a no-op.
+func InitHandoffSession(sessionDir string) error {
+	if IsHandoffSession(sessionDir) {
+		return nil
+	}
+
+	// Create the first checkpoint.
+	checkpointName, err := CreateHandoffCheckpoint(sessionDir, "")
+	if err != nil {
+		return fmt.Errorf("create initial checkpoint: %w", err)
+	}
+
+	// Point current.txt at it.
+	if err := SwitchCheckpoint(sessionDir, checkpointName); err != nil {
+		return fmt.Errorf("switch to initial checkpoint: %w", err)
+	}
+
+	return nil
+}
+
+// ReadHandoffCheckpointHeader reads the SessionHeader (first line) from the
+// checkpoint's messages.jsonl. Returns an error if the file cannot be read or
+// the header line is missing/malformed.
+func ReadHandoffCheckpointHeader(sessionDir, checkpointName string) (*SessionHeader, error) {
+	msgsPath := filepath.Join(handoffCheckpointDir(sessionDir, checkpointName), handoffMessagesFile)
+	f, err := os.Open(msgsPath)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", msgsPath, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("scan %s: %w", msgsPath, err)
+		}
+		return nil, fmt.Errorf("header line not found in %s", msgsPath)
+	}
+
+	line := scanner.Bytes()
+	if len(line) == 0 {
+		return nil, fmt.Errorf("empty header line in %s", msgsPath)
+	}
+
+	var header SessionHeader
+	if err := json.Unmarshal(line, &header); err != nil {
+		return nil, fmt.Errorf("unmarshal header: %w", err)
+	}
+	return &header, nil
+}
+
+// ReadRootMessagesAfter reads the root messages.jsonl and returns message
+// entries whose RFC3339 timestamp is strictly after cutoffTimestamp. Non-message
+// entries and entries at or before the cutoff are skipped. If the root file
+// does not exist, returns (nil, nil).
+func ReadRootMessagesAfter(sessionDir, cutoffTimestamp string) ([]agentctx.AgentMessage, error) {
+	cutoff, err := time.Parse(time.RFC3339Nano, cutoffTimestamp)
+	if err != nil {
+		return nil, fmt.Errorf("parse cutoff timestamp %q: %w", cutoffTimestamp, err)
+	}
+
+	rootPath := filepath.Join(sessionDir, "messages.jsonl")
+	f, err := os.Open(rootPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open root messages.jsonl: %w", err)
+	}
+	defer f.Close()
+
+	var messages []agentctx.AgentMessage
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		entry, derr := decodeSessionEntry(line)
+		if derr != nil || entry == nil {
+			continue
+		}
+		if entry.Type != EntryTypeMessage || entry.Message == nil {
+			continue
+		}
+		entryTime, terr := time.Parse(time.RFC3339Nano, entry.Timestamp)
+		if terr != nil {
+			continue
+		}
+		if entryTime.After(cutoff) {
+			msg := *entry.Message
+			msg.EntryID = entry.ID
+			messages = append(messages, msg)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan root messages.jsonl: %w", err)
+	}
+	return messages, nil
+}
+
+// WriteHandoffAgentState writes agent_state.json into the checkpoint directory.
+// This allows the resume path to restore AgentState (CWD, token counts, etc.)
+// after a handoff checkpoint switch.
+func WriteHandoffAgentState(sessionDir, checkpointName string, state *agentctx.AgentState) error {
+	statePath := filepath.Join(handoffCheckpointDir(sessionDir, checkpointName), "agent_state.json")
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal agent state: %w", err)
+	}
+	if err := os.WriteFile(statePath, data, 0644); err != nil {
+		return fmt.Errorf("write agent_state.json: %w", err)
+	}
+	return nil
+}
+
+// LoadHandoffCheckpointAgentState reads agent_state.json from the checkpoint
+// directory. Returns (nil, nil) if the file does not exist (backward
+// compatible with checkpoints created before agent state persistence).
+func LoadHandoffCheckpointAgentState(sessionDir, checkpointName string) (*agentctx.AgentState, error) {
+	statePath := filepath.Join(handoffCheckpointDir(sessionDir, checkpointName), "agent_state.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read agent_state.json: %w", err)
+	}
+	var state agentctx.AgentState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("unmarshal agent state: %w", err)
+	}
+	return &state, nil
+}

--- a/pkg/session/handoff_checkpoint.go
+++ b/pkg/session/handoff_checkpoint.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"sort"
-	"strconv"
 	"time"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
@@ -37,60 +34,60 @@ const (
 	handoffDocumentFile = "handoff.md"
 )
 
-// checkpointNamePattern matches checkpoint directory names like cp_001, cp_042.
-var checkpointNamePattern = regexp.MustCompile(`^cp_(\d+)$`)
-
 // handoffCheckpointDir returns the directory path for a named checkpoint.
 func handoffCheckpointDir(sessionDir, checkpointName string) string {
 	return filepath.Join(sessionDir, handoffCheckpointsDir, checkpointName)
 }
 
-// listExistingCheckpoints returns the sorted checkpoint directory names found
-// under sessionDir/checkpoints/. Only directories matching cp_NNN are returned.
-func listExistingCheckpoints(sessionDir string) ([]string, error) {
-	cpDir := filepath.Join(sessionDir, handoffCheckpointsDir)
-	entries, err := os.ReadDir(cpDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	var names []string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		if checkpointNamePattern.MatchString(e.Name()) {
-			names = append(names, e.Name())
-		}
-	}
-	sort.Strings(names)
-	return names, nil
+// metaFilePath returns the path to the session's meta.json file.
+func metaFilePath(sessionDir string) string {
+	return filepath.Join(sessionDir, "meta.json")
 }
 
-// nextCheckpointName determines the next sequential checkpoint name based on
-// existing checkpoint directories. Returns "cp_001" if none exist yet.
-func nextCheckpointName(sessionDir string) (string, error) {
-	names, err := listExistingCheckpoints(sessionDir)
+// ReadCheckpointCount reads the handoff checkpoint count from the session's
+// meta.json. Returns 0 if meta.json does not exist or the field is unset.
+func ReadCheckpointCount(sessionDir string) (int, error) {
+	data, err := os.ReadFile(metaFilePath(sessionDir))
 	if err != nil {
-		return "", fmt.Errorf("list checkpoints: %w", err)
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read meta.json: %w", err)
 	}
-	maxNum := 0
-	for _, name := range names {
-		m := checkpointNamePattern.FindStringSubmatch(name)
-		if len(m) < 2 {
-			continue
-		}
-		n, err := strconv.Atoi(m[1])
-		if err != nil {
-			continue
-		}
-		if n > maxNum {
-			maxNum = n
-		}
+	var meta SessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return 0, fmt.Errorf("unmarshal meta.json: %w", err)
 	}
-	return fmt.Sprintf("cp_%03d", maxNum+1), nil
+	return meta.HandoffCheckpointCount, nil
+}
+
+// WriteCheckpointCount writes the handoff checkpoint count to the session's
+// meta.json, preserving other existing fields.
+func WriteCheckpointCount(sessionDir string, count int) error {
+	metaPath := metaFilePath(sessionDir)
+	var meta SessionMeta
+
+	if data, err := os.ReadFile(metaPath); err == nil {
+		if err := json.Unmarshal(data, &meta); err != nil {
+			return fmt.Errorf("unmarshal meta.json: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read meta.json: %w", err)
+	}
+
+	meta.HandoffCheckpointCount = count
+
+	data, err := json.MarshalIndent(&meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal meta.json: %w", err)
+	}
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		return fmt.Errorf("create session dir: %w", err)
+	}
+	if err := os.WriteFile(metaPath, data, 0644); err != nil {
+		return fmt.Errorf("write meta.json: %w", err)
+	}
+	return nil
 }
 
 // newHandoffSessionHeader builds a SessionHeader for a checkpoint's
@@ -110,13 +107,10 @@ func newHandoffSessionHeader(parentCheckpoint string) SessionHeader {
 // It does NOT update current.txt — that is done by SwitchCheckpoint after the
 // checkpoint data has been fully written.
 //
-// Returns the checkpoint name (e.g. "cp_002").
-func CreateHandoffCheckpoint(sessionDir, parentCheckpoint string) (string, error) {
-	checkpointName, err := nextCheckpointName(sessionDir)
-	if err != nil {
-		return "", err
-	}
-
+// The checkpoint number (checkpointNum, 1-based) is assigned by the caller and
+// formatted as cp_%03d. Returns the checkpoint name (e.g. "cp_002").
+func CreateHandoffCheckpoint(sessionDir string, checkpointNum int, parentCheckpoint string) (string, error) {
+	checkpointName := fmt.Sprintf("cp_%03d", checkpointNum)
 	cpDir := handoffCheckpointDir(sessionDir, checkpointName)
 	if err := os.MkdirAll(cpDir, 0755); err != nil {
 		return "", fmt.Errorf("create checkpoint dir %s: %w", cpDir, err)
@@ -231,39 +225,93 @@ func LoadHandoffCheckpointMessages(sessionDir, checkpointName string) ([]agentct
 	return messages, nil
 }
 
-// IsHandoffSession returns true if sessionDir has both a checkpoints/ directory
-// and a current.txt file. This distinguishes handoff-mode sessions from legacy
-// sessions that use the old checkpoint_%05d recovery system.
+// IsHandoffSession returns true if the session's context management mode is
+// "handoff" according to meta.json. If meta.json does not exist (a legacy
+// session), this returns false because legacy sessions must not be treated as
+// handoff.
 func IsHandoffSession(sessionDir string) bool {
 	if sessionDir == "" {
 		return false
 	}
-	cpDir := filepath.Join(sessionDir, handoffCheckpointsDir)
-	if info, err := os.Stat(cpDir); err != nil || !info.IsDir() {
+	mode, err := ReadSessionMode(sessionDir)
+	if err != nil {
 		return false
 	}
-	curPath := filepath.Join(sessionDir, handoffCurrentFile)
-	if info, err := os.Stat(curPath); err != nil || info.IsDir() {
+	return mode == "handoff"
+}
+
+// ReadSessionMode reads the context management mode from the session's
+// meta.json. If meta.json exists but the mode field is empty, it returns
+// "handoff" (the project default for NEW sessions). If meta.json does NOT
+// exist, it returns an error so that callers can distinguish legacy sessions
+// (which must not be treated as handoff) from new ones.
+func ReadSessionMode(sessionDir string) (string, error) {
+	data, err := os.ReadFile(metaFilePath(sessionDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("meta.json not found")
+		}
+		return "", fmt.Errorf("read meta.json: %w", err)
+	}
+	var meta SessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", fmt.Errorf("unmarshal meta.json: %w", err)
+	}
+	if meta.ContextManagementMode == "" {
+		return "handoff", nil
+	}
+	return meta.ContextManagementMode, nil
+}
+
+// IsHandoffSessionWithDefault is like IsHandoffSession but uses defaultMode
+// when the session has no meta.json. This lets callers pass the configured
+// default (e.g. from app.cfg.ContextManagementMode()) for sessions that have
+// not been persisted yet.
+func IsHandoffSessionWithDefault(sessionDir, defaultMode string) bool {
+	if sessionDir == "" {
 		return false
 	}
-	return true
+	data, err := os.ReadFile(metaFilePath(sessionDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return defaultMode == "handoff"
+		}
+		return false
+	}
+	var meta SessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return false
+	}
+	mode := meta.ContextManagementMode
+	if mode == "" {
+		mode = defaultMode
+	}
+	return mode == "handoff"
 }
 
 // InitHandoffSession initializes the checkpoint structure for a new handoff-mode
 // session. It creates checkpoints/cp_001/ with a SessionHeader (ParentCheckpoint
 // empty) and writes current.txt pointing to "cp_001".
 //
-// If the session is already initialized (IsHandoffSession returns true), this
-// is a no-op.
+// If the session already has a checkpoint structure (current.txt exists),
+// this is a no-op.
 func InitHandoffSession(sessionDir string) error {
-	if IsHandoffSession(sessionDir) {
-		return nil
+	// Check for existing checkpoint structure directly, not IsHandoffSession,
+	// because IsHandoffSession reads mode from meta.json which may not exist yet.
+	curPath := filepath.Join(sessionDir, handoffCurrentFile)
+	if _, err := os.Stat(curPath); err == nil {
+		return nil // already initialized
 	}
 
 	// Create the first checkpoint.
-	checkpointName, err := CreateHandoffCheckpoint(sessionDir, "")
+	checkpointName, err := CreateHandoffCheckpoint(sessionDir, 1, "")
 	if err != nil {
 		return fmt.Errorf("create initial checkpoint: %w", err)
+	}
+
+	// Record the checkpoint count in meta.json.
+	if err := WriteCheckpointCount(sessionDir, 1); err != nil {
+		return fmt.Errorf("write checkpoint count: %w", err)
 	}
 
 	// Point current.txt at it.

--- a/pkg/session/handoff_checkpoint_test.go
+++ b/pkg/session/handoff_checkpoint_test.go
@@ -1,0 +1,455 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+func makeTestSessionDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return dir
+}
+
+func TestInitHandoffSession(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+
+	err := InitHandoffSession(sessionDir)
+	if err != nil {
+		t.Fatalf("InitHandoffSession failed: %v", err)
+	}
+
+	// Verify checkpoints/cp_001/ exists
+	cp001Dir := filepath.Join(sessionDir, "checkpoints", "cp_001")
+	if info, err := os.Stat(cp001Dir); err != nil || !info.IsDir() {
+		t.Fatalf("cp_001 directory not created: %v", err)
+	}
+
+	// Verify messages.jsonl exists with a SessionHeader
+	msgsPath := filepath.Join(cp001Dir, "messages.jsonl")
+	data, err := os.ReadFile(msgsPath)
+	if err != nil {
+		t.Fatalf("messages.jsonl not created: %v", err)
+	}
+
+	var header SessionHeader
+	if err := json.Unmarshal(data[:len(data)-1], &header); err != nil { // trim newline
+		t.Fatalf("failed to parse header: %v", err)
+	}
+	if header.Type != EntryTypeSession {
+		t.Errorf("expected header type %q, got %q", EntryTypeSession, header.Type)
+	}
+	if header.ParentCheckpoint != "" {
+		t.Errorf("expected empty ParentCheckpoint, got %q", header.ParentCheckpoint)
+	}
+
+	// Verify current.txt contains "cp_001"
+	curData, err := os.ReadFile(filepath.Join(sessionDir, "current.txt"))
+	if err != nil {
+		t.Fatalf("current.txt not created: %v", err)
+	}
+	if string(curData) != "cp_001" {
+		t.Errorf("expected current.txt content %q, got %q", "cp_001", string(curData))
+	}
+
+	// Verify IsHandoffSession returns true
+	if !IsHandoffSession(sessionDir) {
+		t.Error("IsHandoffSession should return true after InitHandoffSession")
+	}
+}
+
+func TestInitHandoffSession_Idempotent(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+
+	// First init
+	if err := InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("first InitHandoffSession failed: %v", err)
+	}
+
+	// Second init should be a no-op
+	if err := InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("second InitHandoffSession failed: %v", err)
+	}
+
+	// current.txt should still point to cp_001
+	cur, err := GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint failed: %v", err)
+	}
+	if cur != "cp_001" {
+		t.Errorf("expected cp_001, got %s", cur)
+	}
+}
+
+func TestCreateHandoffCheckpoint_Sequential(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+
+	// First checkpoint
+	cp1, err := CreateHandoffCheckpoint(sessionDir, "")
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint #1 failed: %v", err)
+	}
+	if cp1 != "cp_001" {
+		t.Errorf("expected cp_001, got %s", cp1)
+	}
+
+	// Second checkpoint with parent
+	cp2, err := CreateHandoffCheckpoint(sessionDir, cp1)
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint #2 failed: %v", err)
+	}
+	if cp2 != "cp_002" {
+		t.Errorf("expected cp_002, got %s", cp2)
+	}
+
+	// Third checkpoint
+	cp3, err := CreateHandoffCheckpoint(sessionDir, cp2)
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint #3 failed: %v", err)
+	}
+	if cp3 != "cp_003" {
+		t.Errorf("expected cp_003, got %s", cp3)
+	}
+
+	// Verify parent checkpoint in cp_002 header
+	msgsPath := filepath.Join(sessionDir, "checkpoints", "cp_002", "messages.jsonl")
+	data, err := os.ReadFile(msgsPath)
+	if err != nil {
+		t.Fatalf("read cp_002 messages.jsonl: %v", err)
+	}
+	var header SessionHeader
+	if err := json.Unmarshal(data[:len(data)-1], &header); err != nil {
+		t.Fatalf("parse cp_002 header: %v", err)
+	}
+	if header.ParentCheckpoint != cp1 {
+		t.Errorf("expected ParentCheckpoint %q, got %q", cp1, header.ParentCheckpoint)
+	}
+}
+
+func TestWriteHandoffMessages(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
+	}
+
+	entries := []SessionEntry{
+		{
+			Type:      EntryTypeMessage,
+			ID:        "msg1",
+			Timestamp: "2024-01-01T00:00:00Z",
+			Message: &agentctx.AgentMessage{
+				Role: "user",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: "hello"},
+				},
+			},
+		},
+		{
+			Type:      EntryTypeMessage,
+			ID:        "msg2",
+			Timestamp: "2024-01-01T00:00:01Z",
+			Message: &agentctx.AgentMessage{
+				Role: "assistant",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: "hi there"},
+				},
+			},
+		},
+	}
+
+	if err := WriteHandoffMessages(sessionDir, cpName, entries); err != nil {
+		t.Fatalf("WriteHandoffMessages failed: %v", err)
+	}
+
+	// Verify messages can be loaded back
+	msgs, err := LoadHandoffCheckpointMessages(sessionDir, cpName)
+	if err != nil {
+		t.Fatalf("LoadHandoffCheckpointMessages failed: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Role != "user" {
+		t.Errorf("expected first message role 'user', got %q", msgs[0].Role)
+	}
+	if msgs[1].Role != "assistant" {
+		t.Errorf("expected second message role 'assistant', got %q", msgs[1].Role)
+	}
+	if msgs[0].EntryID != "msg1" {
+		t.Errorf("expected first message EntryID 'msg1', got %q", msgs[0].EntryID)
+	}
+}
+
+func TestLoadHandoffCheckpointMessages_SkipsHeader(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
+	}
+
+	// No messages written — just the header
+	msgs, err := LoadHandoffCheckpointMessages(sessionDir, cpName)
+	if err != nil {
+		t.Fatalf("LoadHandoffCheckpointMessages failed: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages with only header, got %d", len(msgs))
+	}
+}
+
+func TestSwitchCheckpoint(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+
+	if err := SwitchCheckpoint(sessionDir, "cp_005"); err != nil {
+		t.Fatalf("SwitchCheckpoint failed: %v", err)
+	}
+
+	// Verify current.txt content
+	cur, err := GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint failed: %v", err)
+	}
+	if cur != "cp_005" {
+		t.Errorf("expected cp_005, got %s", cur)
+	}
+
+	// Switch again
+	if err := SwitchCheckpoint(sessionDir, "cp_006"); err != nil {
+		t.Fatalf("SwitchCheckpoint #2 failed: %v", err)
+	}
+	cur, err = GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint #2 failed: %v", err)
+	}
+	if cur != "cp_006" {
+		t.Errorf("expected cp_006, got %s", cur)
+	}
+
+	// Verify temp file doesn't linger
+	if _, err := os.Stat(filepath.Join(sessionDir, ".current.txt.tmp")); err == nil {
+		t.Error("temp file should have been renamed")
+	}
+}
+
+func TestGetCurrentCheckpoint_NoFile(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+
+	cur, err := GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint should not error on missing file: %v", err)
+	}
+	if cur != "" {
+		t.Errorf("expected empty string for missing file, got %q", cur)
+	}
+}
+
+func TestIsHandoffSession(t *testing.T) {
+	t.Run("not handoff (empty)", func(t *testing.T) {
+		if IsHandoffSession("") {
+			t.Error("empty dir should not be handoff")
+		}
+	})
+
+	t.Run("not handoff (no checkpoints)", func(t *testing.T) {
+		dir := makeTestSessionDir(t)
+		if IsHandoffSession(dir) {
+			t.Error("dir without checkpoints should not be handoff")
+		}
+	})
+
+	t.Run("not handoff (checkpoints but no current.txt)", func(t *testing.T) {
+		dir := makeTestSessionDir(t)
+		_ = os.MkdirAll(filepath.Join(dir, "checkpoints", "cp_001"), 0755)
+		if IsHandoffSession(dir) {
+			t.Error("dir with checkpoints but no current.txt should not be handoff")
+		}
+	})
+
+	t.Run("is handoff", func(t *testing.T) {
+		dir := makeTestSessionDir(t)
+		if err := InitHandoffSession(dir); err != nil {
+			t.Fatalf("InitHandoffSession failed: %v", err)
+		}
+		if !IsHandoffSession(dir) {
+			t.Error("initialized session should be handoff")
+		}
+	})
+}
+
+func TestWriteHandoffDocument(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
+	}
+
+	content := "# Handoff Document\n\nThis is a test handoff."
+	if err := WriteHandoffDocument(sessionDir, cpName, content); err != nil {
+		t.Fatalf("WriteHandoffDocument failed: %v", err)
+	}
+
+	docPath := filepath.Join(sessionDir, "checkpoints", cpName, "handoff.md")
+	data, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read handoff.md: %v", err)
+	}
+	if string(data) != content {
+		t.Errorf("expected %q, got %q", content, string(data))
+	}
+}
+
+func TestLoadHandoffCheckpointMessages_MixedEntries(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
+	}
+
+	// Write a mix of message and non-message entries
+	entries := []SessionEntry{
+		{
+			Type: EntryTypeMessage,
+			ID:   "m1",
+			Message: &agentctx.AgentMessage{
+				Role: "user",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: "q"},
+				},
+			},
+		},
+		{
+			Type:  EntryTypeSessionInfo,
+			ID:    "si1",
+			Name:  "test",
+			Title: "Test",
+		},
+		{
+			Type: EntryTypeMessage,
+			ID:   "m2",
+			Message: &agentctx.AgentMessage{
+				Role: "assistant",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: "a"},
+				},
+			},
+		},
+	}
+
+	if err := WriteHandoffMessages(sessionDir, cpName, entries); err != nil {
+		t.Fatalf("WriteHandoffMessages failed: %v", err)
+	}
+
+	msgs, err := LoadHandoffCheckpointMessages(sessionDir, cpName)
+	if err != nil {
+		t.Fatalf("LoadHandoffCheckpointMessages failed: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages (non-message entries skipped), got %d", len(msgs))
+	}
+}
+
+// TestCreateHandoffCheckpoint_IgnoresNonCheckpointDirs verifies that
+// non-matching directories under checkpoints/ are ignored when computing
+// the next checkpoint number.
+func TestCreateHandoffCheckpoint_IgnoresNonCheckpointDirs(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+
+	// Create a bogus directory that doesn't match cp_NNN pattern
+	_ = os.MkdirAll(filepath.Join(sessionDir, "checkpoints", "random_dir"), 0755)
+
+	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
+	}
+	if cpName != "cp_001" {
+		t.Errorf("expected cp_001 (ignoring non-matching dirs), got %s", cpName)
+	}
+}
+
+// TestFullHandoffLifecycle exercises the complete handoff workflow:
+// init → write messages → create second checkpoint → switch → resume.
+func TestFullHandoffLifecycle(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+
+	// 1. Initialize
+	if err := InitHandoffSession(sessionDir); err != nil {
+		t.Fatalf("InitHandoffSession: %v", err)
+	}
+
+	// 2. Write some messages to cp_001
+	msgs1 := []SessionEntry{
+		{
+			Type: EntryTypeMessage,
+			ID:   "m1",
+			Message: &agentctx.AgentMessage{
+				Role: "user",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: "start"},
+				},
+			},
+		},
+	}
+	if err := WriteHandoffMessages(sessionDir, "cp_001", msgs1); err != nil {
+		t.Fatalf("WriteHandoffMessages: %v", err)
+	}
+
+	// 3. Create cp_002 and write a handoff doc
+	cp2, err := CreateHandoffCheckpoint(sessionDir, "cp_001")
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint: %v", err)
+	}
+	if cp2 != "cp_002" {
+		t.Fatalf("expected cp_002, got %s", cp2)
+	}
+	handoffContent := "# Handoff\nKey info here."
+	if err := WriteHandoffDocument(sessionDir, cp2, handoffContent); err != nil {
+		t.Fatalf("WriteHandoffDocument: %v", err)
+	}
+	msgs2 := []SessionEntry{
+		{
+			Type: EntryTypeMessage,
+			ID:   "m2",
+			Message: &agentctx.AgentMessage{
+				Role: "user",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: "continued"},
+				},
+			},
+		},
+	}
+	if err := WriteHandoffMessages(sessionDir, cp2, msgs2); err != nil {
+		t.Fatalf("WriteHandoffMessages cp2: %v", err)
+	}
+
+	// 4. Switch to cp_002
+	if err := SwitchCheckpoint(sessionDir, cp2); err != nil {
+		t.Fatalf("SwitchCheckpoint: %v", err)
+	}
+
+	// 5. Verify current points to cp_002
+	cur, err := GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint: %v", err)
+	}
+	if cur != "cp_002" {
+		t.Fatalf("expected current cp_002, got %s", cur)
+	}
+
+	// 6. Load messages from cp_002
+	loaded, err := LoadHandoffCheckpointMessages(sessionDir, "cp_002")
+	if err != nil {
+		t.Fatalf("LoadHandoffCheckpointMessages: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 message in cp_002, got %d", len(loaded))
+	}
+	if !strings.Contains(loaded[0].ExtractText(), "continued") {
+		t.Errorf("unexpected message content: %s", loaded[0].ExtractText())
+	}
+}

--- a/pkg/session/handoff_checkpoint_test.go
+++ b/pkg/session/handoff_checkpoint_test.go
@@ -86,6 +86,78 @@ func TestInitHandoffSession_Idempotent(t *testing.T) {
 	}
 }
 
+func TestInitHandoffFromExisting(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+
+	entries := []SessionEntry{
+		{Type: EntryTypeMessage, ID: "m1", Message: &agentctx.AgentMessage{Role: "user", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "hello"}}}},
+		{Type: EntryTypeMessage, ID: "m2", Message: &agentctx.AgentMessage{Role: "assistant", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "hi there"}}}},
+	}
+
+	if err := InitHandoffFromExisting(sessionDir, entries); err != nil {
+		t.Fatalf("InitHandoffFromExisting failed: %v", err)
+	}
+
+	// Verify current.txt
+	cur, err := GetCurrentCheckpoint(sessionDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint: %v", err)
+	}
+	if cur != "cp_001" {
+		t.Errorf("expected cp_001, got %s", cur)
+	}
+
+	// Verify messages were written
+	msgs, err := LoadHandoffCheckpointMessages(sessionDir, "cp_001")
+	if err != nil {
+		t.Fatalf("LoadHandoffCheckpointMessages: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Role != "user" || msgs[1].Role != "assistant" {
+		t.Errorf("unexpected roles: %s, %s", msgs[0].Role, msgs[1].Role)
+	}
+
+	// Verify checkpoint count
+	count, err := ReadCheckpointCount(sessionDir)
+	if err != nil {
+		t.Fatalf("ReadCheckpointCount: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected count 1, got %d", count)
+	}
+}
+
+func TestInitHandoffFromExisting_Idempotent(t *testing.T) {
+	sessionDir := makeTestSessionDir(t)
+
+	// First call initializes
+	entries := []SessionEntry{
+		{Type: EntryTypeMessage, ID: "m1", Message: &agentctx.AgentMessage{Role: "user", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "first"}}}},
+	}
+	if err := InitHandoffFromExisting(sessionDir, entries); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// Second call should be no-op (current.txt exists)
+	entries2 := []SessionEntry{
+		{Type: EntryTypeMessage, ID: "m2", Message: &agentctx.AgentMessage{Role: "user", Content: []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "second"}}}},
+	}
+	if err := InitHandoffFromExisting(sessionDir, entries2); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	// Should still have only the first message
+	msgs, err := LoadHandoffCheckpointMessages(sessionDir, "cp_001")
+	if err != nil {
+		t.Fatalf("LoadHandoffCheckpointMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message (no-op), got %d", len(msgs))
+	}
+}
+
 func TestCreateHandoffCheckpoint_Sequential(t *testing.T) {
 	sessionDir := makeTestSessionDir(t)
 

--- a/pkg/session/handoff_checkpoint_test.go
+++ b/pkg/session/handoff_checkpoint_test.go
@@ -90,7 +90,7 @@ func TestCreateHandoffCheckpoint_Sequential(t *testing.T) {
 	sessionDir := makeTestSessionDir(t)
 
 	// First checkpoint
-	cp1, err := CreateHandoffCheckpoint(sessionDir, "")
+	cp1, err := CreateHandoffCheckpoint(sessionDir, 1, "")
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint #1 failed: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestCreateHandoffCheckpoint_Sequential(t *testing.T) {
 	}
 
 	// Second checkpoint with parent
-	cp2, err := CreateHandoffCheckpoint(sessionDir, cp1)
+	cp2, err := CreateHandoffCheckpoint(sessionDir, 2, cp1)
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint #2 failed: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestCreateHandoffCheckpoint_Sequential(t *testing.T) {
 	}
 
 	// Third checkpoint
-	cp3, err := CreateHandoffCheckpoint(sessionDir, cp2)
+	cp3, err := CreateHandoffCheckpoint(sessionDir, 3, cp2)
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint #3 failed: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestCreateHandoffCheckpoint_Sequential(t *testing.T) {
 
 func TestWriteHandoffMessages(t *testing.T) {
 	sessionDir := makeTestSessionDir(t)
-	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	cpName, err := CreateHandoffCheckpoint(sessionDir, 1, "")
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestWriteHandoffMessages(t *testing.T) {
 
 func TestLoadHandoffCheckpointMessages_SkipsHeader(t *testing.T) {
 	sessionDir := makeTestSessionDir(t)
-	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	cpName, err := CreateHandoffCheckpoint(sessionDir, 1, "")
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
 	}
@@ -250,28 +250,37 @@ func TestGetCurrentCheckpoint_NoFile(t *testing.T) {
 }
 
 func TestIsHandoffSession(t *testing.T) {
-	t.Run("not handoff (empty)", func(t *testing.T) {
+	t.Run("not handoff (empty path)", func(t *testing.T) {
 		if IsHandoffSession("") {
 			t.Error("empty dir should not be handoff")
 		}
 	})
 
-	t.Run("not handoff (no checkpoints)", func(t *testing.T) {
+	t.Run("not handoff (no meta, treated as legacy)", func(t *testing.T) {
 		dir := makeTestSessionDir(t)
+		// With no meta.json, the session is legacy and must NOT be treated
+		// as handoff.
 		if IsHandoffSession(dir) {
-			t.Error("dir without checkpoints should not be handoff")
+			t.Error("dir without meta.json should not be handoff")
 		}
 	})
 
-	t.Run("not handoff (checkpoints but no current.txt)", func(t *testing.T) {
+	t.Run("not handoff (legacy mode in meta)", func(t *testing.T) {
 		dir := makeTestSessionDir(t)
-		_ = os.MkdirAll(filepath.Join(dir, "checkpoints", "cp_001"), 0755)
+		meta := SessionMeta{ContextManagementMode: "legacy"}
+		data, err := json.Marshal(meta)
+		if err != nil {
+			t.Fatalf("marshal meta: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "meta.json"), data, 0644); err != nil {
+			t.Fatalf("write meta.json: %v", err)
+		}
 		if IsHandoffSession(dir) {
-			t.Error("dir with checkpoints but no current.txt should not be handoff")
+			t.Error("legacy session should not be handoff")
 		}
 	})
 
-	t.Run("is handoff", func(t *testing.T) {
+	t.Run("is handoff (initialized)", func(t *testing.T) {
 		dir := makeTestSessionDir(t)
 		if err := InitHandoffSession(dir); err != nil {
 			t.Fatalf("InitHandoffSession failed: %v", err)
@@ -280,11 +289,25 @@ func TestIsHandoffSession(t *testing.T) {
 			t.Error("initialized session should be handoff")
 		}
 	})
+
+	t.Run("IsHandoffSessionWithDefault (legacy default)", func(t *testing.T) {
+		dir := makeTestSessionDir(t)
+		if IsHandoffSessionWithDefault(dir, "legacy") {
+			t.Error("should be false when default is legacy and no meta")
+		}
+	})
+
+	t.Run("IsHandoffSessionWithDefault (handoff default)", func(t *testing.T) {
+		dir := makeTestSessionDir(t)
+		if !IsHandoffSessionWithDefault(dir, "handoff") {
+			t.Error("should be true when default is handoff and no meta")
+		}
+	})
 }
 
 func TestWriteHandoffDocument(t *testing.T) {
 	sessionDir := makeTestSessionDir(t)
-	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	cpName, err := CreateHandoffCheckpoint(sessionDir, 1, "")
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
 	}
@@ -306,7 +329,7 @@ func TestWriteHandoffDocument(t *testing.T) {
 
 func TestLoadHandoffCheckpointMessages_MixedEntries(t *testing.T) {
 	sessionDir := makeTestSessionDir(t)
-	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	cpName, err := CreateHandoffCheckpoint(sessionDir, 1, "")
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
 	}
@@ -354,21 +377,21 @@ func TestLoadHandoffCheckpointMessages_MixedEntries(t *testing.T) {
 	}
 }
 
-// TestCreateHandoffCheckpoint_IgnoresNonCheckpointDirs verifies that
-// non-matching directories under checkpoints/ are ignored when computing
-// the next checkpoint number.
-func TestCreateHandoffCheckpoint_IgnoresNonCheckpointDirs(t *testing.T) {
+// TestCreateHandoffCheckpoint_WithExistingDirs verifies that creating a
+// checkpoint works even when non-matching directories exist under checkpoints/.
+// The checkpoint number comes from the caller, not directory scanning.
+func TestCreateHandoffCheckpoint_WithExistingDirs(t *testing.T) {
 	sessionDir := makeTestSessionDir(t)
 
 	// Create a bogus directory that doesn't match cp_NNN pattern
 	_ = os.MkdirAll(filepath.Join(sessionDir, "checkpoints", "random_dir"), 0755)
 
-	cpName, err := CreateHandoffCheckpoint(sessionDir, "")
+	cpName, err := CreateHandoffCheckpoint(sessionDir, 1, "")
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint failed: %v", err)
 	}
 	if cpName != "cp_001" {
-		t.Errorf("expected cp_001 (ignoring non-matching dirs), got %s", cpName)
+		t.Errorf("expected cp_001 (number from caller), got %s", cpName)
 	}
 }
 
@@ -400,7 +423,7 @@ func TestFullHandoffLifecycle(t *testing.T) {
 	}
 
 	// 3. Create cp_002 and write a handoff doc
-	cp2, err := CreateHandoffCheckpoint(sessionDir, "cp_001")
+	cp2, err := CreateHandoffCheckpoint(sessionDir, 2, "cp_001")
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint: %v", err)
 	}

--- a/pkg/session/handoff_fork.go
+++ b/pkg/session/handoff_fork.go
@@ -1,0 +1,134 @@
+package session
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ForkHandoffSession copies the entire session directory to a new session ID.
+// This is the handoff-mode equivalent of ForkSessionFrom. The new session
+// inherits all checkpoints, current.txt, meta.json, and the full history.
+//
+// Unlike ForkSessionFrom (which performs entry-level branching via the
+// leafID/parent tree), this method performs a raw filesystem-level copy of
+// every file under the source session directory. This preserves the complete
+// checkpoint chain (cp_001 → cp_002 → …) and the handoff.md documents.
+func (sm *SessionManager) ForkHandoffSession(source *Session, name, title string) (*Session, error) {
+	if source == nil {
+		return nil, fmt.Errorf("source session is nil")
+	}
+	if err := os.MkdirAll(sm.sessionsDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create sessions directory: %w", err)
+	}
+
+	sourceDir := source.GetDir()
+	if sourceDir == "" {
+		return nil, fmt.Errorf("source session has no directory")
+	}
+
+	// Read the source's meta to inherit ContextManagementMode.
+	sourceID := filepath.Base(sourceDir)
+	inheritedMode := ""
+	if meta, err := sm.GetMeta(sourceID); err == nil {
+		inheritedMode = meta.ContextManagementMode
+	}
+
+	// Generate new ID and destination directory.
+	id := uuid.New().String()
+	sessDir := sm.getSessionPath(id)
+
+	// Create the destination directory.
+	if err := os.MkdirAll(sessDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create session directory: %w", err)
+	}
+
+	// Copy the entire source directory tree (messages.jsonl, checkpoints/,
+	// current.txt, meta.json, handoff.md files, etc.).
+	if err := copyDir(sourceDir, sessDir); err != nil {
+		_ = os.RemoveAll(sessDir)
+		return nil, fmt.Errorf("failed to copy session directory: %w", err)
+	}
+
+	// Load the copied session so we can update its header.
+	newSess, err := LoadSession(sessDir)
+	if err != nil {
+		_ = os.RemoveAll(sessDir)
+		return nil, fmt.Errorf("failed to load forked session: %w", err)
+	}
+
+	// Set ParentSession pointer to the source session's messages.jsonl path.
+	newSess.header.ParentSession = source.GetPath()
+	if err := newSess.rewriteFile(); err != nil {
+		_ = os.RemoveAll(sessDir)
+		return nil, fmt.Errorf("failed to update session header: %w", err)
+	}
+
+	// Create new metadata with the new ID, name, title, and inherited mode.
+	meta := &SessionMeta{
+		ID:                    id,
+		Name:                  name,
+		Title:                 title,
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+		MessageCount:          len(newSess.GetMessages()),
+		ContextManagementMode: inheritedMode,
+	}
+	if err := sm.saveMeta(id, meta); err != nil {
+		_ = os.RemoveAll(sessDir)
+		return nil, fmt.Errorf("failed to save metadata: %w", err)
+	}
+
+	return newSess, nil
+}
+
+// copyDir recursively copies all files and subdirectories from src to dst.
+// dst is assumed to already exist. Symlinks are not specially handled — the
+// session directory should only contain regular files and directories.
+func copyDir(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			if err := os.MkdirAll(dstPath, 0755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", dstPath, err)
+			}
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			if err := copyFile(srcPath, dstPath); err != nil {
+				return fmt.Errorf("copy %s → %s: %w", srcPath, dstPath, err)
+			}
+		}
+	}
+	return nil
+}
+
+// copyFile copies a single regular file from src to dst.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}

--- a/pkg/session/handoff_fork_test.go
+++ b/pkg/session/handoff_fork_test.go
@@ -1,0 +1,278 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+// makeTestHandoffSessionDir creates a temporary sessions directory, initializes
+// a handoff-mode session inside it via the SessionManager, populates it with
+// checkpoints and messages, and returns the manager, session, and session dir.
+func makeTestHandoffSessionDir(t *testing.T) (*SessionManager, *Session, string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	sm := NewSessionManager(tmp)
+
+	// Create a session.
+	sess, err := sm.CreateSession("handoff-src", "Handoff Source")
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	sessDir := sess.GetDir()
+
+	// Initialize the handoff checkpoint structure.
+	if err := InitHandoffSession(sessDir); err != nil {
+		t.Fatalf("InitHandoffSession failed: %v", err)
+	}
+
+	// Write some messages into cp_001.
+	messages := []SessionEntry{
+		{
+			Type:      EntryTypeMessage,
+			ID:        "msg-001",
+			Timestamp: "2024-01-01T00:00:00Z",
+			Message: &agentctx.AgentMessage{
+				Role: "user",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: "hello from checkpoint 1"},
+				},
+			},
+		},
+		{
+			Type:      EntryTypeMessage,
+			ID:        "msg-002",
+			Timestamp: "2024-01-01T00:00:01Z",
+			Message: &agentctx.AgentMessage{
+				Role: "assistant",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: "hi there"},
+				},
+			},
+		},
+	}
+	if err := WriteHandoffMessages(sessDir, "cp_001", messages); err != nil {
+		t.Fatalf("WriteHandoffMessages cp_001 failed: %v", err)
+	}
+
+	// Create a second checkpoint (simulating a handoff).
+	cp2, err := CreateHandoffCheckpoint(sessDir, "cp_001")
+	if err != nil {
+		t.Fatalf("CreateHandoffCheckpoint cp_002 failed: %v", err)
+	}
+	if err := SwitchCheckpoint(sessDir, cp2); err != nil {
+		t.Fatalf("SwitchCheckpoint failed: %v", err)
+	}
+
+	// Write a handoff.md for cp_002.
+	if err := WriteHandoffDocument(sessDir, cp2, "# Handoff\n\nSummary of checkpoint 1"); err != nil {
+		t.Fatalf("WriteHandoffDocument failed: %v", err)
+	}
+
+	// Write messages into cp_002.
+	messages2 := []SessionEntry{
+		{
+			Type:      EntryTypeMessage,
+			ID:        "msg-003",
+			Timestamp: "2024-01-01T00:00:02Z",
+			Message: &agentctx.AgentMessage{
+				Role: "user",
+				Content: []agentctx.ContentBlock{
+					agentctx.TextContent{Type: "text", Text: "hello from checkpoint 2"},
+				},
+			},
+		},
+	}
+	if err := WriteHandoffMessages(sessDir, cp2, messages2); err != nil {
+		t.Fatalf("WriteHandoffMessages cp_002 failed: %v", err)
+	}
+
+	// Set the source session's meta to handoff mode.
+	sourceID := filepath.Base(sessDir)
+	meta, err := sm.GetMeta(sourceID)
+	if err != nil {
+		t.Fatalf("GetMeta failed: %v", err)
+	}
+	meta.ContextManagementMode = "handoff"
+	if err := sm.saveMeta(sourceID, meta); err != nil {
+		t.Fatalf("saveMeta failed: %v", err)
+	}
+
+	return sm, sess, sessDir
+}
+
+func TestForkHandoffSession_CopiesAllFiles(t *testing.T) {
+	sm, sess, sessDir := makeTestHandoffSessionDir(t)
+
+	newSess, err := sm.ForkHandoffSession(sess, "handoff-fork", "Forked Handoff Session")
+	if err != nil {
+		t.Fatalf("ForkHandoffSession failed: %v", err)
+	}
+
+	newDir := newSess.GetDir()
+
+	// Verify the new session is a handoff session.
+	if !IsHandoffSession(newDir) {
+		t.Fatal("forked session should be a handoff session")
+	}
+
+	// Verify checkpoints/ directory exists.
+	cpDir := filepath.Join(newDir, "checkpoints")
+	if info, err := os.Stat(cpDir); err != nil || !info.IsDir() {
+		t.Fatalf("checkpoints/ directory not copied: %v", err)
+	}
+
+	// Verify both checkpoint directories were copied.
+	for _, cpName := range []string{"cp_001", "cp_002"} {
+		dir := filepath.Join(cpDir, cpName)
+		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+			t.Fatalf("checkpoint %s not copied: %v", cpName, err)
+		}
+
+		// Verify messages.jsonl exists.
+		msgsPath := filepath.Join(dir, "messages.jsonl")
+		if _, err := os.Stat(msgsPath); err != nil {
+			t.Fatalf("messages.jsonl in %s not copied: %v", cpName, err)
+		}
+	}
+
+	// Verify current.txt matches the source.
+	srcCurrent, err := GetCurrentCheckpoint(sessDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint source failed: %v", err)
+	}
+	newCurrent, err := GetCurrentCheckpoint(newDir)
+	if err != nil {
+		t.Fatalf("GetCurrentCheckpoint forked failed: %v", err)
+	}
+	if srcCurrent != newCurrent {
+		t.Errorf("current.txt mismatch: source=%q, forked=%q", srcCurrent, newCurrent)
+	}
+	if newCurrent != "cp_002" {
+		t.Errorf("expected current.txt to point to cp_002, got %q", newCurrent)
+	}
+
+	// Verify handoff.md was copied for cp_002.
+	docPath := filepath.Join(cpDir, "cp_002", "handoff.md")
+	data, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("handoff.md not copied: %v", err)
+	}
+	if string(data) == "" {
+		t.Error("handoff.md content is empty")
+	}
+
+	// Verify messages.jsonl in the root was copied.
+	rootMsgs := filepath.Join(newDir, "messages.jsonl")
+	if _, err := os.Stat(rootMsgs); err != nil {
+		t.Fatalf("root messages.jsonl not copied: %v", err)
+	}
+}
+
+func TestForkHandoffSession_InheritsMode(t *testing.T) {
+	sm, sess, _ := makeTestHandoffSessionDir(t)
+
+	newSess, err := sm.ForkHandoffSession(sess, "handoff-fork-2", "Forked Handoff")
+	if err != nil {
+		t.Fatalf("ForkHandoffSession failed: %v", err)
+	}
+
+	newID := filepath.Base(newSess.GetDir())
+	meta, err := sm.GetMeta(newID)
+	if err != nil {
+		t.Fatalf("GetMeta failed: %v", err)
+	}
+
+	if meta.ContextManagementMode != "handoff" {
+		t.Errorf("expected ContextManagementMode %q, got %q", "handoff", meta.ContextManagementMode)
+	}
+	if meta.Name != "handoff-fork-2" {
+		t.Errorf("expected name %q, got %q", "handoff-fork-2", meta.Name)
+	}
+}
+
+func TestForkHandoffSession_CurrentTxtPointsToSameCheckpoint(t *testing.T) {
+	sm, sess, sessDir := makeTestHandoffSessionDir(t)
+
+	newSess, err := sm.ForkHandoffSession(sess, "handoff-fork-3", "Forked")
+	if err != nil {
+		t.Fatalf("ForkHandoffSession failed: %v", err)
+	}
+
+	srcCurrent, _ := GetCurrentCheckpoint(sessDir)
+	newCurrent, _ := GetCurrentCheckpoint(newSess.GetDir())
+
+	if srcCurrent != newCurrent {
+		t.Errorf("checkpoint mismatch: source=%q forked=%q", srcCurrent, newCurrent)
+	}
+
+	// Verify the messages in the forked checkpoint match the source.
+	srcMsgs, err := LoadHandoffCheckpointMessages(sessDir, srcCurrent)
+	if err != nil {
+		t.Fatalf("LoadHandoffCheckpointMessages source failed: %v", err)
+	}
+	newMsgs, err := LoadHandoffCheckpointMessages(newSess.GetDir(), newCurrent)
+	if err != nil {
+		t.Fatalf("LoadHandoffCheckpointMessages forked failed: %v", err)
+	}
+
+	if len(srcMsgs) != len(newMsgs) {
+		t.Fatalf("message count mismatch: source=%d forked=%d", len(srcMsgs), len(newMsgs))
+	}
+}
+
+func TestForkHandoffSession_SetsParentSession(t *testing.T) {
+	sm, sess, _ := makeTestHandoffSessionDir(t)
+
+	newSess, err := sm.ForkHandoffSession(sess, "handoff-fork-parent", "Forked")
+	if err != nil {
+		t.Fatalf("ForkHandoffSession failed: %v", err)
+	}
+
+	header := newSess.GetHeader()
+	if header.ParentSession == "" {
+		t.Error("expected ParentSession to be set on forked session")
+	}
+
+	sourcePath := sess.GetPath()
+	if header.ParentSession != sourcePath {
+		t.Errorf("expected ParentSession %q, got %q", sourcePath, header.ParentSession)
+	}
+}
+
+func TestForkHandoffSession_NilSource(t *testing.T) {
+	sm := NewSessionManager(t.TempDir())
+
+	_, err := sm.ForkHandoffSession(nil, "fork", "Forked")
+	if err == nil {
+		t.Fatal("expected error for nil source")
+	}
+}
+
+func TestForkHandoffSession_DifferentDirectory(t *testing.T) {
+	sm, sess, sessDir := makeTestHandoffSessionDir(t)
+
+	newSess, err := sm.ForkHandoffSession(sess, "unique-fork", "Unique")
+	if err != nil {
+		t.Fatalf("ForkHandoffSession failed: %v", err)
+	}
+
+	// The new session must be in a different directory.
+	if newSess.GetDir() == sessDir {
+		t.Fatal("forked session should be in a different directory from source")
+	}
+
+	// The new session must be loadable via the manager.
+	newID := filepath.Base(newSess.GetDir())
+	loaded, err := sm.GetSession(newID)
+	if err != nil {
+		t.Fatalf("GetSession on forked session failed: %v", err)
+	}
+	if loaded.GetDir() != newSess.GetDir() {
+		t.Error("loaded session dir mismatch")
+	}
+}

--- a/pkg/session/handoff_fork_test.go
+++ b/pkg/session/handoff_fork_test.go
@@ -60,7 +60,7 @@ func makeTestHandoffSessionDir(t *testing.T) (*SessionManager, *Session, string)
 	}
 
 	// Create a second checkpoint (simulating a handoff).
-	cp2, err := CreateHandoffCheckpoint(sessDir, "cp_001")
+	cp2, err := CreateHandoffCheckpoint(sessDir, 2, "cp_001")
 	if err != nil {
 		t.Fatalf("CreateHandoffCheckpoint cp_002 failed: %v", err)
 	}

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -25,6 +25,8 @@ type SessionMeta struct {
 	Workspace string `json:"workspace,omitempty"`
 	// CurrentWorkdir is the current working directory path
 	CurrentWorkdir string `json:"currentWorkdir,omitempty"`
+	// ContextManagementMode records which context management strategy is used ("legacy" | "handoff").
+	ContextManagementMode string `json:"contextManagementMode,omitempty"`
 }
 
 // SessionManager manages multiple sessions.

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -27,6 +27,10 @@ type SessionMeta struct {
 	CurrentWorkdir string `json:"currentWorkdir,omitempty"`
 	// ContextManagementMode records which context management strategy is used ("legacy" | "handoff").
 	ContextManagementMode string `json:"contextManagementMode,omitempty"`
+	// HandoffCheckpointCount tracks the number of handoff checkpoints created
+	// for this session. Used to assign sequential checkpoint names (cp_001,
+	// cp_002, ...) without scanning the directory.
+	HandoffCheckpointCount int `json:"handoffCheckpointCount,omitempty"`
 }
 
 // SessionManager manages multiple sessions.


### PR DESCRIPTION
## Summary

Implements handoff-based context management as described in [`docs/handoff-context-mgmt-design.md`](docs/handoff-context-mgmt-design.md).

When context quality degrades, the agent writes a handoff document, a Q&A verification loop validates it, and a new checkpoint with fresh context is created. Legacy compaction mode is preserved via a config switch.

## Key Changes

**Config** (`pkg/config/config.go`)
- `ContextManagementConfig` with mode switch (`legacy` | `handoff`), defaults to `legacy`
- Custom `UnmarshalJSON` migrates old `true`/`false` bool config format

**Session** (`pkg/session/`)
- `ParentCheckpoint` field on `SessionHeader`, `ContextManagementMode` on `SessionMeta`
- Checkpoint directory structure: `checkpoints/cp_NNN/` with `messages.jsonl` + `current.txt` (atomic switch)
- `ForkHandoffSession` for directory-level fork in handoff mode

**Agent loop** (`pkg/agent/loop.go`)
- Handoff mode guard skips proactive compaction, retains reactive `context_limit_recovery`
- `maybeInjectHandoffReminder`: token usage monitoring with soft/hard thresholds and dynamic injection interval

**Handoff process** (`pkg/agent/handoff_*.go`)
- `hasHandoffMarker`/`extractHandoffDoc`: detect `<handoff_complete>` in LLM output
- `performHandoff`: Q&A verification loop via `llm.StreamLLM`, creates checkpoint, reloads context
- `autoGenerateHandoffDoc`: hard底线 auto-execute fallback

**Resume** (`pkg/agent/resume.go`)
- `LoadHandoffResumeState`: loads checkpoint messages + replays root journal entries post-checkpoint + restores `AgentState`

## Test Results
- ✅ `go build ./...` clean
- ✅ `make fmt-check` clean
- ✅ `go test ./...` — all 22 packages pass
- ✅ Unit tests for all new functionality (checkpoint lifecycle, reminder thresholds, marker detection, fork, resume)

## Post-Review Fixes

- **`InitHandoffSession` never called** — a faulty guard condition prevented session initialization in the handoff path; fixed (`65caca5`)
- **Dedicated handoff generation prompt** — `autoGenerateHandoffDoc` reused the coding-assistant system prompt, confusing the model into a 28-token output. Now uses a dedicated `handoffGenerateSystemPrompt` (`1c34524`)
- **Text serialization for API calls** — raw `AgentMessage` (carrying `toolResult` role / consecutive same-role messages) triggered API 400s in both doc generation and the Q&A answer phase. Both paths now serialize the conversation to a plain-text transcript (512KB cap)
- **`/handoff` manual command** — added a slash command in `rpc_message_handlers.go` for manual trigger + testing
- **Fallback on empty handoff messages** — `LoadResumeState` falls back when the handoff path returns empty messages

## End-to-End Validation

Tested `/handoff` on a real session (475 messages / ~114K tokens):
- ✅ Handoff doc generated (8.4KB)
- ✅ Q&A Round 0 completed (question + answer)
- ✅ Checkpoint `cp_002` created (3 messages, parent `cp_001`)
- ✅ Context switched: 475 → 3 messages
- ✅ 429 rate limit on Q&A Round 1 handled gracefully (warn + proceed with checkpoint)

## Known Follow-ups

- `runHandoffQA` still reuses the main agent's coding-assistant system prompt (for prefix-cache friendliness); a dedicated QA prompt is worth evaluating
- Design doc §7 economic model assumes cross-call prefix-cache persistence — not yet validated
- Thresholds (40K/100K/150K/200K) are provisional and need tuning with real workloads
