### PR TITLE
feat: emit cache_read in llm_call trace events

### DIFF
--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -219,6 +219,11 @@ func streamAssistantResponse(
 			llmSpan.AddField("input_tokens", e.Usage.InputTokens)
 			llmSpan.AddField("output_tokens", e.Usage.OutputTokens)
 			llmSpan.AddField("total_tokens", e.Usage.TotalTokens)
+			cachedTokens := 0
+			if e.Usage.PromptTokensDetails != nil {
+				cachedTokens = e.Usage.PromptTokensDetails.CachedTokens
+			}
+			llmSpan.AddField("cache_read", cachedTokens)
 			llmSpan.AddField("stop_reason", e.StopReason)
 			elapsed := time.Since(llmStart)
 			if elapsed > 0 {
@@ -272,6 +277,7 @@ func streamAssistantResponse(
 				InputTokens:  e.Usage.InputTokens,
 				OutputTokens: e.Usage.OutputTokens,
 				TotalTokens:  e.Usage.TotalTokens,
+				CacheRead:    cachedTokens,
 			}
 
 			// Try to inject tool calls from tagged text

--- a/pkg/compact/context_management.go
+++ b/pkg/compact/context_management.go
@@ -316,6 +316,9 @@ func (c *ContextManager) CompactWithCtx(parent context.Context, agentCtx *agentc
 			llmSpan.AddField("input_tokens", usage.InputTokens)
 			llmSpan.AddField("output_tokens", usage.OutputTokens)
 			llmSpan.AddField("total_tokens", usage.TotalTokens)
+			if usage.PromptTokensDetails != nil {
+				llmSpan.AddField("cache_read", usage.PromptTokensDetails.CachedTokens)
+			}
 			duration := time.Since(llmCallStart)
 			if duration.Seconds() > 0 {
 				llmSpan.AddField("input_tokens_per_sec", float64(usage.InputTokens)/duration.Seconds())

--- a/pkg/llm/types.go
+++ b/pkg/llm/types.go
@@ -103,9 +103,15 @@ type ToolFunction struct {
 
 // Usage represents token usage information.
 type Usage struct {
-	InputTokens  int `json:"prompt_tokens"`
-	OutputTokens int `json:"completion_tokens"`
-	TotalTokens  int `json:"total_tokens"`
+	InputTokens         int                  `json:"prompt_tokens"`
+	OutputTokens        int                  `json:"completion_tokens"`
+	TotalTokens         int                  `json:"total_tokens"`
+	PromptTokensDetails *PromptTokensDetails `json:"prompt_tokens_details,omitempty"`
+}
+
+// PromptTokensDetails holds the breakdown of prompt tokens, including cache hits.
+type PromptTokensDetails struct {
+	CachedTokens int `json:"cached_tokens"`
 }
 
 // LLMEvent represents an event from the LLM stream.


### PR DESCRIPTION
## Summary

ZAI（智谱）及 OpenAI-compatible provider 通过 `usage.prompt_tokens_details.cached_tokens` 返回上下文缓存命中的 token 数。但下游 metrics 管道（`metrics_aggregate.go`）和 UI 渲染（`event_renderer.go`）早已消费 `llm_call` span 上的 `cache_read` 字段，却从未有人 emit，导致 `CacheRead` 始终为 0。

本次改动补上**生产端**，打通端到端链路。

## Changes

- **`pkg/llm/types.go`** — `Usage` 新增 `PromptTokensDetails` 嵌套结构体，解析 API 响应中的 `cached_tokens`。SSE 流解析（`client.go`）用 `Usage *Usage` 反序列化，加字段即自动填充。
- **`pkg/agent/llm_stream.go`** — `ChunkDone` 处给 `llm_call` span emit `cache_read`，并填充 `finalMessage.Usage.CacheRead`。
- **`pkg/compact/context_management.go`** — compaction 路径的 `llm_call` span 同步 emit `cache_read`，保持一致。

## Why no new trace event

复用现有 `llm_call` span。下游消费链（`metrics_aggregate.go:55-56` → `event_renderer.go:648-649`）早已建好，补上 emit 后 metrics 聚合与 UI 展示自动生效，无需新事件。

`cache_write` 未触碰 —— ZAI 隐式缓存模型不单独报告 cache write（该字段留给 Anthropic 等其他 provider）。

## Test

- `go build ./...` ✅
- `go test ./pkg/llm/... ./pkg/agent/... ./pkg/compact/...` ✅
- `make fmt` ✅