### PR TITLE
feat: reuse prefix cache in compaction via structured messages + agent context

### DIFF
--- a/cmd/ai/rpc_helpers.go
+++ b/cmd/ai/rpc_helpers.go
@@ -97,6 +97,7 @@ func (app *rpcApp) createBaseContext() *agentctx.AgentContext {
 		app.loopCfg.AgentContextPrefix = app.agentContextPrefix
 	}
 	ctx := agentctx.NewAgentContext(app.systemPrompt)
+	ctx.AgentContextPrefix = app.agentContextPrefix
 	for _, tool := range app.registry.All() {
 		ctx.AddTool(tool)
 	}

--- a/pkg/agent/conversion.go
+++ b/pkg/agent/conversion.go
@@ -3,8 +3,8 @@ package agent
 import (
 	"context"
 	"encoding/json"
+
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
-	"strings"
 
 	"github.com/tiancaiamao/ai/pkg/llm"
 	"github.com/tiancaiamao/ai/pkg/traceevent"
@@ -14,157 +14,14 @@ import (
 func ConvertMessagesToLLM(ctx context.Context, messages []agentctx.AgentMessage) []llm.LLMMessage {
 	span := traceevent.StartSpan(ctx, "ConvertMessagesToLLM", traceevent.CategoryEvent)
 	defer span.End()
-
-	llmMessages := make([]llm.LLMMessage, 0, len(messages))
-
-	for _, msg := range messages {
-		if !msg.IsAgentVisible() {
-			continue
-		}
-
-		role := msg.Role
-		if role == "toolResult" {
-			role = "tool"
-		}
-		llmMsg := llm.LLMMessage{
-			Role: role,
-		}
-
-		// Extract content and thinking
-		for _, block := range msg.Content {
-			switch b := block.(type) {
-			case agentctx.TextContent:
-				llmMsg.Content = b.Text
-			case agentctx.ImageContent:
-				// For multimodal, use ContentParts
-				llmMsg.ContentParts = append(llmMsg.ContentParts, llm.ContentPart{
-					Type: "image_url",
-					ImageURL: &struct {
-						URL string `json:"url"`
-					}{
-						URL: b.Data,
-					},
-				})
-			case agentctx.ThinkingContent:
-				// Preserve reasoning content for providers like DeepSeek
-				// that require it to be passed back (especially for tool-call rounds).
-				llmMsg.Thinking = b.Thinking
-			}
-		}
-
-		// Extract tool calls (from assistant messages)
-		if msg.Role == "assistant" {
-			toolCalls := msg.ExtractToolCalls()
-			if len(toolCalls) > 0 {
-				llmMsg.ToolCalls = make([]llm.ToolCall, len(toolCalls))
-				for i, tc := range toolCalls {
-					// Convert arguments map to JSON string
-					argsJSON, _ := json.Marshal(tc.Arguments)
-					llmMsg.ToolCalls[i] = llm.ToolCall{
-						ID:   tc.ID,
-						Type: "function",
-						Function: llm.FunctionCall{
-							Name:      tc.Name,
-							Arguments: string(argsJSON),
-						},
-					}
-				}
-			}
-		}
-
-		// agentctx.Tool result message
-		if msg.Role == "toolResult" {
-			llmMsg.ToolCallID = msg.ToolCallID
-			llmMsg.Content = msg.ExtractText()
-		}
-
-		llmMessages = append(llmMessages, llmMsg)
-	}
-
-	return sanitizeToolCallProtocol(llmMessages)
+	return agentctx.ConvertMessagesToLLM(messages)
 }
 
-// sanitizeToolCallProtocol ensures generated messages follow strict assistant/tool pairing rules:
-// - a tool message must follow a pending assistant tool call
-// - unresolved tool calls are stripped before appending non-tool messages
-func sanitizeToolCallProtocol(messages []llm.LLMMessage) []llm.LLMMessage {
-	if len(messages) == 0 {
-		return messages
-	}
-
-	sanitized := make([]llm.LLMMessage, 0, len(messages))
-	pendingToolCalls := map[string]struct{}{}
-
-	clearPending := func() {
-		if len(pendingToolCalls) == 0 {
-			return
-		}
-		sanitized = stripPendingToolCallsFromLastAssistant(sanitized, pendingToolCalls)
-		pendingToolCalls = map[string]struct{}{}
-	}
-
-	for _, msg := range messages {
-		switch msg.Role {
-		case "assistant":
-			clearPending()
-			sanitized = append(sanitized, msg)
-			for _, toolCall := range msg.ToolCalls {
-				if strings.TrimSpace(toolCall.ID) == "" {
-					continue
-				}
-				pendingToolCalls[toolCall.ID] = struct{}{}
-			}
-		case "tool":
-			toolCallID := strings.TrimSpace(msg.ToolCallID)
-			if toolCallID == "" || len(pendingToolCalls) == 0 {
-				continue
-			}
-			if _, ok := pendingToolCalls[toolCallID]; !ok {
-				continue
-			}
-			sanitized = append(sanitized, msg)
-			delete(pendingToolCalls, toolCallID)
-		default:
-			clearPending()
-			sanitized = append(sanitized, msg)
-		}
-	}
-
-	clearPending()
-	return sanitized
-}
-
-func stripPendingToolCallsFromLastAssistant(messages []llm.LLMMessage, pending map[string]struct{}) []llm.LLMMessage {
-	if len(messages) == 0 || len(pending) == 0 {
-		return messages
-	}
-
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role != "assistant" {
-			continue
-		}
-		if len(messages[i].ToolCalls) == 0 {
-			return messages
-		}
-
-		filteredToolCalls := make([]llm.ToolCall, 0, len(messages[i].ToolCalls))
-		for _, toolCall := range messages[i].ToolCalls {
-			if _, drop := pending[toolCall.ID]; drop {
-				continue
-			}
-			filteredToolCalls = append(filteredToolCalls, toolCall)
-		}
-		messages[i].ToolCalls = filteredToolCalls
-
-		if len(messages[i].ToolCalls) == 0 &&
-			strings.TrimSpace(messages[i].Content) == "" &&
-			len(messages[i].ContentParts) == 0 {
-			return append(messages[:i], messages[i+1:]...)
-		}
-		return messages
-	}
-
-	return messages
+// ConvertToolsToLLM converts agent tools to LLM tools.
+func ConvertToolsToLLM(ctx context.Context, tools []agentctx.Tool) []llm.LLMTool {
+	span := traceevent.StartSpan(ctx, "ConvertToolsToLLM", traceevent.CategoryEvent)
+	defer span.End()
+	return agentctx.ConvertToolsToLLM(tools)
 }
 
 // ConvertLLMMessageToAgent converts an LLM message to an agent message.
@@ -207,34 +64,4 @@ func ConvertLLMMessageToAgent(llmMsg llm.LLMMessage) agentctx.AgentMessage {
 	}
 
 	return agentMsg
-}
-
-// ConvertToolsToLLM converts agent tools to LLM tools.
-func ConvertToolsToLLM(ctx context.Context, tools []agentctx.Tool) []llm.LLMTool {
-	span := traceevent.StartSpan(ctx, "ConvertToolsToLLM", traceevent.CategoryEvent)
-	defer span.End()
-
-	llmTools := make([]llm.LLMTool, 0, len(tools))
-	seen := make(map[string]struct{}, len(tools))
-
-	for _, tool := range tools {
-		if tool == nil {
-			continue
-		}
-		name := tool.Name()
-		if _, ok := seen[name]; ok {
-			continue
-		}
-		seen[name] = struct{}{}
-		llmTools = append(llmTools, llm.LLMTool{
-			Type: "function",
-			Function: llm.ToolFunction{
-				Name:        name,
-				Description: tool.Description(),
-				Parameters:  tool.Parameters(),
-			},
-		})
-	}
-
-	return llmTools
 }

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -383,7 +383,7 @@ func (c *Compactor) Compact(ctx *agentctx.AgentContext) (*agentctx.CompactionRes
 	}
 
 	// Generate summary of old messages (with previous summary for incremental update)
-	summary, err := c.GenerateSummaryWithPrevious(oldMessages, ctx.LastCompactionSummary)
+	summary, err := c.GenerateSummaryWithPrevious(oldMessages, ctx.SystemPrompt, ctx.AgentContextPrefix, ctx.Tools, ctx.LastCompactionSummary)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate summary: %w", err)
 	}

