### PR TITLE
feat: support thinking API parameters for ZAI/DeepSeek models

### DIFF
--- a/cmd/ai/helpers.go
+++ b/cmd/ai/helpers.go
@@ -159,6 +159,9 @@ func applyModelLimitsFromSpec(model llm.Model, spec config.ModelSpec) llm.Model 
 	if model.MaxTokens <= 0 && spec.MaxTokens > 0 {
 		model.MaxTokens = spec.MaxTokens
 	}
+	if spec.Reasoning {
+		model.Reasoning = true
+	}
 	return model
 }
 

--- a/cmd/ai/rpc_config_handlers.go
+++ b/cmd/ai/rpc_config_handlers.go
@@ -125,6 +125,7 @@ func (app *rpcApp) handleModelSet(args string) (any, error) {
 		API:           spec.API,
 		ContextWindow: spec.ContextWindow,
 		MaxTokens:     spec.MaxTokens,
+		Reasoning:     spec.Reasoning,
 	}
 	app.apiKey = newAPIKey
 

--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -35,17 +35,21 @@ func streamAssistantResponse(
 	selectedMessages, _ := selectMessagesForLLM(agentCtx)
 	llmMessages = ConvertMessagesToLLM(ctx, selectedMessages)
 
+	// Resolve model early — needed for thinking API detection and cache mode.
+	model := getEffectiveModel(config)
+
 	systemPrompt := agentCtx.SystemPrompt
-	if instruction := prompt.ThinkingInstruction(thinkingLevel); instruction != "" {
-		if strings.TrimSpace(systemPrompt) == "" {
-			systemPrompt = instruction
-		} else {
-			systemPrompt = systemPrompt + "\n\n" + instruction
+	// For models that support thinking via API params, skip the text instruction;
+	// the thinking level is passed as API parameters instead.
+	if !model.Reasoning {
+		if instruction := prompt.ThinkingInstruction(thinkingLevel); instruction != "" {
+			if strings.TrimSpace(systemPrompt) == "" {
+				systemPrompt = instruction
+			} else {
+				systemPrompt = systemPrompt + "\n\n" + instruction
+			}
 		}
 	}
-
-	// Resolve model early — needed for cache mode detection before runtime_state injection.
-	model := getEffectiveModel(config)
 
 	// Resolve cache mode and determine runtime_state injection strategy.
 	// Cache-first (e.g. DeepSeek): persist runtime_state as AgentMessage in RecentMessages
@@ -107,9 +111,10 @@ func streamAssistantResponse(
 	llmTools := ConvertToolsToLLM(ctx, agentCtx.Tools)
 
 	llmCtxParams := llm.LLMContext{
-		SystemPrompt: systemPrompt,
-		Messages:     llmMessages,
-		Tools:        llmTools,
+		SystemPrompt:  systemPrompt,
+		Messages:      llmMessages,
+		Tools:         llmTools,
+		ThinkingLevel: thinkingLevel,
 	}
 	//	emitLLMRequestSnapshot(ctx, config.Model, llmCtxParams)
 

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -84,6 +84,11 @@ func StreamLLM(
 			reqBody["tool_choice"] = "auto"
 		}
 
+		// Inject thinking/reasoning parameters for models that support API control.
+		for k, v := range buildThinkingParams(model, llmCtx.ThinkingLevel) {
+			reqBody[k] = v
+		}
+
 		jsonBody, err := json.Marshal(reqBody)
 		if err != nil {
 			stream.Push(LLMErrorEvent{Error: err})

--- a/pkg/llm/thinking.go
+++ b/pkg/llm/thinking.go
@@ -1,0 +1,56 @@
+package llm
+
+// supportsThinkingObject returns true for providers that accept the
+// "thinking":{"type":"enabled/disabled"} object in their OpenAI-compatible
+// request body (ZAI and DeepSeek).
+func supportsThinkingObject(provider string) bool {
+	return provider == "zai" || provider == "deepseek"
+}
+
+// buildThinkingParams returns thinking/reasoning parameters to inject into an
+// OpenAI-compatible request body, or nil if none should be sent.
+//
+// level is expected to be pre-normalized to one of:
+// off/minimal/low/medium/high/xhigh. An empty level means "no preference" — the
+// model uses its default and no params are injected.
+func buildThinkingParams(model Model, level string) map[string]any {
+	if !model.Reasoning || level == "" {
+		return nil
+	}
+
+	provider := model.Provider
+	useThinkingObj := supportsThinkingObject(provider)
+
+	// "off" — disable thinking entirely.
+	if level == "off" {
+		if useThinkingObj {
+			return map[string]any{"thinking": map[string]string{"type": "disabled"}}
+		}
+		// No way to disable via API for this provider.
+		return nil
+	}
+
+	// "minimal" — DeepSeek has no lightweight effort, disabling is closest.
+	if level == "minimal" && provider == "deepseek" {
+		return map[string]any{"thinking": map[string]string{"type": "disabled"}}
+	}
+
+	// Map level to reasoning_effort for the target provider.
+	effort := level
+	switch {
+	case provider == "deepseek" && level == "xhigh":
+		effort = "max"
+	case provider == "deepseek":
+		// DeepSeek only supports high/max.
+		effort = "high"
+	case provider != "zai" && level == "xhigh":
+		// OpenAI-standard providers don't have xhigh.
+		effort = "high"
+	}
+
+	params := map[string]any{"reasoning_effort": effort}
+	if useThinkingObj {
+		params["thinking"] = map[string]string{"type": "enabled"}
+	}
+	return params
+}

--- a/pkg/llm/thinking_test.go
+++ b/pkg/llm/thinking_test.go
@@ -1,0 +1,85 @@
+package llm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildThinkingParams(t *testing.T) {
+	zaiModel := Model{Provider: "zai", Reasoning: true}
+	dsModel := Model{Provider: "deepseek", Reasoning: true}
+	genericModel := Model{Provider: "openai", Reasoning: true}
+	nonReasoning := Model{Provider: "zai", Reasoning: false}
+
+	tests := []struct {
+		name   string
+		model  Model
+		level  string
+		expect map[string]any
+	}{
+		// Non-reasoning model — no params regardless of level.
+		{"non-reasoning off", nonReasoning, "off", nil},
+		{"non-reasoning high", nonReasoning, "high", nil},
+
+		// Empty level — no params (let model use default).
+		{"zai empty", zaiModel, "", nil},
+
+		// ZAI: pass through all levels (server-side degradation handles them).
+		{"zai off", zaiModel, "off", map[string]any{"thinking": map[string]string{"type": "disabled"}}},
+		{"zai minimal", zaiModel, "minimal", map[string]any{
+			"thinking":         map[string]string{"type": "enabled"},
+			"reasoning_effort": "minimal",
+		}},
+		{"zai low", zaiModel, "low", map[string]any{
+			"thinking":         map[string]string{"type": "enabled"},
+			"reasoning_effort": "low",
+		}},
+		{"zai medium", zaiModel, "medium", map[string]any{
+			"thinking":         map[string]string{"type": "enabled"},
+			"reasoning_effort": "medium",
+		}},
+		{"zai high", zaiModel, "high", map[string]any{
+			"thinking":         map[string]string{"type": "enabled"},
+			"reasoning_effort": "high",
+		}},
+		{"zai xhigh", zaiModel, "xhigh", map[string]any{
+			"thinking":         map[string]string{"type": "enabled"},
+			"reasoning_effort": "xhigh",
+		}},
+
+		// DeepSeek: only high/max supported; minimal→disabled.
+		{"ds off", dsModel, "off", map[string]any{"thinking": map[string]string{"type": "disabled"}}},
+		{"ds minimal", dsModel, "minimal", map[string]any{"thinking": map[string]string{"type": "disabled"}}},
+		{"ds low", dsModel, "low", map[string]any{
+			"thinking":         map[string]string{"type": "enabled"},
+			"reasoning_effort": "high",
+		}},
+		{"ds medium", dsModel, "medium", map[string]any{
+			"thinking":         map[string]string{"type": "enabled"},
+			"reasoning_effort": "high",
+		}},
+		{"ds high", dsModel, "high", map[string]any{
+			"thinking":         map[string]string{"type": "enabled"},
+			"reasoning_effort": "high",
+		}},
+		{"ds xhigh", dsModel, "xhigh", map[string]any{
+			"thinking":         map[string]string{"type": "enabled"},
+			"reasoning_effort": "max",
+		}},
+
+		// Generic OpenAI-compat: reasoning_effort only, no thinking object.
+		{"generic off", genericModel, "off", nil},
+		{"generic minimal", genericModel, "minimal", map[string]any{"reasoning_effort": "minimal"}},
+		{"generic high", genericModel, "high", map[string]any{"reasoning_effort": "high"}},
+		{"generic xhigh", genericModel, "xhigh", map[string]any{"reasoning_effort": "high"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildThinkingParams(tt.model, tt.level)
+			if !reflect.DeepEqual(got, tt.expect) {
+				t.Errorf("buildThinkingParams(%+v, %q)\n  got:  %v\n  want: %v", tt.model, tt.level, got, tt.expect)
+			}
+		})
+	}
+}

--- a/pkg/llm/types.go
+++ b/pkg/llm/types.go
@@ -14,13 +14,15 @@ type Model struct {
 	API           string `json:"api"`           // e.g., "openai-completions"
 	ContextWindow int    `json:"contextWindow"` // e.g., 128000, 0 means unknown
 	MaxTokens     int    `json:"maxTokens,omitempty"`
+	Reasoning     bool   `json:"reasoning,omitempty"` // model supports thinking/reasoning control via API
 }
 
 // LLMContext represents the context for an LLM request.
 type LLMContext struct {
-	SystemPrompt string       `json:"systemPrompt,omitempty"`
-	Messages     []LLMMessage `json:"messages"`
-	Tools        []LLMTool    `json:"tools,omitempty"`
+	SystemPrompt  string       `json:"systemPrompt,omitempty"`
+	Messages      []LLMMessage `json:"messages"`
+	Tools         []LLMTool    `json:"tools,omitempty"`
+	ThinkingLevel string       `json:"thinkingLevel,omitempty"` // normalized: off/minimal/low/medium/high/xhigh
 }
 
 // LLMMessage represents a message in the LLM conversation.


### PR DESCRIPTION
## Summary

Replace system-prompt-only approach with provider-specific API parameters for models that support reasoning control (ZAI GLM-5.x, DeepSeek V4).

## Behavior Matrix

**ZAI (glm-5.1 / glm-5.2)** — full pass-through (server handles degradation):
| `/set thinking-level` | API params |
|---|---|
| off | `thinking:{type:disabled}` |
| minimal/low/medium/high/xhigh | `thinking:{type:enabled}` + `reasoning_effort:<level>` |

**DeepSeek (v4)** — only high/max supported:
| `/set thinking-level` | API params |
|---|---|
| off, minimal | `thinking:{type:disabled}` |
| low/medium/high | `reasoning_effort:high` |
| xhigh | `reasoning_effort:max` |

**Non-reasoning models** — unchanged, system prompt text instruction fallback.

## Changes
- `pkg/llm/types.go`: `Model.Reasoning`, `LLMContext.ThinkingLevel`
- `pkg/llm/thinking.go` (new): `buildThinkingParams()` provider-aware injection
- `pkg/llm/client.go`: inject params into OpenAI-compat request body
- `cmd/ai/helpers.go`, `rpc_config_handlers.go`: propagate `spec.Reasoning`
- `pkg/agent/llm_stream.go`: skip text instruction for reasoning models, pass ThinkingLevel