### PR TITLE
feat: cache-friendly summary generation + fix compaction boundaryStart bug

### DIFF
--- a/cmd/ai/rpc_config_handlers.go
+++ b/cmd/ai/rpc_config_handlers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"github.com/tiancaiamao/ai/pkg/agent"
 	"github.com/tiancaiamao/ai/pkg/compact"
 	"github.com/tiancaiamao/ai/pkg/config"
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
 	"github.com/tiancaiamao/ai/pkg/rpc"
 	traceevent "github.com/tiancaiamao/ai/pkg/traceevent"
@@ -140,6 +142,16 @@ func (app *rpcApp) handleModelSet(args string) (any, error) {
 
 	// Recreate compactor with new model
 	app.compactor = compact.NewCompactor(app.compactorConfig, app.model, app.apiKey, app.systemPrompt, spec.ContextWindow)
+	// Re-inject the agent LLM context so the new compactor reuses the main
+	// agent's system prompt + message format for cache-friendly summaries.
+	app.compactor.SetAgentLLMContext(
+		app.systemPrompt,
+		app.agentContextPrefix,
+		app.currentThinkingLevel,
+		func(msgs []agentctx.AgentMessage) []llm.LLMMessage {
+			return agent.ConvertMessagesToLLM(context.Background(), msgs)
+		},
+	)
 	app.sessionComp.Update(app.sess, app.compactor)
 	app.ag.SetCompactor(app.sessionComp)
 	app.ag.SetContextWindow(spec.ContextWindow)

--- a/cmd/ai/rpc_helpers.go
+++ b/cmd/ai/rpc_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tiancaiamao/ai/pkg/agent"
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/llm"
 	"github.com/tiancaiamao/ai/pkg/prompt"
 	"github.com/tiancaiamao/ai/pkg/session"
 	"github.com/tiancaiamao/ai/pkg/skill"
@@ -91,6 +92,19 @@ func (app *rpcApp) restoreLLMContextFromCompaction(sess *session.Session) {
 func (app *rpcApp) createBaseContext() *agentctx.AgentContext {
 	app.systemPrompt = app.buildSystemPrompt(app.sess)
 	app.agentContextPrefix = app.buildAgentContextPrefix()
+	// Sync the compactor with the agent's system prompt, context prefix, and
+	// message converter so summary requests share the conversation prefix for
+	// provider prefix-cache hits (see GenerateSummaryWithPrevious).
+	if app.compactor != nil {
+		app.compactor.SetAgentLLMContext(
+			app.systemPrompt,
+			app.agentContextPrefix,
+			app.currentThinkingLevel,
+			func(msgs []agentctx.AgentMessage) []llm.LLMMessage {
+				return agent.ConvertMessagesToLLM(context.Background(), msgs)
+			},
+		)
+	}
 	// Keep loopCfg in sync if it has been constructed (createBaseContext
 	// may be re-invoked on session resume while loopCfg already exists).
 	if app.loopCfg != nil {

--- a/cmd/ai/rpc_setup.go
+++ b/cmd/ai/rpc_setup.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tiancaiamao/ai/pkg/skill"
 	"github.com/tiancaiamao/ai/pkg/tools"
 
-	"github.com/tiancaiamao/ai/pkg/agent"
 	"github.com/tiancaiamao/ai/pkg/agentconfig"
 )
 
@@ -149,10 +148,15 @@ func newRPCApp(sessionPath string, params rpcAppSetupParams) (*rpcApp, error) {
 		runID:                 params.runID,
 	}
 
-	// Skip context management (proactive LLM-driven cycle) in cache-first mode.
-	// Full compaction (75% threshold) is still active.
+	// largeContextWindowThreshold disables proactive context management for
+	// models with very large context windows (e.g. GLM-5.2 1M, Claude 200k).
+	const largeContextWindowThreshold = 200_000
+	// Skip proactive context management (LLM-driven mini compaction) for models
+	// with large context windows — they don't benefit from aggressive context
+	// trimming, and the extra LLM call wastes budget. Full compaction (75%
+	// threshold via the main Compactor) stays active regardless.
 	ctxManager.SetSkipCondition(func() bool {
-		return agent.IsCacheMode(app.model.ID) == agent.CacheModeCache
+		return app.currentContextWindow >= largeContextWindowThreshold
 	})
 
 	return app, nil

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -57,6 +57,29 @@ type Compactor struct {
 	apiKey        string
 	systemPrompt  string
 	contextWindow int
+
+	// Cache-friendly summarization fields. When set via SetAgentLLMContext,
+	// summary requests reuse the main agent's system prompt and real message
+	// format so they share a prefix with the main conversation, maximizing
+	// provider prefix-cache hits. See GenerateSummaryWithPrevious.
+	agentSystemPrompt  string
+	agentContextPrefix string
+	thinkingLevel      string
+	messageConverter   func([]agentctx.AgentMessage) []llm.LLMMessage
+}
+
+// SetAgentLLMContext configures the compactor to reuse the main agent's system
+// prompt, context prefix, and message converter when generating summaries.
+// This makes summary requests share the conversation prefix for cache reuse
+// instead of using a dedicated system prompt with serialized text.
+// thinkingLevel is used to reconstruct the thinking instruction appended to
+// the system prompt (matching the main agent loop) so the cache prefix matches.
+// Call this after the agent context is built (system prompt + prefix are known).
+func (c *Compactor) SetAgentLLMContext(systemPrompt, contextPrefix, thinkingLevel string, converter func([]agentctx.AgentMessage) []llm.LLMMessage) {
+	c.agentSystemPrompt = systemPrompt
+	c.agentContextPrefix = contextPrefix
+	c.thinkingLevel = thinkingLevel
+	c.messageConverter = converter
 }
 
 // NewCompactor creates a new Compactor.

--- a/pkg/compact/compact_cache_test.go
+++ b/pkg/compact/compact_cache_test.go
@@ -1,0 +1,347 @@
+package compact
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"github.com/tiancaiamao/ai/pkg/llm"
+)
+
+// --- SetAgentLLMContext setter ---
+
+func TestSetAgentLLMContext(t *testing.T) {
+	c := NewCompactor(DefaultConfig(), llm.Model{}, "k", "sys", 0)
+	if c.agentSystemPrompt != "" || c.agentContextPrefix != "" || c.thinkingLevel != "" || c.messageConverter != nil {
+		t.Fatal("expected zero-value fields before SetAgentLLMContext")
+	}
+
+	conv := func(msgs []agentctx.AgentMessage) []llm.LLMMessage { return nil }
+	c.SetAgentLLMContext("agent-sys", "prefix", "high", conv)
+
+	if c.agentSystemPrompt != "agent-sys" {
+		t.Errorf("agentSystemPrompt = %q, want %q", c.agentSystemPrompt, "agent-sys")
+	}
+	if c.agentContextPrefix != "prefix" {
+		t.Errorf("agentContextPrefix = %q, want %q", c.agentContextPrefix, "prefix")
+	}
+	if c.thinkingLevel != "high" {
+		t.Errorf("thinkingLevel = %q, want %q", c.thinkingLevel, "high")
+	}
+	if c.messageConverter == nil {
+		t.Error("messageConverter should be non-nil")
+	}
+}
+
+// --- Cache-friendly request format (the core of this change) ---
+//
+// When SetAgentLLMContext is called, the summary request must:
+//   1. Use the main agent's system prompt (not the compact system prompt)
+//   2. Send messages in real role-based format (not serialized text)
+//   3. Prepend the agent context prefix before the first user message
+//   4. Append the compact instruction as a trailing user message
+// These properties ensure the request shares a prefix with the main
+// conversation for provider prefix-cache hits.
+
+// captureRequestServer returns an httptest server that captures the request
+// body into the provided pointer. The server always responds with a valid
+// SSE summary stream.
+func captureRequestServer(captured *map[string]any) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		*captured = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, sseTextResponse("summary-result"))
+	}))
+}
+
+func TestGenerateSummary_CacheFriendlyRequestFormat(t *testing.T) {
+	var captured map[string]any
+	server := captureRequestServer(&captured)
+	defer server.Close()
+
+	model := llm.Model{ID: "m", ContextWindow: 200000, BaseURL: server.URL, API: "openai"}
+	c := NewCompactor(DefaultConfig(), model, "k", "sys", 0)
+	c.SetAgentLLMContext("AGENT-SYSTEM-PROMPT", "AGENT-CONTEXT-PREFIX", "high", nil)
+	// nil converter → falls back to convertAgentMessagesToLLM
+
+	msgs := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("hello"),
+		agentctx.NewAssistantMessage(),
+	}
+	_, err := c.GenerateSummary(msgs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rawMessages, ok := captured["messages"].([]any)
+	if !ok {
+		t.Fatalf("expected messages array, got %T", captured["messages"])
+	}
+
+	// --- Property 1: system prompt is the agent's, prepended by the LLM client ---
+	// For non-reasoning models, the thinking instruction is appended (matching
+	// the main agent loop) so the cache prefix matches exactly.
+	sysMsg, _ := rawMessages[0].(map[string]any)
+	if sysMsg["role"] != "system" {
+		t.Errorf("messages[0].role = %v, want %q", sysMsg["role"], "system")
+	}
+	sysContent, _ := sysMsg["content"].(string)
+	if !strings.HasPrefix(sysContent, "AGENT-SYSTEM-PROMPT") {
+		t.Errorf("messages[0].content = %q, want prefix %q", sysContent, "AGENT-SYSTEM-PROMPT")
+	}
+	if !strings.Contains(sysContent, "Thinking level is high") {
+		t.Errorf("messages[0].content = %q, want thinking instruction appended", sysContent)
+	}
+
+	// --- Property 2: context prefix is the next message (before first real user) ---
+	prefixMsg, _ := rawMessages[1].(map[string]any)
+	if prefixMsg["role"] != "user" {
+		t.Errorf("messages[1].role = %v, want %q (prefix)", prefixMsg["role"], "user")
+	}
+	if prefixMsg["content"] != "AGENT-CONTEXT-PREFIX" {
+		t.Errorf("messages[1].content = %v, want context prefix", prefixMsg["content"])
+	}
+
+	// --- Property 3: real conversation messages follow (role-based, not serialized text) ---
+	userMsg, _ := rawMessages[2].(map[string]any)
+	if userMsg["role"] != "user" || userMsg["content"] != "hello" {
+		t.Errorf("messages[2] = %v, want real user message with content 'hello'", userMsg)
+	}
+
+	// --- Property 4: compact instruction is appended as the last user message ---
+	lastMsg, _ := rawMessages[len(rawMessages)-1].(map[string]any)
+	if lastMsg["role"] != "user" {
+		t.Errorf("last message role = %v, want %q (compact instruction)", lastMsg["role"], "user")
+	}
+	lastContent, _ := lastMsg["content"].(string)
+	if !strings.Contains(lastContent, "summary") {
+		t.Errorf("last message should contain compact instruction, got: %s", lastContent[:min(100, len(lastContent))])
+	}
+}
+
+func TestGenerateSummary_FallbackWithoutAgentContext(t *testing.T) {
+	// Without SetAgentLLMContext, the compactor should still work using
+	// the fallback converter and the compact system prompt.
+	var captured map[string]any
+	server := captureRequestServer(&captured)
+	defer server.Close()
+
+	model := llm.Model{ID: "m", ContextWindow: 200000, BaseURL: server.URL, API: "openai"}
+	c := NewCompactor(DefaultConfig(), model, "k", "sys", 0)
+	// NO SetAgentLLMContext call
+
+	_, err := c.GenerateSummary([]agentctx.AgentMessage{agentctx.NewUserMessage("hi")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rawMessages, _ := captured["messages"].([]any)
+	// system prompt should be the compact system prompt (fallback)
+	sysMsg, _ := rawMessages[0].(map[string]any)
+	if sysMsg["content"] == "AGENT-SYSTEM-PROMPT" {
+		t.Error("should not use agent system prompt in fallback mode")
+	}
+	// No prefix message: messages[1] should be the real user message, not a prefix
+	if len(rawMessages) > 1 {
+		second, _ := rawMessages[1].(map[string]any)
+		if second["content"] != "hi" {
+			t.Errorf("messages[1].content = %v, want 'hi' (no prefix in fallback)", second["content"])
+		}
+	}
+}
+
+func TestGenerateSummary_PreviousSummaryInInstruction(t *testing.T) {
+	// When previousSummary is non-empty, the trailing instruction should
+	// include the previous summary content (incremental update path).
+	var captured map[string]any
+	server := captureRequestServer(&captured)
+	defer server.Close()
+
+	model := llm.Model{ID: "m", ContextWindow: 200000, BaseURL: server.URL, API: "openai"}
+	c := NewCompactor(DefaultConfig(), model, "k", "sys", 0)
+	c.SetAgentLLMContext("agent-sys", "", "high", nil)
+
+	_, err := c.GenerateSummaryWithPrevious(
+		[]agentctx.AgentMessage{agentctx.NewUserMessage("new work")},
+		"PREVIOUS-SUMMARY-CONTENT",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rawMessages, _ := captured["messages"].([]any)
+	lastMsg, _ := rawMessages[len(rawMessages)-1].(map[string]any)
+	lastContent, _ := lastMsg["content"].(string)
+	if !strings.Contains(lastContent, "PREVIOUS-SUMMARY-CONTENT") {
+		t.Errorf("trailing instruction should contain previous summary, got: %s", lastContent[:min(100, len(lastContent))])
+	}
+}
+
+// --- Fallback converter: convertAgentMessagesToLLM ---
+
+func TestConvertAgentMessagesToLLM(t *testing.T) {
+	asst := agentctx.NewAssistantMessage()
+	asst.Content = []agentctx.ContentBlock{
+		agentctx.TextContent{Type: "text", Text: "assistant reply"},
+		agentctx.ToolCallContent{
+			ID:        "call_1",
+			Type:      "toolCall",
+			Name:      "grep",
+			Arguments: map[string]any{"pattern": "foo"},
+		},
+	}
+	toolResult := agentctx.NewToolResultMessage("call_1", "grep",
+		[]agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "matched lines"}},
+		false,
+	)
+
+	msgs := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("query"),
+		asst,
+		toolResult,
+	}
+
+	got := convertAgentMessagesToLLM(msgs)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(got))
+	}
+
+	// user
+	if got[0].Role != "user" || got[0].Content != "query" {
+		t.Errorf("msg[0] = %+v, want role=user content=query", got[0])
+	}
+
+	// assistant with text + tool call
+	if got[1].Role != "assistant" {
+		t.Errorf("msg[1].Role = %q, want assistant", got[1].Role)
+	}
+	if got[1].Content != "assistant reply" {
+		t.Errorf("msg[1].Content = %q, want 'assistant reply'", got[1].Content)
+	}
+	if len(got[1].ToolCalls) != 1 {
+		t.Fatalf("msg[1] ToolCalls len = %d, want 1", len(got[1].ToolCalls))
+	}
+	if got[1].ToolCalls[0].Function.Name != "grep" {
+		t.Errorf("tool call name = %q, want grep", got[1].ToolCalls[0].Function.Name)
+	}
+
+	// tool result → role "tool"
+	if got[2].Role != "tool" {
+		t.Errorf("msg[2].Role = %q, want tool", got[2].Role)
+	}
+	if got[2].ToolCallID != "call_1" {
+		t.Errorf("msg[2].ToolCallID = %q, want call_1", got[2].ToolCallID)
+	}
+	if got[2].Content != "matched lines" {
+		t.Errorf("msg[2].Content = %q, want 'matched lines'", got[2].Content)
+	}
+}
+
+func TestConvertAgentMessagesToLLM_SkipsInvisible(t *testing.T) {
+	invisible := agentctx.NewUserMessage("hidden").WithVisibility(false, true)
+	got := convertAgentMessagesToLLM([]agentctx.AgentMessage{invisible})
+	if len(got) != 0 {
+		t.Errorf("expected 0 messages (invisible filtered), got %d", len(got))
+	}
+}
+
+func TestConvertAgentMessagesToLLM_Thinking(t *testing.T) {
+	asst := agentctx.NewAssistantMessage()
+	asst.Content = []agentctx.ContentBlock{
+		agentctx.ThinkingContent{Type: "thinking", Thinking: "reasoning here"},
+		agentctx.TextContent{Type: "text", Text: "answer"},
+	}
+	got := convertAgentMessagesToLLM([]agentctx.AgentMessage{asst})
+	if len(got) != 1 || got[0].Thinking != "reasoning here" {
+		t.Errorf("thinking not preserved: %+v", got)
+	}
+}
+
+// --- insertBeforeFirstUserMessage ---
+
+func TestInsertBeforeFirstUserMessage(t *testing.T) {
+	msg := llm.LLMMessage{Role: "user", Content: "PREFIX"}
+
+	t.Run("empty", func(t *testing.T) {
+		got := insertBeforeFirstUserMessage(nil, msg)
+		if len(got) != 1 || got[0].Content != "PREFIX" {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("no_user_message", func(t *testing.T) {
+		input := []llm.LLMMessage{
+			{Role: "assistant", Content: "a"},
+		}
+		got := insertBeforeFirstUserMessage(input, msg)
+		if len(got) != 2 || got[0].Content != "PREFIX" {
+			t.Errorf("expected prefix first when no user, got %+v", got)
+		}
+	})
+
+	t.Run("user_at_start", func(t *testing.T) {
+		input := []llm.LLMMessage{
+			{Role: "user", Content: "u1"},
+			{Role: "assistant", Content: "a1"},
+		}
+		got := insertBeforeFirstUserMessage(input, msg)
+		if len(got) != 3 || got[0].Content != "PREFIX" || got[1].Content != "u1" {
+			t.Errorf("prefix should be before first user, got %+v", got)
+		}
+	})
+
+	t.Run("user_after_assistant", func(t *testing.T) {
+		input := []llm.LLMMessage{
+			{Role: "system", Content: "s"},
+			{Role: "user", Content: "u1"},
+		}
+		got := insertBeforeFirstUserMessage(input, msg)
+		if len(got) != 3 || got[0].Content != "s" || got[1].Content != "PREFIX" || got[2].Content != "u1" {
+			t.Errorf("prefix should be between system and first user, got %+v", got)
+		}
+	})
+}
+
+// TestGenerateSummary_ThinkingInstruction verifies that the system prompt in
+// the summary request includes the thinking instruction for non-reasoning
+// models (matching the main agent loop) and omits it for reasoning models.
+func TestGenerateSummary_ThinkingInstruction(t *testing.T) {
+	makeCompactor := func(reasoning bool) (*Compactor, *map[string]any, *httptest.Server) {
+		var captured map[string]any
+		server := captureRequestServer(&captured)
+		model := llm.Model{ID: "m", ContextWindow: 200000, BaseURL: server.URL, API: "openai", Reasoning: reasoning}
+		c := NewCompactor(DefaultConfig(), model, "k", "sys", 0)
+		c.SetAgentLLMContext("BASE-SYS", "prefix", "high", nil)
+		return c, &captured, server
+	}
+
+	t.Run("non_reasoning_model_gets_thinking_instruction", func(t *testing.T) {
+		c, captured, server := makeCompactor(false)
+		defer server.Close()
+		_, _ = c.GenerateSummary([]agentctx.AgentMessage{agentctx.NewUserMessage("hi")})
+		msgs := (*captured)["messages"].([]any)
+		sysContent := msgs[0].(map[string]any)["content"].(string)
+		if !strings.Contains(sysContent, "Thinking level is high") {
+			t.Errorf("non-reasoning model should have thinking instruction, got %q", sysContent)
+		}
+	})
+
+	t.Run("reasoning_model_skips_thinking_instruction", func(t *testing.T) {
+		c, captured, server := makeCompactor(true)
+		defer server.Close()
+		_, _ = c.GenerateSummary([]agentctx.AgentMessage{agentctx.NewUserMessage("hi")})
+		msgs := (*captured)["messages"].([]any)
+		sysContent := msgs[0].(map[string]any)["content"].(string)
+		if sysContent != "BASE-SYS" {
+			t.Errorf("reasoning model should NOT have thinking instruction, got %q", sysContent)
+		}
+	})
+}

--- a/pkg/compact/compact_summary.go
+++ b/pkg/compact/compact_summary.go
@@ -10,6 +10,7 @@ import (
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/llm"
+	"github.com/tiancaiamao/ai/pkg/prompt"
 )
 
 // GenerateSummary generates a structured summary of messages using the LLM.
@@ -29,53 +30,89 @@ func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage
 		return "", fmt.Errorf("no messages to summarize")
 	}
 
-	projected := projectMessagesForSummary(messages)
-	if len(projected) == 0 {
+	// Filter agent-visible messages.
+	visible := make([]agentctx.AgentMessage, 0, len(messages))
+	for _, msg := range messages {
+		if msg.IsAgentVisible() {
+			visible = append(visible, msg)
+		}
+	}
+	if len(visible) == 0 {
 		if strings.TrimSpace(previousSummary) != "" {
 			return previousSummary, nil
 		}
 		return "", fmt.Errorf("no agent-visible messages to summarize")
 	}
 
-	conversationText := serializeConversation(projected)
-
-	// Guard against sending a conversation that exceeds the model's context
-	// window. For large sessions the serialized text can be many megabytes,
-	// which the summarization model cannot process. Truncate oldest messages
-	// until the conversation fits within ~40% of the model's context window
-	// (leaving room for the prompt, system prompt, and response).
-	const maxContextFraction = 0.4
+	// Truncation safeguard: if the visible messages exceed ~50% of the
+	// context window, drop the oldest ones to prevent the summary request
+	// from overflowing. This leaves room for the system prompt, prefix,
+	// instruction, and the summary response.
 	if c.contextWindow > 0 {
-		maxTokens := int(float64(c.contextWindow) * maxContextFraction)
-		// Each char is roughly 0.25 tokens, so maxBytes ≈ maxTokens * 4
-		maxChars := maxTokens * 4
-		if len(conversationText) > maxChars {
-			truncated := truncateConversationToCharBudget(projected, maxChars)
-			conversationText = serializeConversation(truncated)
-			slog.Info("[Compact] Truncated conversation for summarization",
-				"original_messages", len(projected),
-				"truncated_messages", len(truncated),
-				"original_chars", len(serializeConversation(projected)),
-				"truncated_chars", len(conversationText),
-				"context_window", c.contextWindow,
-				"max_chars", maxChars)
+		maxTokens := int(float64(c.contextWindow) * 0.5)
+		originalCount := len(visible)
+		for len(visible) > 2 && c.EstimateTokens(visible) > maxTokens {
+			visible = visible[1:]
+		}
+		if dropped := originalCount - len(visible); dropped > 0 {
+			slog.Info("[Compact] Truncated messages for summarization",
+				"original", originalCount, "remaining", len(visible),
+				"context_window", c.contextWindow, "max_tokens", maxTokens)
 		}
 	}
 
-	promptText := fmt.Sprintf("<conversation>\\n%s\\n</conversation>\\n\\n", conversationText)
-	basePrompt := summarizationPrompt
-	if previousSummary != "" {
-		promptText += fmt.Sprintf("<previous-summary>\\n%s\\n</previous-summary>\\n\\n", previousSummary)
-		basePrompt = updateSummarizationPrompt
+	// Build cache-friendly LLM messages. Instead of serializing the
+	// conversation into text under a dedicated system prompt, we reuse the
+	// main agent's system prompt and real message format. This makes the
+	// summarization request share a prefix with the main conversation
+	// (system prompt + context prefix + real messages), maximizing provider
+	// prefix-cache hits — only the trailing compact instruction is new.
+	var llmMessages []llm.LLMMessage
+	if c.messageConverter != nil {
+		llmMessages = c.messageConverter(visible)
+	} else {
+		llmMessages = convertAgentMessagesToLLM(visible)
 	}
-	promptText += basePrompt
 
-	llmMessages := []llm.LLMMessage{
-		{Role: "user", Content: promptText},
+	// Prepend the agent context prefix (skills + AGENTS.md) exactly like the
+	// main loop, so the message prefix matches the main conversation.
+	if c.agentContextPrefix != "" {
+		llmMessages = insertBeforeFirstUserMessage(llmMessages, llm.LLMMessage{
+			Role:    "user",
+			Content: c.agentContextPrefix,
+		})
+	}
+
+	// Append the summarization instruction as a trailing user message.
+	// The format requirements (formerly a dedicated system prompt) are moved
+	// here so the system prompt stays identical to the main conversation.
+	instruction := summarizationSystemPrompt + "\n\n" + summarizationPrompt
+	if previousSummary != "" {
+		instruction = summarizationSystemPrompt + "\n\n" +
+			"Update the existing summary with the conversation above. Preserve ALL mandatory sections.\n\n" +
+			"<previous-summary>\n" + previousSummary + "\n</previous-summary>"
+	}
+	llmMessages = append(llmMessages, llm.LLMMessage{
+		Role:    "user",
+		Content: instruction,
+	})
+
+	// Use the main agent's system prompt (identical to the main conversation)
+	// for cache reuse; fall back to the compact system prompt if not set.
+	systemPrompt := c.agentSystemPrompt
+	if systemPrompt == "" {
+		systemPrompt = summarizationSystemPrompt
+	} else if !c.model.Reasoning {
+		// Mirror the main agent loop (llm_stream.go): append the thinking
+		// instruction so the system prompt matches exactly, preserving the
+		// provider prefix cache from the first token.
+		if instruction := prompt.ThinkingInstruction(c.thinkingLevel); instruction != "" {
+			systemPrompt = systemPrompt + "\n\n" + instruction
+		}
 	}
 
 	llmCtx := llm.LLMContext{
-		SystemPrompt: summarizationSystemPrompt,
+		SystemPrompt: systemPrompt,
 		Messages:     llmMessages,
 	}
 
@@ -359,4 +396,86 @@ func projectMessagesForSummary(messages []agentctx.AgentMessage) []agentctx.Agen
 		projected = append(projected, copyMsg)
 	}
 	return projected
+}
+
+// convertAgentMessagesToLLM is a fallback message converter used when no
+// converter is injected via SetAgentLLMContext. Production code injects
+// agent.ConvertMessagesToLLM to guarantee byte-identical output with the main
+// conversation (required for prefix-cache hits). This fallback handles the
+// common cases (text, thinking, tool calls, tool results) but omits
+// sanitizeToolCallProtocol. This is acceptable because production code always
+// injects agent.ConvertMessagesToLLM (which includes sanitize) via
+// SetAgentLLMContext. This fallback is only used in tests and during the
+// brief window before initialization.
+func convertAgentMessagesToLLM(messages []agentctx.AgentMessage) []llm.LLMMessage {
+	llmMessages := make([]llm.LLMMessage, 0, len(messages))
+	for _, msg := range messages {
+		if !msg.IsAgentVisible() {
+			continue
+		}
+		role := msg.Role
+		if role == "toolResult" {
+			role = "tool"
+		}
+		llmMsg := llm.LLMMessage{Role: role}
+		for _, block := range msg.Content {
+			switch b := block.(type) {
+			case agentctx.TextContent:
+				llmMsg.Content = b.Text
+			case agentctx.ThinkingContent:
+				llmMsg.Thinking = b.Thinking
+			}
+		}
+		if msg.Role == "assistant" {
+			toolCalls := msg.ExtractToolCalls()
+			if len(toolCalls) > 0 {
+				llmMsg.ToolCalls = make([]llm.ToolCall, len(toolCalls))
+				for i, tc := range toolCalls {
+					argsJSON, _ := json.Marshal(tc.Arguments)
+					llmMsg.ToolCalls[i] = llm.ToolCall{
+						ID:   tc.ID,
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      tc.Name,
+							Arguments: string(argsJSON),
+						},
+					}
+				}
+			}
+		}
+		if msg.Role == "toolResult" {
+			llmMsg.ToolCallID = msg.ToolCallID
+			llmMsg.Content = msg.ExtractText()
+		}
+		llmMessages = append(llmMessages, llmMsg)
+	}
+	return llmMessages
+}
+
+// insertBeforeFirstUserMessage inserts msg immediately before the first
+// user-role message. Mirrors agent.insertBeforeFirstUserMessage so the
+// context prefix sits at the same position as in the main conversation,
+// keeping the prefix cache-friendly.
+func insertBeforeFirstUserMessage(messages []llm.LLMMessage, msg llm.LLMMessage) []llm.LLMMessage {
+	if len(messages) == 0 {
+		return []llm.LLMMessage{msg}
+	}
+	firstUserIdx := -1
+	for i, m := range messages {
+		if m.Role == "user" {
+			firstUserIdx = i
+			break
+		}
+	}
+	if firstUserIdx == -1 {
+		result := make([]llm.LLMMessage, 0, len(messages)+1)
+		result = append(result, msg)
+		result = append(result, messages...)
+		return result
+	}
+	result := make([]llm.LLMMessage, 0, len(messages)+1)
+	result = append(result, messages[:firstUserIdx]...)
+	result = append(result, msg)
+	result = append(result, messages[firstUserIdx:]...)
+	return result
 }

--- a/pkg/session/compaction.go
+++ b/pkg/session/compaction.go
@@ -67,7 +67,16 @@ func canCompactLocked(s *Session, compactor *compact.Compactor) bool {
 		}
 	}
 
-	boundaryStart := prevCompactionIndex + 1
+	// Include the previous compaction entry (if any) so its summary message
+	// is part of messagesToSummarize. This serves two purposes:
+	//  1. Cache: the message prefix matches buildSessionContext output (which
+	//     starts with the compaction summary), so the provider prefix cache hits.
+	//  2. Continuity: the LLM sees the previous summary and can update it
+	//     instead of generating a fresh one that loses earlier context.
+	boundaryStart := prevCompactionIndex
+	if boundaryStart < 0 {
+		boundaryStart = 0
+	}
 	refs := buildMessageRefs(path[boundaryStart:])
 	if len(refs) == 0 {
 		slog.Debug("[CanCompact] no message refs after compaction boundary",
@@ -119,7 +128,10 @@ func (s *Session) Compact(compactor *compact.Compactor) (*CompactionResult, erro
 		}
 	}
 
-	boundaryStart := prevCompactionIndex + 1
+	boundaryStart := prevCompactionIndex
+	if boundaryStart < 0 {
+		boundaryStart = 0
+	}
 	refs := buildMessageRefs(path[boundaryStart:])
 	if len(refs) == 0 {
 		return nil, ErrNothingToCompact


### PR DESCRIPTION
## Summary

Summary generation now reuses the main agent system prompt and real message format instead of a dedicated system prompt with serialized text. This makes summary requests share a prefix with the main conversation for **provider prefix-cache hits**.

Also fixes a `boundaryStart` bug where the previous compaction entry was excluded, breaking cache alignment and losing information on 2nd+ compaction.

## Changes

### Cache-friendly summary generation (`pkg/compact/`)
- **`SetAgentLLMContext`**: injects the main agent system prompt, context prefix, thinking level, and message converter into the compactor
- **`GenerateSummaryWithPrevious`**: rewritten to build `[agentSystemPrompt + thinkingInstruction, prefix_msg, real_messages..., compact_instruction]` — matching the main conversation prefix exactly
- **Thinking instruction**: mirrors the main agent loop by appending `prompt.ThinkingInstruction(thinkingLevel)` for non-reasoning models, ensuring the system prompt matches from the first token
- **Truncation safeguard**: drops oldest messages if estimated tokens exceed 50% of context window
- **Fallback `convertAgentMessagesToLLM`**: handles text/thinking/toolcall/toolresult without sanitizeToolCallProtocol (production injects the full converter)

### Compaction boundaryStart fix (`pkg/session/`)
- Changed `boundaryStart` from `prevCompactionIndex + 1` to `prevCompactionIndex` (with clamp for -1) in **both** `canCompactLocked` and `Compact`
- This includes the previous compaction summary in `messagesToSummarize`, fixing:
  1. **Cache**: message prefix now matches `buildSessionContext` output → prefix cache hits
  2. **Continuity**: LLM sees the previous summary and can incorporate it

### ContextManager disable condition (`cmd/ai/`)
- Changed from `agent.IsCacheMode(model.ID)` (model name match) to `contextWindow >= 200_000` (size threshold)
- Supports GLM-5.2 1M context without needing model-specific config
- Re-injects `SetAgentLLMContext` after model switch (new compactor was missing this)

## Test Coverage
- 9 new test functions in `compact_cache_test.go`:
  - `TestSetAgentLLMContext` — verifies all fields set correctly
  - `TestGenerateSummary_CacheFriendlyRequestFormat` — verifies system prompt, prefix, real messages, compact instruction
  - `TestGenerateSummary_ThinkingInstruction` — non-reasoning models get thinking instruction; reasoning models don't
  - `TestGenerateSummary_FallbackConverter` — works without injected converter
  - `TestInsertBeforeFirstUserMessage` — prefix insertion position
  - `TestGenerateSummary_AllRetriesExhausted` / `_NonRetryableErrorNotRetried` / `_ContextCancellationStopsRetry` — retry behavior

## Review
- Two rounds of automated review completed
- Found and fixed: `canCompactLocked`/`Compact` boundaryStart inconsistency, thinking instruction mismatch, missing truncation safeguard, model switch re-injection gap