--- a/pkg/compact/compact_coverage_test.go
+++ b/pkg/compact/compact_coverage_test.go
@@ -29,28 +29,6 @@ func TestEstimateStringTokens(t *testing.T) {
 	}
 }
 
-func TestTrimTextWithTail(t *testing.T) {
-	if got := trimTextWithTail("", 10); got != "" {
-		t.Errorf("empty input should return empty, got %q", got)
-	}
-	short := "hello"
-	if got := trimTextWithTail(short, 100); got != short {
-		t.Errorf("input under limit should return unchanged, got %q", got)
-	}
-	if got := trimTextWithTail("xyz", 0); got != "xyz" {
-		t.Errorf("limit=0 should return input, got %q", got)
-	}
-	// Long input — verify head + tail + truncation marker structure
-	long := strings.Repeat("a", 300)
-	got := trimTextWithTail(long, 30)
-	if !strings.Contains(got, "(truncated)") {
-		t.Errorf("expected truncation marker, got %q", got)
-	}
-	if !strings.HasPrefix(got, strings.Repeat("a", 20)) {
-		t.Errorf("expected head to be first 2/3 of limit, got %q", got[:20])
-	}
-}
-
 func TestExtractText(t *testing.T) {
 	// With content blocks
 	msg := agentctx.AgentMessage{
@@ -304,138 +282,6 @@ func TestEstimateMessageTokens_Variants(t *testing.T) {
 	}
 }
 
-// --- serialization helpers ---
-
-func TestSerializeConversation_AllRoles(t *testing.T) {
-	messages := []agentctx.AgentMessage{
-		agentctx.NewUserMessage("user-text"),
-	}
-
-	// Assistant with text, thinking, tool call
-	a := agentctx.NewAssistantMessage()
-	a.Content = []agentctx.ContentBlock{
-		agentctx.ThinkingContent{Type: "thinking", Thinking: "I should think"},
-		agentctx.TextContent{Type: "text", Text: "answer"},
-		agentctx.ToolCallContent{Type: "toolCall", ID: "c1", Name: "bash", Arguments: map[string]any{"cmd": "ls"}},
-	}
-	messages = append(messages, a)
-
-	// Tool result with name
-	messages = append(messages, agentctx.NewToolResultMessage("c1", "bash",
-		[]agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "result"}}, false))
-
-	// Tool result without name
-	tr := agentctx.NewToolResultMessage("c2", "",
-		[]agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "no name"}}, false)
-	messages = append(messages, tr)
-
-	out := serializeConversation(messages)
-	for _, want := range []string{"[User]: user-text", "[Assistant thinking]", "[Assistant]: answer", "[Assistant tool calls]", "[Tool result bash]: result", "[Tool result]: no name"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("expected %q in output, got:\n%s", want, out)
-		}
-	}
-
-	// Tool call with no arguments should render with empty parens
-	a2 := agentctx.NewAssistantMessage()
-	a2.Content = []agentctx.ContentBlock{
-		agentctx.ToolCallContent{Type: "toolCall", ID: "c3", Name: "ping"},
-	}
-	out2 := serializeConversation([]agentctx.AgentMessage{a2})
-	if !strings.Contains(out2, "ping()") {
-		t.Errorf("expected empty args rendered as ping(), got:\n%s", out2)
-	}
-}
-
-func TestSerializeConversation_EmptyAndInvisible(t *testing.T) {
-	if serializeConversation(nil) != "" {
-		t.Error("expected empty output for nil input")
-	}
-
-	// Agent-invisible messages are skipped
-	visible := agentctx.NewUserMessage("visible")
-	invisible := agentctx.NewUserMessage("hidden").WithVisibility(false, true)
-	out := serializeConversation([]agentctx.AgentMessage{visible, invisible})
-	if !strings.Contains(out, "visible") {
-		t.Errorf("expected visible text, got %q", out)
-	}
-	if strings.Contains(out, "hidden") {
-		t.Errorf("expected invisible to be skipped, got %q", out)
-	}
-}
-
-func TestSerializeSingleMessage(t *testing.T) {
-	if got := serializeSingleMessage(agentctx.AgentMessage{}); got != "" {
-		t.Errorf("expected empty for unknown role, got %q", got)
-	}
-	if got := serializeSingleMessage(agentctx.NewUserMessage("hi")); !strings.Contains(got, "[User]: hi") {
-		t.Errorf("expected user prefix, got %q", got)
-	}
-	a := agentctx.NewAssistantMessage()
-	a.Content = []agentctx.ContentBlock{
-		agentctx.TextContent{Type: "text", Text: "ok"},
-		agentctx.ToolCallContent{Type: "toolCall", ID: "x", Name: "noArgs"},
-	}
-	if got := serializeSingleMessage(a); !strings.Contains(got, "[Assistant]:") || !strings.Contains(got, "noArgs()") {
-		t.Errorf("unexpected assistant serialization: %q", got)
-	}
-	// Tool result with no name → no suffix
-	tr := agentctx.NewToolResultMessage("c", "", []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "data"}}, false)
-	if got := serializeSingleMessage(tr); !strings.Contains(got, "[Tool result]: data") {
-		t.Errorf("expected plain tool result prefix, got %q", got)
-	}
-	// Tool result with name
-	tr2 := agentctx.NewToolResultMessage("c", "grep", []agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: "match"}}, false)
-	if got := serializeSingleMessage(tr2); !strings.Contains(got, "[Tool result grep]: match") {
-		t.Errorf("expected named tool result, got %q", got)
-	}
-}
-
-func TestProjectMessagesForSummary(t *testing.T) {
-	messages := []agentctx.AgentMessage{
-		agentctx.NewUserMessage("u"),
-		agentctx.NewAssistantMessage(),
-		agentctx.NewToolResultMessage("c1", "bash",
-			[]agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: strings.Repeat("y", 5000)}}, false),
-		agentctx.NewToolResultMessage("c2", "grep",
-			[]agentctx.ContentBlock{agentctx.TextContent{Type: "text", Text: ""}}, false),
-	}
-
-	out := projectMessagesForSummary(messages)
-	if len(out) != 4 {
-		t.Fatalf("expected 4 projected messages, got %d", len(out))
-	}
-
-	// Tool result text should be truncated to ≤1800 runes + tail marker
-	trText := ""
-	for _, blk := range out[2].Content {
-		if tc, ok := blk.(agentctx.TextContent); ok {
-			trText = tc.Text
-		}
-	}
-	if !strings.Contains(trText, "(truncated)") {
-		t.Errorf("expected large tool result to be truncated, got %d chars", len(trText))
-	}
-
-	// Empty tool result text → "(empty output)"
-	emptyText := ""
-	for _, blk := range out[3].Content {
-		if tc, ok := blk.(agentctx.TextContent); ok {
-			emptyText = tc.Text
-		}
-	}
-	if emptyText != "(empty output)" {
-		t.Errorf("expected '(empty output)', got %q", emptyText)
-	}
-
-	// Agent-invisible messages are skipped
-	invisible := agentctx.NewUserMessage("hidden").WithVisibility(false, true)
-	out2 := projectMessagesForSummary([]agentctx.AgentMessage{invisible})
-	if len(out2) != 0 {
-		t.Errorf("expected 0 projected messages for invisible, got %d", len(out2))
-	}
-}
-
 // --- splitMessagesByTokenBudget edge cases ---
 
 func TestSplitMessagesByTokenBudget_EdgeCases(t *testing.T) {
@@ -480,20 +326,6 @@ func TestSplitMessagesByTokenBudget_EdgeCases(t *testing.T) {
 	}
 	if !foundSummary {
 		t.Errorf("expected compaction summary in recent, got old=%d recent=%d", len(old), len(recent))
-	}
-}
-
-// --- truncateConversationToCharBudget edge cases ---
-
-func TestTruncateConversationToCharBudget_EdgeCases(t *testing.T) {
-	if got := truncateConversationToCharBudget(nil, 100); got != nil {
-		t.Errorf("expected nil for nil input, got %v", got)
-	}
-	if got := truncateConversationToCharBudget([]agentctx.AgentMessage{agentctx.NewUserMessage("x")}, 0); len(got) != 1 {
-		t.Errorf("budget=0: expected input unchanged, got %d", len(got))
-	}
-	if got := truncateConversationToCharBudget([]agentctx.AgentMessage{agentctx.NewUserMessage("x")}, -1); len(got) != 1 {
-		t.Errorf("budget<0: expected input unchanged, got %d", len(got))
 	}
 }
 
