### PR TITLE
feat: support thinking level in config file

### DIFF
--- a/cmd/ai/rpc_handlers.go
+++ b/cmd/ai/rpc_handlers.go
@@ -102,7 +102,7 @@ func runRPC(sessionPath string, debugAddr string, input io.Reader, output io.Wri
 	// Create agent with LoopConfig
 	ag := agent.NewAgentFromConfigWithContext(app.model, app.apiKey, agentCtx, loopCfg)
 	defer ag.Shutdown()
-	ag.SetThinkingLevel("high")
+	ag.SetThinkingLevel(app.cfg.ThinkingLevel)
 	app.ag = ag
 
 	// Initialize checkpoint manager for persistent state

--- a/cmd/ai/rpc_setup.go
+++ b/cmd/ai/rpc_setup.go
@@ -141,7 +141,7 @@ func newRPCApp(sessionPath string, params rpcAppSetupParams) (*rpcApp, error) {
 		agentConfig:           agentCfg,
 		steeringMode:          "all",
 		followUpMode:          "one-at-a-time",
-		currentThinkingLevel:  "high",
+		currentThinkingLevel:  cfg.ThinkingLevel,
 		showThinking:          true,
 		showTools:             true,
 		showPrefix:            true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	// Model configuration
 	Model ModelConfig `json:"model"`
 
+	// Thinking level: off, minimal, low, medium, high, xhigh
+	ThinkingLevel string `json:"thinkingLevel,omitempty"`
+
 	// Compactor configuration
 	Compactor *compact.Config `json:"compactor,omitempty"`
 
@@ -240,10 +243,11 @@ func DefaultConfig() *Config {
 			BaseURL:  "https://api.z.ai/api/coding/paas/v4",
 			API:      "openai-completions",
 		},
-		Compactor:   compact.DefaultConfig(),
-		Concurrency: DefaultConcurrencyConfig(),
-		ToolOutput:  DefaultToolOutputConfig(),
-		Log:         DefaultLogConfig(),
+		ThinkingLevel: "high",
+		Compactor:     compact.DefaultConfig(),
+		Concurrency:   DefaultConcurrencyConfig(),
+		ToolOutput:    DefaultToolOutputConfig(),
+		Log:           DefaultLogConfig(),
 	}
 }
 

--- a/pkg/config/coverage_test.go
+++ b/pkg/config/coverage_test.go
@@ -803,3 +803,47 @@ func TestLoadConfigEnvOverride_InvalidInt(t *testing.T) {
 		t.Errorf("expected fallback to file value 333, got %d", cfg.Model.MaxTokens)
 	}
 }
+
+// TestDefaultConfig_ThinkingLevel verifies DefaultConfig sets ThinkingLevel to "high".
+func TestDefaultConfig_ThinkingLevel(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.ThinkingLevel != "high" {
+		t.Errorf("expected default ThinkingLevel 'high', got %q", cfg.ThinkingLevel)
+	}
+}
+
+// TestLoadConfig_ThinkingLevelFromFile verifies ThinkingLevel is read from config file.
+func TestLoadConfig_ThinkingLevelFromFile(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.json")
+
+	if err := os.WriteFile(cfgPath, []byte(`{"thinkingLevel":"medium"}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.ThinkingLevel != "medium" {
+		t.Errorf("expected ThinkingLevel 'medium', got %q", cfg.ThinkingLevel)
+	}
+}
+
+// TestLoadConfig_ThinkingLevelDefault verifies default "high" when not set in file.
+func TestLoadConfig_ThinkingLevelDefault(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.json")
+
+	if err := os.WriteFile(cfgPath, []byte(`{"model":{"id":"x"}}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.ThinkingLevel != "high" {
+		t.Errorf("expected default ThinkingLevel 'high' when unset, got %q", cfg.ThinkingLevel)
+	}
+}


### PR DESCRIPTION
## Workpad

```text
geniusdeMBP:/Users/genius/.symphony/workspaces/9ff137c3-9622-4775-80fb-d536bf3b9faf@6f4623a
```

### Plan

- [x] 1. Investigation: locate hardcoded thinking level usages
  - [x] 1.1 `pkg/config/config.go`: Config has NO ThinkingLevel field; LoopConfig has it via WithThinkingLevel option
  - [x] 1.2 `cmd/ai/rpc_handlers.go:105`: `ag.SetThinkingLevel("high")` hardcoded
  - [x] 1.3 `cmd/ai/rpc_setup.go:144`: `currentThinkingLevel: "high"` hardcoded
- [ ] 2. Add `ThinkingLevel string` field to `Config` struct (json tag `thinkingLevel`)
- [ ] 3. Set default "high" in `DefaultConfig()`
- [ ] 4. `rpc_handlers.go`: read from `app.cfg.ThinkingLevel` instead of hardcoded "high"
- [ ] 5. `rpc_setup.go`: read from `cfg.ThinkingLevel` for `currentThinkingLevel` initial value
- [ ] 6. Add/update tests in `pkg/config`
- [ ] 7. Run validation: `go test ./pkg/config ./cmd/ai` + `make fmt-check`
- [ ] 8. Commit, push, create PR, self-review

### Acceptance Criteria

- [ ] config.json `thinkingLevel` field read at startup and applied
- [ ] Default "high" when unset (backward compat)
- [ ] `go test ./pkg/config ./cmd/ai` passes
- [ ] `make fmt-check` passes

### Validation

- [ ] targeted tests: `go test ./pkg/config ./cmd/ai -v`
- [ ] formatting: `make fmt-check`

### Notes

- 2025-01-01: Investigation complete. `NormalizeThinkingLevel("")` returns "high", invalid→"high", so passing raw config value to SetThinkingLevel is safe.
- 2025-01-01: Implementation complete. All tests pass, fmt-check clean. Ready to commit & PR.