@@ -550,11 +382,11 @@ func TestGenerateSummaryWithPrevious_NoVisibleMessages(t *testing.T) {
 	// Agent-invisible messages only → no agent-visible
 	invisible := agentctx.NewUserMessage("hidden").WithVisibility(false, true)
 	// With empty previous summary → error
-	if _, err := c.GenerateSummaryWithPrevious([]agentctx.AgentMessage{invisible}, ""); err == nil {
+	if _, err := c.GenerateSummaryWithPrevious([]agentctx.AgentMessage{invisible}, "", "", nil, ""); err == nil {
 		t.Error("expected error when no agent-visible messages and no previous summary")
 	}
 	// With non-empty previous summary → returned as-is
-	got, err := c.GenerateSummaryWithPrevious([]agentctx.AgentMessage{invisible}, "prior")
+	got, err := c.GenerateSummaryWithPrevious([]agentctx.AgentMessage{invisible}, "", "", nil, "prior")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -587,7 +419,7 @@ func TestGenerateSummaryWithPrevious_LLMSuccessAndFailures(t *testing.T) {
 	model := llm.Model{ID: "m", ContextWindow: 200000, BaseURL: server.URL, API: "openai"}
 	c := NewCompactor(DefaultConfig(), model, "k", "sys", 0)
 
-	got, err := c.GenerateSummaryWithPrevious([]agentctx.AgentMessage{agentctx.NewUserMessage("hi")}, "")
+	got, err := c.GenerateSummaryWithPrevious([]agentctx.AgentMessage{agentctx.NewUserMessage("hi")}, "", "", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -606,7 +438,7 @@ func TestGenerateSummaryWithPrevious_LLMSuccessAndFailures(t *testing.T) {
 	}))
 	defer emptyServer.Close()
 	c2 := NewCompactor(DefaultConfig(), llm.Model{ID: "m", ContextWindow: 200000, BaseURL: emptyServer.URL, API: "openai"}, "k", "sys", 0)
-	_, err = c2.GenerateSummaryWithPrevious([]agentctx.AgentMessage{agentctx.NewUserMessage("hi")}, "")
+	_, err = c2.GenerateSummaryWithPrevious([]agentctx.AgentMessage{agentctx.NewUserMessage("hi")}, "", "", nil, "")
 	if err == nil {
 		t.Error("expected error for empty summary")
 	}
@@ -620,7 +452,7 @@ func TestGenerateSummaryWithPrevious_LLMSuccessAndFailures(t *testing.T) {
 	}))
 	defer authServer.Close()
 	c3 := NewCompactor(DefaultConfig(), llm.Model{ID: "m", ContextWindow: 200000, BaseURL: authServer.URL, API: "openai"}, "k", "sys", 0)
-	_, err = c3.GenerateSummaryWithPrevious([]agentctx.AgentMessage{agentctx.NewUserMessage("hi")}, "")
+	_, err = c3.GenerateSummaryWithPrevious([]agentctx.AgentMessage{agentctx.NewUserMessage("hi")}, "", "", nil, "")
 	if err == nil {
 		t.Error("expected error from 401")
 	}

--- a/pkg/compact/compact_summary.go
+++ b/pkg/compact/compact_summary.go
@@ -35,16 +35,11 @@ func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage
 		return "", fmt.Errorf("no messages to summarize")
 	}
 
-	// Guard: cap old messages to fit within ~40% of context window, leaving
-	// room for system prompt, tools, instruction, and the summary response.
-	// For large sessions oldMessages can be very large; without this guard
-	// the request exceeds the model's context window and compaction fails.
-	if c.contextWindow > 0 {
-		messages = c.truncateForSummary(messages)
-	}
-
 	// Convert old messages to the same structured LLMMessage format used by
-	// normal agent turns — this is what makes the prefix cache hit work.
+	// normal agent turns. oldMessages is a strict prefix of the conversation
+	// (split off by splitMessagesByTokenBudget in Compact), so it already fits
+	// within the context window — no further truncation needed or wanted:
+	// truncating here would break prefix-cache alignment.
 	llmMessages := agentctx.ConvertMessagesToLLM(messages)
 	if len(llmMessages) == 0 {
 		if strings.TrimSpace(previousSummary) != "" {
@@ -53,15 +48,15 @@ func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage
 		return "", fmt.Errorf("no agent-visible messages to summarize")
 	}
 
-	// Inject contextPrefix (skills + AGENTS.md) before the first user message,
-	// mirroring insertBeforeFirstUserMessage in the agent loop.
-	// This must match the agent loop's message structure exactly for prefix
-	// cache to hit on the [contextPrefix + old messages] segment.
+	// Prepend contextPrefix (skills + AGENTS.md) as the first message (after
+	// system). oldMessages starts with the conversation's first user message
+	// (it's a strict prefix), so placing the prefix at [0] mirrors the agent
+	// loop's structure exactly: [system, prefix, real_first_user, ...].
 	if strings.TrimSpace(contextPrefix) != "" {
-		llmMessages = agentctx.InsertBeforeFirstUserMessage(llmMessages, llm.LLMMessage{
+		llmMessages = append([]llm.LLMMessage{{
 			Role:    "user",
 			Content: contextPrefix,
-		})
+		}}, llmMessages...)
 	}
 
 	// Build the summarisation instruction as a trailing user message.
@@ -196,41 +191,4 @@ func splitMessagesByTokenBudget(
 		return messages[:len(messages)-1], messages[len(messages)-1:]
 	}
 	return messages[:start], messages[start:]
-}
-
-// truncateForSummary drops oldest messages until the remaining fit within
-// ~40% of the model's context window. This prevents oversized requests
-// that would exceed the context window and fail compaction.
-func (c *Compactor) truncateForSummary(messages []agentctx.AgentMessage) []agentctx.AgentMessage {
-	const maxContextFraction = 0.4
-	maxTokens := int(float64(c.contextWindow) * maxContextFraction)
-	if maxTokens <= 0 {
-		return messages
-	}
-
-	// Quick check: sum token estimates across all messages.
-	totalTokens := 0
-	for _, msg := range messages {
-		totalTokens += estimateMessageTokens(msg)
-	}
-	if totalTokens <= maxTokens {
-		return messages
-	}
-
-	// Drop oldest messages to fit within budget. splitMessagesByTokenBudget
-	// walks from the newest backwards, so recent = the suffix that fits.
-	dropped, kept := splitMessagesByTokenBudget(messages, maxTokens)
-	if len(dropped) > 0 {
-		slog.Info("[Compact] Truncated old messages for summary",
-			"dropped", len(dropped), "kept", len(kept),
-			"total_tokens", totalTokens, "max_tokens", maxTokens)
-	}
-
-	// Fix tool_call/tool_result pairing that the split may have broken.
-	if c.config.GracePeriod > 0 {
-		kept = c.ensureToolCallPairingWithGrace(dropped, kept)
-	} else {
-		kept = ensureToolCallPairing(dropped, kept)
-	}
-	return kept
 }

--- a/pkg/compact/compact_summary.go
+++ b/pkg/compact/compact_summary.go
@@ -2,7 +2,6 @@ package compact
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -14,69 +13,73 @@ import (
 
 // GenerateSummary generates a structured summary of messages using the LLM.
 func (c *Compactor) GenerateSummary(messages []agentctx.AgentMessage) (string, error) {
-	return c.GenerateSummaryWithPrevious(messages, "")
+	return c.GenerateSummaryWithPrevious(messages, c.systemPrompt, "", nil, "")
 }
 
-// GenerateSummaryWithPrevious generates a structured summary, optionally updating a previous summary.
-// It includes retry logic for transient LLM errors and a total timeout to prevent
-// the compaction path from hanging indefinitely on network failures.
-
-// GenerateSummaryWithPrevious generates a structured summary, optionally updating a previous summary.
-// It includes retry logic for transient LLM errors and a total timeout to prevent
-// the compaction path from hanging indefinitely on network failures.
-func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage, previousSummary string) (string, error) {
+// GenerateSummaryWithPrevious generates a structured summary, optionally
+// updating a previous summary.
+//
+// To maximise prompt-cache reuse, the request mirrors a normal agent turn:
+//
+//	SystemPrompt: systemPrompt              (cached)
+//	Tools:        agent tools               (cached)
+//	Messages:     [contextPrefix] + old messages + summarisation instruction
+//
+// The contextPrefix (skills + AGENTS.md) is injected as a user message before
+// the first old message, exactly like the agent loop does. The old messages
+// are a prefix of the full conversation, so the entire prefix
+// [system_prompt + tools + contextPrefix + old_messages] is served from cache.
+// Only the trailing summarisation instruction is new.
+func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage, systemPrompt string, contextPrefix string, tools []agentctx.Tool, previousSummary string) (string, error) {
 	if len(messages) == 0 {
 		return "", fmt.Errorf("no messages to summarize")
 	}
 
-	projected := projectMessagesForSummary(messages)
-	if len(projected) == 0 {
+	// Guard: cap old messages to fit within ~40% of context window, leaving
+	// room for system prompt, tools, instruction, and the summary response.
+	// For large sessions oldMessages can be very large; without this guard
+	// the request exceeds the model's context window and compaction fails.
+	if c.contextWindow > 0 {
+		messages = c.truncateForSummary(messages)
+	}
+
+	// Convert old messages to the same structured LLMMessage format used by
+	// normal agent turns — this is what makes the prefix cache hit work.
+	llmMessages := agentctx.ConvertMessagesToLLM(messages)
+	if len(llmMessages) == 0 {
 		if strings.TrimSpace(previousSummary) != "" {
 			return previousSummary, nil
 		}
 		return "", fmt.Errorf("no agent-visible messages to summarize")
 	}
 
-	conversationText := serializeConversation(projected)
-
-	// Guard against sending a conversation that exceeds the model's context
-	// window. For large sessions the serialized text can be many megabytes,
-	// which the summarization model cannot process. Truncate oldest messages
-	// until the conversation fits within ~40% of the model's context window
-	// (leaving room for the prompt, system prompt, and response).
-	const maxContextFraction = 0.4
-	if c.contextWindow > 0 {
-		maxTokens := int(float64(c.contextWindow) * maxContextFraction)
-		// Each char is roughly 0.25 tokens, so maxBytes ≈ maxTokens * 4
-		maxChars := maxTokens * 4
-		if len(conversationText) > maxChars {
-			truncated := truncateConversationToCharBudget(projected, maxChars)
-			conversationText = serializeConversation(truncated)
-			slog.Info("[Compact] Truncated conversation for summarization",
-				"original_messages", len(projected),
-				"truncated_messages", len(truncated),
-				"original_chars", len(serializeConversation(projected)),
-				"truncated_chars", len(conversationText),
-				"context_window", c.contextWindow,
-				"max_chars", maxChars)
-		}
+	// Inject contextPrefix (skills + AGENTS.md) before the first user message,
+	// mirroring insertBeforeFirstUserMessage in the agent loop.
+	// This must match the agent loop's message structure exactly for prefix
+	// cache to hit on the [contextPrefix + old messages] segment.
+	if strings.TrimSpace(contextPrefix) != "" {
+		llmMessages = agentctx.InsertBeforeFirstUserMessage(llmMessages, llm.LLMMessage{
+			Role:    "user",
+			Content: contextPrefix,
+		})
 	}
 
-	promptText := fmt.Sprintf("<conversation>\\n%s\\n</conversation>\\n\\n", conversationText)
-	basePrompt := summarizationPrompt
+	// Build the summarisation instruction as a trailing user message.
+	// Everything before this point is identical to a normal agent request,
+	// so it is served from the provider's prompt cache.
+	var instruction string
 	if previousSummary != "" {
-		promptText += fmt.Sprintf("<previous-summary>\\n%s\\n</previous-summary>\\n\\n", previousSummary)
-		basePrompt = updateSummarizationPrompt
+		instruction = summarizationSystemPrompt + "\n\n" +
+			fmt.Sprintf(updateSummarizationPrompt, previousSummary, "(see conversation messages above)")
+	} else {
+		instruction = summarizationSystemPrompt + "\n\n" + summarizationPrompt
 	}
-	promptText += basePrompt
-
-	llmMessages := []llm.LLMMessage{
-		{Role: "user", Content: promptText},
-	}
+	llmMessages = append(llmMessages, llm.LLMMessage{Role: "user", Content: instruction})
 
 	llmCtx := llm.LLMContext{
-		SystemPrompt: summarizationSystemPrompt,
+		SystemPrompt: systemPrompt,
 		Messages:     llmMessages,
+		Tools:        agentctx.ConvertToolsToLLM(tools),
 	}
 
 	const maxRetries = 3
@@ -85,7 +88,6 @@ func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage
 	var lastErr error
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		// Use a bounded context with timeout instead of context.Background().
 		ctx, cancel := context.WithTimeout(context.Background(), totalTimeout)
 
 		llmStream := llm.StreamLLM(ctx, c.model, llmCtx, c.apiKey, chunkTimeout)
@@ -135,8 +137,6 @@ func (c *Compactor) GenerateSummaryWithPrevious(messages []agentctx.AgentMessage
 
 	return "", fmt.Errorf("failed to generate summary after %d retries: %w", maxRetries, lastErr)
 }
-
-// ContextWindow returns the configured model context window.
 
 func splitMessagesByTokenBudget(
 	messages []agentctx.AgentMessage,
@@ -198,165 +198,39 @@ func splitMessagesByTokenBudget(
 	return messages[:start], messages[start:]
 }
 
-func serializeConversation(messages []agentctx.AgentMessage) string {
-	parts := make([]string, 0, len(messages))
-	for _, msg := range messages {
-		if !msg.IsAgentVisible() {
-			continue
-		}
-
-		switch msg.Role {
-		case "user":
-			if text := msg.ExtractText(); text != "" {
-				parts = append(parts, "[User]: "+text)
-			}
-		case "assistant":
-			textParts := make([]string, 0)
-			thinkingParts := make([]string, 0)
-			toolCalls := make([]string, 0)
-			for _, block := range msg.Content {
-				switch b := block.(type) {
-				case agentctx.TextContent:
-					if b.Text != "" {
-						textParts = append(textParts, b.Text)
-					}
-				case agentctx.ThinkingContent:
-					if b.Thinking != "" {
-						thinkingParts = append(thinkingParts, b.Thinking)
-					}
-				case agentctx.ToolCallContent:
-					args := ""
-					if b.Arguments != nil {
-						if raw, err := json.Marshal(b.Arguments); err == nil {
-							args = string(raw)
-						}
-					}
-					if args != "" {
-						toolCalls = append(toolCalls, fmt.Sprintf("%s(%s)", b.Name, args))
-					} else {
-						toolCalls = append(toolCalls, fmt.Sprintf("%s()", b.Name))
-					}
-				}
-			}
-			if len(thinkingParts) > 0 {
-				parts = append(parts, "[Assistant thinking]: "+strings.Join(thinkingParts, "\n"))
-			}
-			if len(textParts) > 0 {
-				parts = append(parts, "[Assistant]: "+strings.Join(textParts, "\n"))
-			}
-			if len(toolCalls) > 0 {
-				parts = append(parts, "[Assistant tool calls]: "+strings.Join(toolCalls, "; "))
-			}
-		case "toolResult":
-			if text := msg.ExtractText(); text != "" {
-				toolName := strings.TrimSpace(msg.ToolName)
-				if toolName == "" {
-					parts = append(parts, "[Tool result]: "+text)
-				} else {
-					parts = append(parts, "[Tool result "+toolName+"]: "+text)
-				}
-			}
-		}
-	}
-	return strings.Join(parts, "\n\n")
-}
-
-// truncateConversationToCharBudget keeps the most recent messages whose
-// serialized text fits within charBudget. It drops oldest messages first.
-
-// truncateConversationToCharBudget keeps the most recent messages whose
-// serialized text fits within charBudget. It drops oldest messages first.
-func truncateConversationToCharBudget(messages []agentctx.AgentMessage, charBudget int) []agentctx.AgentMessage {
-	if len(messages) == 0 || charBudget <= 0 {
+// truncateForSummary drops oldest messages until the remaining fit within
+// ~40% of the model's context window. This prevents oversized requests
+// that would exceed the context window and fail compaction.
+func (c *Compactor) truncateForSummary(messages []agentctx.AgentMessage) []agentctx.AgentMessage {
+	const maxContextFraction = 0.4
+	maxTokens := int(float64(c.contextWindow) * maxContextFraction)
+	if maxTokens <= 0 {
 		return messages
 	}
 
-	// Walk from the end backwards, accumulating size until we exceed the budget.
-	totalChars := 0
-	cutoff := len(messages)
-	for i := len(messages) - 1; i >= 0; i-- {
-		msgText := serializeSingleMessage(messages[i])
-		totalChars += len(msgText)
-		if totalChars > charBudget {
-			cutoff = i + 1
-			break
-		}
+	// Quick check: sum token estimates across all messages.
+	totalTokens := 0
+	for _, msg := range messages {
+		totalTokens += estimateMessageTokens(msg)
 	}
-
-	if cutoff >= len(messages) {
+	if totalTokens <= maxTokens {
 		return messages
 	}
-	return messages[cutoff:]
-}
 
-// serializeSingleMessage returns the serialized text of a single message.
-
-// serializeSingleMessage returns the serialized text of a single message.
-func serializeSingleMessage(msg agentctx.AgentMessage) string {
-	switch msg.Role {
-	case "user":
-		if text := msg.ExtractText(); text != "" {
-			return "[User]: " + text
-		}
-	case "assistant":
-		parts := make([]string, 0)
-		for _, block := range msg.Content {
-			switch b := block.(type) {
-			case agentctx.TextContent:
-				if b.Text != "" {
-					parts = append(parts, b.Text)
-				}
-			case agentctx.ToolCallContent:
-				args := ""
-				if b.Arguments != nil {
-					if raw, err := json.Marshal(b.Arguments); err == nil {
-						args = string(raw)
-					}
-				}
-				if args != "" {
-					parts = append(parts, fmt.Sprintf("%s(%s)", b.Name, args))
-				} else {
-					parts = append(parts, fmt.Sprintf("%s()", b.Name))
-				}
-			}
-		}
-		if len(parts) > 0 {
-			return "[Assistant]: " + strings.Join(parts, "\n")
-		}
-	case "toolResult":
-		if text := msg.ExtractText(); text != "" {
-			toolName := strings.TrimSpace(msg.ToolName)
-			if toolName == "" {
-				return "[Tool result]: " + text
-			}
-			return "[Tool result " + toolName + "]: " + text
-		}
+	// Drop oldest messages to fit within budget. splitMessagesByTokenBudget
+	// walks from the newest backwards, so recent = the suffix that fits.
+	dropped, kept := splitMessagesByTokenBudget(messages, maxTokens)
+	if len(dropped) > 0 {
+		slog.Info("[Compact] Truncated old messages for summary",
+			"dropped", len(dropped), "kept", len(kept),
+			"total_tokens", totalTokens, "max_tokens", maxTokens)
 	}
-	return ""
-}
 
-func projectMessagesForSummary(messages []agentctx.AgentMessage) []agentctx.AgentMessage {
-	projected := make([]agentctx.AgentMessage, 0, len(messages))
-	for _, msg := range messages {
-		if !msg.IsAgentVisible() {
-			continue
-		}
-
-		if msg.Role != "toolResult" {
-			projected = append(projected, msg)
-			continue
-		}
-
-		copyMsg := msg
-		toolText := strings.TrimSpace(msg.ExtractText())
-		if toolText == "" {
-			toolText = "(empty output)"
-		}
-		toolText = trimTextWithTail(toolText, 1800)
-		copyMsg.Content = []agentctx.ContentBlock{
-			agentctx.TextContent{Type: "text", Text: toolText},
-		}
-		projected = append(projected, copyMsg)
+	// Fix tool_call/tool_result pairing that the split may have broken.
+	if c.config.GracePeriod > 0 {
+		kept = c.ensureToolCallPairingWithGrace(dropped, kept)
+	} else {
+		kept = ensureToolCallPairing(dropped, kept)
 	}
-	return projected
+	return kept
 }

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -145,44 +145,6 @@ func TestSplitMessagesByTokenBudget(t *testing.T) {
 		t.Errorf("Unexpected recent messages order")
 	}
 }
-func TestTruncateConversationToCharBudget(t *testing.T) {
-	// Create messages with known text sizes
-	messages := []agentctx.AgentMessage{
-		agentctx.NewUserMessage(strings.Repeat("a", 1000)), // 1000+ chars
-		agentctx.NewUserMessage(strings.Repeat("b", 1000)), // 1000+ chars
-		agentctx.NewUserMessage(strings.Repeat("c", 1000)), // 1000+ chars
-		agentctx.NewUserMessage(strings.Repeat("d", 1000)), // 1000+ chars
-		agentctx.NewUserMessage(strings.Repeat("e", 500)),  // 500+ chars
-	}
-
-	// Budget for ~2 messages (2000 chars)
-	truncated := truncateConversationToCharBudget(messages, 2500)
-	if len(truncated) >= len(messages) {
-		t.Fatalf("expected truncation, got %d messages (same as original %d)", len(truncated), len(messages))
-	}
-	// Should keep the most recent messages
-	if len(truncated) < 2 {
-		t.Fatalf("expected at least 2 messages kept, got %d", len(truncated))
-	}
-	lastText := truncated[len(truncated)-1].ExtractText()
-	if !strings.HasPrefix(lastText, strings.Repeat("e", 10)) {
-		t.Fatalf("expected last message to be 'e' message, got %s...", lastText[:20])
-	}
-}
-
-func TestTruncateConversationToCharBudget_NoTruncationNeeded(t *testing.T) {
-	messages := []agentctx.AgentMessage{
-		agentctx.NewUserMessage("short"),
-		agentctx.NewUserMessage("also short"),
-	}
-
-	// Budget larger than total
-	truncated := truncateConversationToCharBudget(messages, 10000)
-	if len(truncated) != len(messages) {
-		t.Fatalf("expected no truncation, got %d messages (original %d)", len(truncated), len(messages))
-	}
-}
-
 func TestCompact_ForcedSplitWhenManyMessagesButNoOldMessages(t *testing.T) {
 	// Create a compactor with a large keep-recent budget
 	// so that splitMessagesByTokenBudget returns oldMessages=[]

--- a/pkg/compact/compact_tools.go
+++ b/pkg/compact/compact_tools.go
@@ -76,27 +76,6 @@ func compactToolResultsInRecent(messages []agentctx.AgentMessage, cutoff int) []
 	return compacted
 }
 
-func trimTextWithTail(input string, maxRunes int) string {
-	if maxRunes <= 0 {
-		return input
-	}
-	runes := []rune(input)
-	if len(runes) <= maxRunes {
-		return input
-	}
-
-	head := maxRunes * 2 / 3
-	tail := maxRunes - head
-	if head < 1 {
-		head = 1
-	}
-	if tail < 1 {
-		tail = 1
-	}
-
-	return string(runes[:head]) + "\n... (truncated) ...\n" + string(runes[len(runes)-tail:])
-}
-
 // ensureToolCallPairing ensures that tool_call and tool_result messages remain paired.
 // If a tool_result is in recentMessages but its corresponding tool_call is in oldMessages,
 // the tool_result must be hidden (archived) so the API doesn't see a mismatch.

--- a/pkg/compact/compact_visibility_test.go
+++ b/pkg/compact/compact_visibility_test.go
@@ -104,28 +104,3 @@ func TestCompactToolResultsInRecent(t *testing.T) {
 		t.Fatalf("expected 1 remaining tool_call after filtering archived pair, got %d", toolCallCount)
 	}
 }
-
-func TestProjectMessagesForSummaryTrimsToolOutputs(t *testing.T) {
-	longText := strings.Repeat("a", 5000)
-	messages := []agentctx.AgentMessage{
-		agentctx.NewToolResultMessage("call-1", "bash", []agentctx.ContentBlock{
-			agentctx.TextContent{Type: "text", Text: longText},
-		}, false),
-		agentctx.NewToolResultMessage("call-2", "grep", []agentctx.ContentBlock{
-			agentctx.TextContent{Type: "text", Text: "hidden"},
-		}, false).WithVisibility(false, true),
-	}
-
-	projected := projectMessagesForSummary(messages)
-	if len(projected) != 1 {
-		t.Fatalf("expected only visible messages in projection, got %d", len(projected))
-	}
-
-	text := projected[0].ExtractText()
-	if len([]rune(text)) > 1850 {
-		t.Fatalf("expected trimmed tool output, got rune length %d", len([]rune(text)))
-	}
-	if !strings.Contains(text, "... (truncated) ...") {
-		t.Fatalf("expected truncation marker, got %q", text)
-	}
-}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -10,9 +10,10 @@ import (
 // AgentContext represents the context for agent execution.
 type AgentContext struct {
 	// Core components
-	SystemPrompt string        `json:"systemPrompt,omitempty"`
-	Tools        []Tool        `json:"tools,omitempty"`
-	Skills       []skill.Skill `json:"skills,omitempty"` // Loaded skills
+	SystemPrompt       string        `json:"systemPrompt,omitempty"`
+	AgentContextPrefix string        `json:"-"` // Skills + AGENTS.md prefix (rebuilt at startup, not persisted)
+	Tools              []Tool        `json:"tools,omitempty"`
+	Skills             []skill.Skill `json:"skills,omitempty"` // Loaded skills
 
 	// Unified context state
 	LLMContext     string         `json:"llmContext,omitempty"` // Structured LLM context content (not file manager)

--- a/pkg/context/conversion.go
+++ b/pkg/context/conversion.go
@@ -1,0 +1,217 @@
+package context
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/tiancaiamao/ai/pkg/llm"
+)
+
+// ConvertMessagesToLLM converts agent messages to LLM messages.
+// This is shared between the agent loop and the compactor so that both
+// produce identical token sequences, enabling prefix-cache reuse.
+func ConvertMessagesToLLM(messages []AgentMessage) []llm.LLMMessage {
+	llmMessages := make([]llm.LLMMessage, 0, len(messages))
+
+	for _, msg := range messages {
+		if !msg.IsAgentVisible() {
+			continue
+		}
+
+		role := msg.Role
+		if role == "toolResult" {
+			role = "tool"
+		}
+		llmMsg := llm.LLMMessage{
+			Role: role,
+		}
+
+		// Extract content and thinking
+		for _, block := range msg.Content {
+			switch b := block.(type) {
+			case TextContent:
+				llmMsg.Content = b.Text
+			case ImageContent:
+				llmMsg.ContentParts = append(llmMsg.ContentParts, llm.ContentPart{
+					Type: "image_url",
+					ImageURL: &struct {
+						URL string `json:"url"`
+					}{
+						URL: b.Data,
+					},
+				})
+			case ThinkingContent:
+				llmMsg.Thinking = b.Thinking
+			}
+		}
+
+		// Extract tool calls (from assistant messages)
+		if msg.Role == "assistant" {
+			toolCalls := msg.ExtractToolCalls()
+			if len(toolCalls) > 0 {
+				llmMsg.ToolCalls = make([]llm.ToolCall, len(toolCalls))
+				for i, tc := range toolCalls {
+					argsJSON, _ := json.Marshal(tc.Arguments)
+					llmMsg.ToolCalls[i] = llm.ToolCall{
+						ID:   tc.ID,
+						Type: "function",
+						Function: llm.FunctionCall{
+							Name:      tc.Name,
+							Arguments: string(argsJSON),
+						},
+					}
+				}
+			}
+		}
+
+		// Tool result message
+		if msg.Role == "toolResult" {
+			llmMsg.ToolCallID = msg.ToolCallID
+			llmMsg.Content = msg.ExtractText()
+		}
+
+		llmMessages = append(llmMessages, llmMsg)
+	}
+
+	return sanitizeToolCallProtocol(llmMessages)
+}
+
+// sanitizeToolCallProtocol ensures generated messages follow strict assistant/tool pairing rules:
+// - a tool message must follow a pending assistant tool call
+// - unresolved tool calls are stripped before appending non-tool messages
+func sanitizeToolCallProtocol(messages []llm.LLMMessage) []llm.LLMMessage {
+	if len(messages) == 0 {
+		return messages
+	}
+
+	sanitized := make([]llm.LLMMessage, 0, len(messages))
+	pendingToolCalls := map[string]struct{}{}
+
+	clearPending := func() {
+		if len(pendingToolCalls) == 0 {
+			return
+		}
+		sanitized = stripPendingToolCallsFromLastAssistant(sanitized, pendingToolCalls)
+		pendingToolCalls = map[string]struct{}{}
+	}
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case "assistant":
+			clearPending()
+			sanitized = append(sanitized, msg)
+			for _, toolCall := range msg.ToolCalls {
+				if strings.TrimSpace(toolCall.ID) == "" {
+					continue
+				}
+				pendingToolCalls[toolCall.ID] = struct{}{}
+			}
+		case "tool":
+			toolCallID := strings.TrimSpace(msg.ToolCallID)
+			if toolCallID == "" || len(pendingToolCalls) == 0 {
+				continue
+			}
+			if _, ok := pendingToolCalls[toolCallID]; !ok {
+				continue
+			}
+			sanitized = append(sanitized, msg)
+			delete(pendingToolCalls, toolCallID)
+		default:
+			clearPending()
+			sanitized = append(sanitized, msg)
+		}
+	}
+
+	clearPending()
+	return sanitized
+}
+
+func stripPendingToolCallsFromLastAssistant(messages []llm.LLMMessage, pending map[string]struct{}) []llm.LLMMessage {
+	if len(messages) == 0 || len(pending) == 0 {
+		return messages
+	}
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role != "assistant" {
+			continue
+		}
+		if len(messages[i].ToolCalls) == 0 {
+			return messages
+		}
+
+		filteredToolCalls := make([]llm.ToolCall, 0, len(messages[i].ToolCalls))
+		for _, toolCall := range messages[i].ToolCalls {
+			if _, drop := pending[toolCall.ID]; drop {
+				continue
+			}
+			filteredToolCalls = append(filteredToolCalls, toolCall)
+		}
+		messages[i].ToolCalls = filteredToolCalls
+
+		if len(messages[i].ToolCalls) == 0 &&
+			strings.TrimSpace(messages[i].Content) == "" &&
+			len(messages[i].ContentParts) == 0 {
+			return append(messages[:i], messages[i+1:]...)
+		}
+		return messages
+	}
+
+	return messages
+}
+
+// ConvertToolsToLLM converts agent tools to LLM tools.
+func ConvertToolsToLLM(tools []Tool) []llm.LLMTool {
+	llmTools := make([]llm.LLMTool, 0, len(tools))
+	seen := make(map[string]struct{}, len(tools))
+
+	for _, tool := range tools {
+		if tool == nil {
+			continue
+		}
+		name := tool.Name()
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		llmTools = append(llmTools, llm.LLMTool{
+			Type: "function",
+			Function: llm.ToolFunction{
+				Name:        name,
+				Description: tool.Description(),
+				Parameters:  tool.Parameters(),
+			},
+		})
+	}
+
+	return llmTools
+}
+
+// InsertBeforeFirstUserMessage inserts msg immediately before the first
+// user-role message. Used for skills/AGENTS.md prefix injection to keep
+// the system prompt + prefix stable across turns for provider prefix caching.
+func InsertBeforeFirstUserMessage(messages []llm.LLMMessage, msg llm.LLMMessage) []llm.LLMMessage {
+	if len(messages) == 0 {
+		return []llm.LLMMessage{msg}
+	}
+
+	firstUserIdx := -1
+	for i := 0; i < len(messages); i++ {
+		if messages[i].Role == "user" {
+			firstUserIdx = i
+			break
+		}
+	}
+
+	if firstUserIdx == -1 {
+		result := make([]llm.LLMMessage, 0, len(messages)+1)
+		result = append(result, msg)
+		result = append(result, messages...)
+		return result
+	}
+
+	result := make([]llm.LLMMessage, 0, len(messages)+1)
+	result = append(result, messages[:firstUserIdx]...)
+	result = append(result, msg)
+	result = append(result, messages[firstUserIdx:]...)
+	return result
+}


### PR DESCRIPTION
## Problem

Compaction's LLM call used a completely different request structure from normal agent turns:

| | Agent turn | Compaction (before) |
|---|---|---|
| SystemPrompt | full agent prompt (~10K+ tokens) | compact_system.md (~1KB) |
| Messages | structured multi-role | serialized text blob |
| Tools | yes | no |
| AgentContextPrefix | skills + AGENTS.md | missing |

Result: **zero prefix-cache hits** — every compaction request diverged at the first token.

## Solution

Align the compaction request structure with normal agent turns so the entire prefix is served from cache:

```
agent turn:  [sys_prompt] [tools] [ctx_prefix] [msg1...msgN]
compaction:  [sys_prompt] [tools] [ctx_prefix] [msg1...msgK] [instruction]
                                                   ^^^^^^^^^^^^^^^ cached
```

### Changes

- **pkg/context/conversion.go** (new): shared ConvertMessagesToLLM, ConvertToolsToLLM, sanitizeToolCallProtocol, InsertBeforeFirstUserMessage — so pkg/compact reuses the exact same message serialization as the agent loop
- **pkg/context/context.go**: add AgentContextPrefix field to AgentContext
- **pkg/agent/conversion.go**: thin wrapper delegating to pkg/context
- **pkg/compact/compact_summary.go**: GenerateSummaryWithPrevious now accepts systemPrompt, contextPrefix, tools — builds a cache-aligned request with structured messages + agent prefix. Adds truncateForSummary guard (40% context window cap) for large sessions
- **pkg/compact/compact.go**: pass ctx.SystemPrompt, ctx.AgentContextPrefix, ctx.Tools to summary generation
- **cmd/ai/rpc_helpers.go**: set ctx.AgentContextPrefix at startup

### Dead code removed

serializeConversation, projectMessagesForSummary, truncateConversationToCharBudget, serializeSingleMessage, trimTextWithTail and their tests.

## Verification

- [x] go build ./... passes
- [x] go test ./pkg/compact/... ./pkg/agent/... ./pkg/context/... ./cmd/ai/... all pass
- [x] make fmt + make fmt-check pass
- [x] Reviewed via review skill (code review subagent)

Net: **-640 lines, +308 lines**