### PR TITLE
feat: append-only compaction with reasoning_content fallback

### DIFF
--- a/cmd/ai/rpc_app.go
+++ b/cmd/ai/rpc_app.go
@@ -183,14 +183,10 @@ func (app *rpcApp) initEventEmitter() (chan struct{}, chan struct{}) {
 			app.pendingSteer = false
 			app.stateMu.Unlock()
 
-			// Sync final messages to session file.
-			// This is the single persistence point for loop-triggered compaction:
-			// all message_end Append calls are already enqueued before agent_end
-			// (event ordering guarantees), so this Replace arrives last in the
-			// writer channel and overwrites any stale pre-compaction entries.
-			if app.sessionWriter != nil && app.sess != nil && len(event.Messages) > 0 {
-				app.sessionWriter.Replace(app.sess, event.Messages)
-			}
+			// Session persistence is handled incrementally:
+			// - message_end/tool_execution_end → sessionWriter.Append (per message)
+			// - compaction_end → sess.AppendCompaction (snapshot + entry)
+			// No Replace needed — messages.jsonl is append-only.
 		}
 		if event.Type == "compaction_start" {
 			app.stateMu.Lock()
@@ -201,6 +197,16 @@ func (app *rpcApp) initEventEmitter() (chan struct{}, chan struct{}) {
 			app.stateMu.Lock()
 			app.isCompacting = false
 			app.stateMu.Unlock()
+
+			// Persist compaction: save snapshot file + append compaction entry
+			// to messages.jsonl. This is the loop-triggered compaction path.
+			if event.Compaction != nil && len(event.Messages) > 0 && app.sess != nil {
+				if _, err := app.sess.AppendCompaction(
+					event.Compaction.Summary, event.Messages,
+				); err != nil {
+					slog.Error("Failed to persist compaction entry", "error", err)
+				}
+			}
 		}
 
 		if event.Type == "message_end" && event.Message != nil {

--- a/cmd/ai/rpc_helpers.go
+++ b/cmd/ai/rpc_helpers.go
@@ -245,9 +245,14 @@ func (app *rpcApp) compactBeforeRequest(trigger string) {
 				span.AddField("tokens_after", result.TokensAfter)
 			}
 
-			// Persist compacted messages to session file
-			if result != nil && app.sess != nil && app.sessionWriter != nil {
-				app.sessionWriter.Replace(app.sess, agentCtx.RecentMessages)
+			// Persist compaction: save snapshot + append compaction entry.
+			// messages.jsonl stays append-only.
+			if result != nil && app.sess != nil {
+				if _, err := app.sess.AppendCompaction(
+					result.Summary, agentCtx.RecentMessages,
+				); err != nil {
+					slog.Error("Failed to persist pre-request compaction", "error", err)
+				}
 			}
 			return nil
 		},

--- a/cmd/ai/rpc_message_handlers.go
+++ b/cmd/ai/rpc_message_handlers.go
@@ -71,9 +71,14 @@ func (app *rpcApp) handleCompact(args string) (any, error) {
 				TokensAfter:  result.TokensAfter,
 			}
 
-			// Persist compacted messages to session file
-			if app.sess != nil && app.sessionWriter != nil {
-				app.sessionWriter.Replace(app.sess, agentCtx.RecentMessages)
+			// Persist compaction: save snapshot + append compaction entry.
+			// messages.jsonl stays append-only.
+			if app.sess != nil {
+				if _, err := app.sess.AppendCompaction(
+					result.Summary, agentCtx.RecentMessages,
+				); err != nil {
+					slog.Error("Failed to persist manual compaction", "error", err)
+				}
 			}
 
 			if app.checkpointMgr != nil && app.checkpointMgr.ShouldCheckpoint() {

--- a/cmd/ai/rpc_setup.go
+++ b/cmd/ai/rpc_setup.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tiancaiamao/ai/pkg/skill"
 	"github.com/tiancaiamao/ai/pkg/tools"
 
-	"github.com/tiancaiamao/ai/pkg/agent"
 	"github.com/tiancaiamao/ai/pkg/agentconfig"
 )
 
@@ -149,25 +148,21 @@ func newRPCApp(sessionPath string, params rpcAppSetupParams) (*rpcApp, error) {
 		runID:                 params.runID,
 	}
 
-	// Enable LLM-decides compaction for large context windows.
-	if currentContextWindow >= compact.LargeContextThreshold {
-		decideCfg := compact.DefaultLLMDecideConfig(currentContextWindow)
-		compactorConfig.LLMDecide = &decideCfg
-		app.proactiveCompactor = compactor
-		slog.Info("Using LLMDecide compaction (large context window)",
-			"contextWindow", currentContextWindow,
-			"softThreshold", decideCfg.SoftThreshold,
-			"hardLimit", decideCfg.HardLimit)
+	// Always use LLM-decides compaction (unified context management).
+	decideCfg := compact.DefaultLLMDecideConfig(currentContextWindow)
+	compactorConfig.LLMDecide = &decideCfg
+	app.proactiveCompactor = compactor
+	slog.Info("Using LLMDecide compaction",
+		"contextWindow", currentContextWindow,
+		"softThreshold", decideCfg.SoftThreshold,
+		"hardLimit", decideCfg.HardLimit)
 
-		// Skip old ContextManager entirely for large windows.
-		ctxManager.SetSkipCondition(func() bool { return true })
-	} else {
-		app.proactiveCompactor = app.ctxManager
-		// Skip context management in cache-first mode.
-		ctxManager.SetSkipCondition(func() bool {
-			return agent.IsCacheMode(app.model.ID) == agent.CacheModeCache
-		})
-	}
+	// TODO(cleanup): ctxManager and the entire ContextManager code path are now
+	// dead code — always skipped in favor of LLMDecide compaction. Remove
+	// ctxManager, ContextManager, context_mgmt tools, and related session
+	// replay logic (applyContextManagementEvents) when cleaning up.
+	// Also remove the cache-mode check (agent.IsCacheMode) that lived here.
+	ctxManager.SetSkipCondition(func() bool { return true })
 
 	return app, nil
 }

--- a/cmd/ai/session_writer.go
+++ b/cmd/ai/session_writer.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"log/slog"
-	"reflect"
 	"sync"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
@@ -60,10 +59,8 @@ func (sc *sessionCompactor) CalculateDynamicThreshold() int {
 // --- sessionWriter: single-goroutine serializer for session writes ---
 
 type sessionWriteRequest struct {
-	sess            *session.Session
-	message         *agentctx.AgentMessage
-	replaceMessages []agentctx.AgentMessage
-	replaceResp     chan error
+	sess    *session.Session
+	message *agentctx.AgentMessage
 }
 
 type sessionWriter struct {
@@ -81,19 +78,6 @@ func newSessionWriter(buffer int) *sessionWriter {
 	go func() {
 		defer writer.wg.Done()
 		for req := range writer.ch {
-			if req.replaceMessages != nil {
-				var err error
-				if req.sess != nil {
-					current := req.sess.GetMessages()
-					if !reflect.DeepEqual(current, req.replaceMessages) {
-						err = req.sess.SaveMessages(req.replaceMessages)
-					}
-				}
-				if req.replaceResp != nil {
-					req.replaceResp <- err
-				}
-				continue
-			}
 			if req.sess == nil || req.message == nil {
 				continue
 			}
@@ -110,22 +94,6 @@ func (w *sessionWriter) Append(sess *session.Session, message agentctx.AgentMess
 		return
 	}
 	w.enqueue(sessionWriteRequest{sess: sess, message: &message})
-}
-
-func (w *sessionWriter) Replace(sess *session.Session, messages []agentctx.AgentMessage) error {
-	if w == nil || sess == nil {
-		return nil
-	}
-	response := make(chan error, 1)
-	req := sessionWriteRequest{
-		sess:            sess,
-		replaceMessages: append([]agentctx.AgentMessage(nil), messages...),
-		replaceResp:     response,
-	}
-	if !w.enqueue(req) {
-		return nil
-	}
-	return <-response
 }
 
 func (w *sessionWriter) Close() {

--- a/cmd/ai/session_writer_test.go
+++ b/cmd/ai/session_writer_test.go
@@ -1,32 +1,25 @@
 package main
 
 import (
-	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"testing"
 
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/session"
 )
 
-func TestSessionWriterReplaceOverridesPreviousAppends(t *testing.T) {
+func TestSessionWriterAppend(t *testing.T) {
 	sess := session.NewSession(t.TempDir())
 	writer := newSessionWriter(16)
 	defer writer.Close()
 
-	writer.Append(sess, agentctx.NewUserMessage("before-1"))
-	writer.Append(sess, agentctx.NewUserMessage("before-2"))
+	writer.Append(sess, agentctx.NewUserMessage("msg-1"))
+	writer.Append(sess, agentctx.NewUserMessage("msg-2"))
 
-	replaced := []agentctx.AgentMessage{
-		agentctx.NewUserMessage("after"),
-	}
-	if err := writer.Replace(sess, replaced); err != nil {
-		t.Fatalf("replace failed: %v", err)
-	}
+	// Drain channel synchronously (Close waits for pending writes).
+	writer.Close()
 
 	messages := sess.GetMessages()
-	if len(messages) != 1 {
-		t.Fatalf("expected 1 message after replace, got %d", len(messages))
-	}
-	if got := messages[0].ExtractText(); got != "after" {
-		t.Fatalf("expected replaced message content, got %q", got)
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
 	}
 }

--- a/pkg/agent/checkpoint_manager.go
+++ b/pkg/agent/checkpoint_manager.go
@@ -176,20 +176,19 @@ func initCheckpointManager(config *LoopConfig) *AgentContextCheckpointManager {
 	return mgr
 }
 
-// saveCheckpointAfterCompaction creates a checkpoint if LLM context was updated
-// during compaction. This avoids saving checkpoints for trivial compactions.
+// saveCheckpointAfterCompaction creates a checkpoint after compaction to
+// persist the current AgentState (turn count, tokens, CWD, etc.).
+// The checkpoint's messages.jsonl is not used for resume (messages come from
+// sess.GetMessages() via compaction snapshot refs); only agent_state.json
+// is consumed by LoadResumeState.
 func saveCheckpointAfterCompaction(mgr *AgentContextCheckpointManager, agentCtx *agentctx.AgentContext, llmContextUpdated bool, turnCount int, trigger string) {
 	if mgr == nil || !mgr.ShouldCheckpoint() {
-		return
-	}
-	if !llmContextUpdated {
-		slog.Info("[Loop] Skipping checkpoint creation after compaction (LLM context not updated, resume will replay from last checkpoint)", "trigger", trigger, "turn", turnCount)
 		return
 	}
 	if _, err := mgr.CreateSnapshot(agentCtx, agentCtx.LLMContext, turnCount); err != nil {
 		slog.Warn("[Loop] Failed to create checkpoint after compaction", "error", err, "turn", turnCount)
 	} else {
-		slog.Info("[Loop] Checkpoint created after compaction (LLM context updated)", "trigger", trigger, "turn", turnCount)
+		slog.Info("[Loop] Checkpoint created after compaction", "trigger", trigger, "turn", turnCount)
 	}
 }
 

--- a/pkg/agent/event.go
+++ b/pkg/agent/event.go
@@ -84,6 +84,10 @@ type CompactionInfo struct {
 	Error   string `json:"error,omitempty"`
 	Trigger string `json:"trigger,omitempty"`
 
+	// Summary is the compaction summary text, carried so the event consumer
+	// (rpc_app) can persist it to a compaction snapshot + entry.
+	Summary string `json:"summary,omitempty"`
+
 	// Context management specific fields
 	TokensBefore      int  `json:"tokens_before,omitempty"`       // Token count before compaction (mini only)
 	TokensAfter       int  `json:"tokens_after,omitempty"`        // Token count after compaction (mini only)

--- a/pkg/agent/loop_state.go
+++ b/pkg/agent/loop_state.go
@@ -208,17 +208,29 @@ func (s *loopState) performCompaction(
 
 	compactionSpan.AddField("after_messages", after)
 	compactionSpan.End()
-	s.stream.Push(NewCompactionEndEvent(CompactionInfo{
+
+	// Carry the summary and a copy of post-compaction messages on the event.
+	// The event consumer (rpc_app) persists these to a compaction snapshot file
+	// and appends a compaction entry to messages.jsonl. We copy the slice to
+	// avoid sharing the backing array with the loop goroutine.
+	endEvent := NewCompactionEndEvent(CompactionInfo{
 		Type:              compacted.Type,
 		Auto:              true,
 		Before:            before,
 		After:             after,
 		Trigger:           trigger,
+		Summary:           compacted.Summary,
 		TokensBefore:      compacted.TokensBefore,
 		TokensAfter:       compacted.TokensAfter,
 		TruncatedCount:    compacted.TruncatedCount,
 		LLMContextUpdated: compacted.LLMContextUpdated,
-	}))
+	})
+	if len(s.agentCtx.RecentMessages) > 0 {
+		msgs := make([]agentctx.AgentMessage, len(s.agentCtx.RecentMessages))
+		copy(msgs, s.agentCtx.RecentMessages)
+		endEvent.Messages = msgs
+	}
+	s.stream.Push(endEvent)
 
 	if trackRecovery {
 		s.compactionRecs++

--- a/pkg/agent/resume.go
+++ b/pkg/agent/resume.go
@@ -1,31 +1,28 @@
 package agent
 
 import (
-	"fmt"
+	"path/filepath"
 
 	agentctx "github.com/tiancaiamao/ai/pkg/context"
 )
 
-// LoadResumeState loads the most up-to-date agent context state from a session
-// directory, replaying journal entries written after the latest checkpoint.
+// LoadResumeState loads the agent state from the latest checkpoint.
 //
-// This is the single source of truth for resume semantics — used by
-// rpcApp.createBaseContext on startup and on session resume.
+// In the Proposal B design, messages are the sole responsibility of
+// sess.GetMessages() (which handles compaction snapshot refs internally).
+// This function only restores AgentState from the latest checkpoint.
 //
 // Parameters:
-//   - sessionDir: session directory containing messages.jsonl and checkpoints/.
+//   - sessionDir: session directory containing checkpoints/.
 //     Empty string disables checkpoint-based resume.
-//   - fallbackMessages: messages to use if no checkpoint exists (typically
-//     sess.GetMessages()).
+//   - fallbackMessages: messages already loaded from sess.GetMessages().
+//     Returned unchanged — they are the authoritative message list.
 //
 // Returns:
-//   - messages: reconstructed RecentMessages (checkpoint snapshot + replayed
-//     post-checkpoint journal entries)
-//   - llmContext: LLM context from the checkpoint ("" if no checkpoint)
-//   - agentState: agent state from the checkpoint (nil if no checkpoint)
+//   - messages: the same fallbackMessages (session is source of truth)
+//   - llmContext: "" (no longer restored from checkpoint)
+//   - agentState: agent state from the latest checkpoint (nil if none)
 //   - err: any I/O or parsing error
-//
-// If no checkpoint exists, returns (fallbackMessages, "", nil, nil).
 func LoadResumeState(sessionDir string, fallbackMessages []agentctx.AgentMessage) (
 	messages []agentctx.AgentMessage,
 	llmContext string,
@@ -37,37 +34,16 @@ func LoadResumeState(sessionDir string, fallbackMessages []agentctx.AgentMessage
 	}
 
 	cpInfo, err := agentctx.LoadLatestCheckpoint(sessionDir)
-	if err != nil {
-		// "no checkpoints found" or missing index file → fallback path.
-		// We treat any load error as "no checkpoint available" rather than
-		// a fatal error, matching the production resume semantics where a
-		// fresh session has no checkpoint yet.
-		return fallbackMessages, "", nil, nil
-	}
-	if cpInfo == nil {
+	if err != nil || cpInfo == nil {
 		return fallbackMessages, "", nil, nil
 	}
 
-	// Read the journal (session-format messages.jsonl) and replay entries
-	// after cpInfo.MessageIndex on top of the checkpoint snapshot. This is
-	// the path that was missing in the original rpcApp.createBaseContext
-	// implementation: that code used snapshot.RecentMessages directly,
-	// silently dropping any messages written after the checkpoint.
-	journal, err := agentctx.OpenJournal(sessionDir)
+	// Load AgentState from checkpoint (for turn count, tokens, CWD, etc.)
+	cpPath := filepath.Join(sessionDir, cpInfo.Path)
+	agentState, err = agentctx.LoadCheckpointAgentState(cpPath)
 	if err != nil {
-		return fallbackMessages, "", nil, fmt.Errorf("open journal: %w", err)
-	}
-	defer journal.Close()
-
-	entries, err := journal.ReadAll()
-	if err != nil {
-		return fallbackMessages, "", nil, fmt.Errorf("read journal: %w", err)
+		return fallbackMessages, "", nil, nil
 	}
 
-	snapshot, err := agentctx.ReconstructSnapshotWithCheckpoint(sessionDir, cpInfo, entries)
-	if err != nil {
-		return fallbackMessages, "", nil, fmt.Errorf("reconstruct snapshot: %w", err)
-	}
-
-	return snapshot.RecentMessages, snapshot.LLMContext, snapshot.AgentState, nil
+	return fallbackMessages, "", agentState, nil
 }

--- a/pkg/agent/resume_test.go
+++ b/pkg/agent/resume_test.go
@@ -10,31 +10,29 @@ import (
 	"github.com/tiancaiamao/ai/pkg/session"
 )
 
-// TestResume_ReplaysPostCheckpointMessages verifies that resuming a session
-// after a checkpoint correctly returns ALL messages including those written
-// after the checkpoint was created.
+// TestResume_LoadsAgentStateFromCheckpoint verifies that resuming a session
+// correctly restores AgentState from the latest checkpoint.
 //
-// This test mirrors the production bug reported in session 8c0ef142:
-// after restarting and resuming, 25 journal entries written between the last
-// checkpoint and the resume were lost, because the resume path loaded only
-// checkpoint.RecentMessages and ignored journal entries appended after the
-// checkpoint (commit / push / PR creation flow was dropped).
+// In the Proposal B design:
+//   - Messages are the sole responsibility of sess.GetMessages() (which
+//     handles compaction snapshot refs internally).
+//   - LoadResumeState returns fallbackMessages unchanged and only restores
+//     AgentState from the latest checkpoint.
 //
 // Scenario:
-//  1. Session writes 3 pre-checkpoint messages
-//  2. SaveCheckpoint (snapshot of current state)
-//  3. Session writes 2 more messages (post-checkpoint, not yet checkpointed)
-//  4. Resume: load state from sessionDir via LoadResumeState
+//  1. Session writes 3 messages
+//  2. SaveCheckpoint (snapshot of current AgentState)
+//  3. Session writes 2 more messages
+//  4. Resume: LoadResumeState with fallback = sess.GetMessages()
 //
-// Expected: LoadResumeState returns 5 messages (3 pre + 2 post).
-// Bug (pre-fix): only 3 messages returned (drops 2 post-checkpoint entries).
-func TestResume_ReplaysPostCheckpointMessages(t *testing.T) {
+// Expected: LoadResumeState returns all 5 messages (from fallback) and
+// AgentState with TotalTurns=7 from checkpoint.
+func TestResume_LoadsAgentStateFromCheckpoint(t *testing.T) {
 	sessionDir := t.TempDir()
 
-	// Use the same sessionDir layout as production.
 	sess := newTestSession(t, sessionDir)
 
-	// Step 1: write 3 pre-checkpoint user messages.
+	// Step 1: write 3 messages.
 	for i := 0; i < 3; i++ {
 		msg := agentctx.NewUserMessage(fmt.Sprintf("pre-checkpoint %d", i))
 		if _, err := sess.AppendMessage(msg); err != nil {
@@ -42,16 +40,11 @@ func TestResume_ReplaysPostCheckpointMessages(t *testing.T) {
 		}
 	}
 
-	// Step 2: snapshot current state and save as a checkpoint.
-	// Use the production SaveCheckpoint path: recent messages come from the
-	// session, and MessageIndex must reflect the journal length AT THIS POINT
-	// so that replay can skip entries already represented in the snapshot.
-	preMessages := cloneMessages(sess.GetMessages())
+	// Step 2: save checkpoint with AgentState.
 	preAgentState := agentctx.NewAgentState("test-session", "/workspace")
-	preAgentState.TotalTurns = 7 // simulate prior work in the session
+	preAgentState.TotalTurns = 7
 	snapshot := &agentctx.ContextSnapshot{
-		LLMContext:     "# Current Task\npre-checkpoint work",
-		RecentMessages: preMessages,
+		RecentMessages: cloneMessages(sess.GetMessages()),
 		AgentState:     preAgentState,
 	}
 	checkpointInfo, err := saveCheckpointAtJournalHead(sessionDir, snapshot, 1)
@@ -59,10 +52,9 @@ func TestResume_ReplaysPostCheckpointMessages(t *testing.T) {
 		t.Fatalf("saveCheckpointAtJournalHead: %v", err)
 	}
 	t.Logf("checkpoint saved: path=%s msgIndex=%d messages=%d",
-		checkpointInfo.Path, checkpointInfo.MessageIndex, len(preMessages))
+		checkpointInfo.Path, checkpointInfo.MessageIndex, len(snapshot.RecentMessages))
 
-	// Step 3: write 2 post-checkpoint messages — these are the entries that
-	// were lost in the production bug.
+	// Step 3: write 2 post-checkpoint messages.
 	for i := 0; i < 2; i++ {
 		msg := agentctx.NewUserMessage(fmt.Sprintf("post-checkpoint %d", i))
 		if _, err := sess.AppendMessage(msg); err != nil {
@@ -70,29 +62,31 @@ func TestResume_ReplaysPostCheckpointMessages(t *testing.T) {
 		}
 	}
 
-	// Step 4: simulate a fresh process resuming the session — load state
-	// purely from disk (sessionDir + journal + checkpoint).
-	gotMessages, gotLLMCtx, gotState, err := LoadResumeState(sessionDir, nil)
+	// Step 4: simulate a fresh process resuming the session.
+	fallback := sess.GetMessages()
+	gotMessages, gotLLMCtx, gotState, err := LoadResumeState(sessionDir, fallback)
 	if err != nil {
 		t.Fatalf("LoadResumeState: %v", err)
 	}
 
-	// Expected: 3 pre + 2 post = 5 messages.
+	// Messages: returned unchanged from fallback (session is source of truth).
 	if got := len(gotMessages); got != 5 {
-		t.Errorf("message count = %d, want 5 (3 pre-checkpoint + 2 post-checkpoint)", got)
+		t.Errorf("message count = %d, want 5", got)
 		for i, m := range gotMessages {
 			t.Logf("  msg[%d] role=%s text=%q", i, m.Role, firstText(m))
 		}
 	}
 
-	// Also check that both pre and post messages are present.
-	if gotLLMCtx != "# Current Task\npre-checkpoint work" {
-		t.Errorf("LLMContext = %q, want checkpoint's LLMContext", gotLLMCtx)
+	// LLMContext: no longer restored from checkpoint.
+	if gotLLMCtx != "" {
+		t.Errorf("LLMContext = %q, want empty", gotLLMCtx)
 	}
+
+	// AgentState: restored from checkpoint.
 	if gotState == nil {
 		t.Error("AgentState = nil, want non-nil")
 	} else if gotState.TotalTurns != 7 {
-		t.Errorf("TotalTurns = %d, want 7 (preserved from checkpoint)", gotState.TotalTurns)
+		t.Errorf("TotalTurns = %d, want 7", gotState.TotalTurns)
 	}
 
 	// Ensure post-checkpoint messages survived.
@@ -105,7 +99,7 @@ func TestResume_ReplaysPostCheckpointMessages(t *testing.T) {
 }
 
 // TestResume_FallsBackWhenNoCheckpoint verifies the no-checkpoint path:
-// LoadResumeState should return the fallback messages as-is.
+// LoadResumeState should return the fallback messages as-is with nil AgentState.
 func TestResume_FallsBackWhenNoCheckpoint(t *testing.T) {
 	sessionDir := t.TempDir()
 
@@ -130,8 +124,7 @@ func TestResume_FallsBackWhenNoCheckpoint(t *testing.T) {
 	}
 }
 
-// TestResume_FallsBackWhenSessionDirEmpty verifies the empty-sessionDir path:
-// LoadResumeState("", fallback) should return fallback messages.
+// TestResume_FallsBackWhenSessionDirEmpty verifies the empty-sessionDir path.
 func TestResume_FallsBackWhenSessionDirEmpty(t *testing.T) {
 	fallback := []agentctx.AgentMessage{agentctx.NewUserMessage("hello")}
 
@@ -146,24 +139,18 @@ func TestResume_FallsBackWhenSessionDirEmpty(t *testing.T) {
 
 // --- helpers ---
 
-// newTestSession creates a Session rooted at sessionDir, mimicking the layout
-// used in production (~/.ai/sessions/<id>/).
 func newTestSession(t *testing.T, sessionDir string) *session.Session {
 	t.Helper()
 	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll %s: %v", sessionDir, err)
 	}
 	sess := session.NewSession(sessionDir)
-	// SessionInfo entry mirrors what production writes shortly after init.
 	if _, err := sess.AppendSessionInfo("test", ""); err != nil {
 		t.Fatalf("AppendSessionInfo: %v", err)
 	}
 	return sess
 }
 
-// saveCheckpointAtJournalHead saves a checkpoint with MessageIndex equal to
-// the current journal length. This mirrors the CORRECT behavior that should
-// happen in production (but currently doesn't — see TestCreateSnapshot_PersistsJournalLength).
 func saveCheckpointAtJournalHead(sessionDir string, snapshot *agentctx.ContextSnapshot, turn int) (*agentctx.CheckpointInfo, error) {
 	journal, err := agentctx.OpenJournal(sessionDir)
 	if err != nil {
@@ -189,5 +176,4 @@ func firstText(m agentctx.AgentMessage) string {
 	return ""
 }
 
-// Ensure filepath import is used when sessionDir is constructed via filepath.Join
 var _ = filepath.Join

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -58,27 +58,42 @@ type LLMDecideConfig struct {
 	IntervalHigh   int
 }
 
-// DefaultLLMDecideConfig returns thresholds scaled to the context window.
+// DefaultLLMDecideConfig returns tuned thresholds for the given context window.
 //
-// For 1M context: soft=80K, tiers at 100K/120K, hard=200K.
-// Smaller windows scale proportionally, capped at the 1M values.
+// These values are empirically tuned per context-window tier, not derived from
+// a single formula. Update them only when you have usage data to justify it.
+//
+//	1M context:  soft=80K(8%),  tiers=100K/120K,  hard=200K(20%)
+//	200K context: soft=40K(20%), tiers=70K/100K,  hard=150K(75%)
 func DefaultLLMDecideConfig(contextWindow int) LLMDecideConfig {
-	soft := min(contextWindow*8/100, 80_000)
-	hard := min(contextWindow*20/100, 200_000)
-	return LLMDecideConfig{
-		SoftThreshold:  soft,
-		HardLimit:      hard,
-		TierMedium:     soft + 20_000,
-		TierHigh:       soft + 40_000,
-		IntervalLow:    15,
-		IntervalMedium: 10,
-		IntervalHigh:   7,
+	switch {
+	case contextWindow >= 800_000: // 1M-class models
+		return LLMDecideConfig{
+			SoftThreshold:  80_000,
+			HardLimit:      200_000,
+			TierMedium:     100_000,
+			TierHigh:       120_000,
+			IntervalLow:    15,
+			IntervalMedium: 10,
+			IntervalHigh:   7,
+		}
+	default: // 200K-class and other smaller models
+		pct := func(p int) int { return contextWindow * p / 100 }
+		return LLMDecideConfig{
+			SoftThreshold:  pct(20),
+			HardLimit:      pct(75),
+			TierMedium:     pct(35),
+			TierHigh:       pct(50),
+			IntervalLow:    15,
+			IntervalMedium: 10,
+			IntervalHigh:   7,
+		}
 	}
 }
 
-// LargeContextThreshold is the minimum context window size for enabling
-// LLM-decides compaction. Models with smaller windows keep the old
-// truncate/update cycle.
+// TODO(cleanup): LargeContextThreshold is no longer used after unifying all
+// context windows onto LLMDecide compaction. Remove when ContextManager code
+// is cleaned up.
 const LargeContextThreshold = 500_000
 
 // DefaultConfig returns default compression configuration.
@@ -601,7 +616,7 @@ func (c *Compactor) shouldCompactLLMDecide(ctx context.Context, agentCtx *agentc
 			traceevent.Field{Key: "reason", Value: "interval_not_reached"},
 			traceevent.Field{Key: "tokens", Value: tokens},
 			traceevent.Field{Key: "tier", Value: tier},
-			traceevent.Field{Key: "tool_calls_since", Value: currentCount},
+			traceevent.Field{Key: "tool_calls_since", Value: currentCount - c.llmDecideLastAskCount},
 			traceevent.Field{Key: "interval", Value: interval},
 		)
 		return false
@@ -732,6 +747,7 @@ func (c *Compactor) askLLM(ctx context.Context, agentCtx *agentctx.AgentContext,
 	stream := llm.StreamLLM(callCtx, c.model, llmCtx, c.apiKey, 60*time.Second)
 
 	var response strings.Builder
+	var thinking strings.Builder
 	for event := range stream.Iterator(callCtx) {
 		if event.Done {
 			break
@@ -739,6 +755,8 @@ func (c *Compactor) askLLM(ctx context.Context, agentCtx *agentctx.AgentContext,
 		switch e := event.Value.(type) {
 		case llm.LLMTextDeltaEvent:
 			response.WriteString(e.Delta)
+		case llm.LLMThinkingDeltaEvent:
+			thinking.WriteString(e.Delta)
 		case llm.LLMDoneEvent:
 			span.AddField("input_tokens", e.Usage.InputTokens)
 			span.AddField("output_tokens", e.Usage.OutputTokens)
@@ -752,10 +770,18 @@ func (c *Compactor) askLLM(ctx context.Context, agentCtx *agentctx.AgentContext,
 		}
 	}
 
-	answer := strings.ToLower(strings.TrimSpace(response.String()))
+	// Fall back to reasoning_content if text response is empty (same model
+	// behavior as GenerateSummaryWithPrevious).
+	answerText := response.String()
+	if strings.TrimSpace(answerText) == "" && thinking.Len() > 0 {
+		answerText = thinking.String()
+		span.AddField("used_thinking_fallback", true)
+	}
+
+	answer := strings.ToLower(strings.TrimSpace(answerText))
 	yes := strings.Contains(answer, "yes")
 
-	span.AddField("response", response.String())
+	span.AddField("response", answerText)
 	span.AddField("decision", yes)
 
 	return yes, nil

--- a/pkg/compact/compact_summary.go
+++ b/pkg/compact/compact_summary.go
@@ -73,6 +73,7 @@ func (c *Compactor) GenerateSummaryWithPrevious(goCtx context.Context, messages 
 		llmStream := llm.StreamLLM(ctx, c.model, llmCtx, c.apiKey, chunkTimeout)
 
 		var summary strings.Builder
+		var thinking strings.Builder
 		var streamErr error
 		var doneEvent llm.LLMDoneEvent
 		for event := range llmStream.Iterator(ctx) {
@@ -83,6 +84,8 @@ func (c *Compactor) GenerateSummaryWithPrevious(goCtx context.Context, messages 
 			switch e := event.Value.(type) {
 			case llm.LLMTextDeltaEvent:
 				summary.WriteString(e.Delta)
+			case llm.LLMThinkingDeltaEvent:
+				thinking.WriteString(e.Delta)
 			case llm.LLMErrorEvent:
 				streamErr = e.Error
 			case llm.LLMDoneEvent:
@@ -124,9 +127,21 @@ func (c *Compactor) GenerateSummaryWithPrevious(goCtx context.Context, messages 
 
 		result := summary.String()
 		if strings.TrimSpace(result) == "" {
-			return "", fmt.Errorf("empty summary generated")
+			// Some models (e.g. GLM-5.1) may place the entire response in
+			// reasoning_content instead of text content, especially when
+			// the agent's system prompt contains conflicting instructions.
+			// Fall back to thinking output to avoid discarding a valid summary.
+			thinkingStr := thinking.String()
+			if strings.TrimSpace(thinkingStr) != "" {
+				slog.Warn("[Compact] Summary text was empty, falling back to reasoning_content",
+					"thinking_chars", len(thinkingStr), "output_tokens", doneEvent.Usage.OutputTokens)
+				result = thinkingStr
+			} else {
+				return "", fmt.Errorf("empty summary generated")
+			}
 		}
 
+		span.AddField("summary_chars", len(result))
 		return result, nil
 	}
 

--- a/pkg/session/compaction_snapshot_test.go
+++ b/pkg/session/compaction_snapshot_test.go
@@ -1,0 +1,170 @@
+package session
+
+import (
+	"testing"
+
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
+)
+
+// TestCompactionSnapshot_PreservesHistoryAndReconstructs verifies the Proposal B
+// design: after compaction, messages.jsonl is append-only (history preserved),
+// and GetMessages() reconstructs the post-compaction state from the snapshot.
+//
+// Flow:
+//  1. Write 10 messages
+//  2. AppendCompaction with [summary, 2 recent] as the post-compaction state
+//  3. Write 3 more messages after compaction
+//  4. GetMessages() should return: snapshot_messages (3) + post-compaction (3) = 6
+//  5. Reload from disk and verify same result
+func TestCompactionSnapshot_PreservesHistoryAndReconstructs(t *testing.T) {
+	dir := t.TempDir()
+	sess := NewSession(dir)
+
+	// Step 1: write 10 messages.
+	for i := 0; i < 10; i++ {
+		if _, err := sess.AppendMessage(agentctx.NewUserMessage("old msg")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Step 2: simulate compaction — post-compaction in-memory state is
+	// [summary_message, 2 kept messages].
+	postCompaction := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("[summary] conversation was about X, Y, Z"),
+		agentctx.NewUserMessage("kept message 1"),
+		agentctx.NewUserMessage("kept message 2"),
+	}
+	if _, err := sess.AppendCompaction("conversation was about X, Y, Z", postCompaction); err != nil {
+		t.Fatalf("AppendCompaction: %v", err)
+	}
+
+	// Step 3: write 3 messages after compaction.
+	for i := 0; i < 3; i++ {
+		if _, err := sess.AppendMessage(agentctx.NewUserMessage("new msg")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Step 4: GetMessages() should return snapshot (3) + post-compaction (3) = 6.
+	msgs := sess.GetMessages()
+	if got := len(msgs); got != 6 {
+		t.Fatalf("GetMessages count = %d, want 6 (3 snapshot + 3 post-compaction)", got)
+		for i, m := range msgs {
+			t.Logf("  msg[%d] = %q", i, firstTextContent(m))
+		}
+	}
+
+	// First 3 should be the snapshot messages.
+	if firstTextContent(msgs[0]) != "[summary] conversation was about X, Y, Z" {
+		t.Errorf("msgs[0] = %q, want summary", firstTextContent(msgs[0]))
+	}
+
+	// Step 5: reload from disk — messages.jsonl should have all entries
+	// (10 old + 1 compaction + 3 new = 14 entries) plus the snapshot file.
+	loaded, err := LoadSession(dir)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+
+	// The loaded session should have 14 entries total (header + 10 msgs +
+	// session_info + compaction + 3 msgs = 16, but let's count properly).
+	// What matters is GetMessages() returns the same 6.
+	loadedMsgs := loaded.GetMessages()
+	if got := len(loadedMsgs); got != 6 {
+		t.Fatalf("after reload: GetMessages count = %d, want 6", got)
+		for i, m := range loadedMsgs {
+			t.Logf("  msg[%d] = %q", i, firstTextContent(m))
+		}
+	}
+
+	// Verify all messages match the in-memory version.
+	for i := range msgs {
+		if firstTextContent(msgs[i]) != firstTextContent(loadedMsgs[i]) {
+			t.Errorf("msg[%d] mismatch: in-memory=%q loaded=%q",
+				i, firstTextContent(msgs[i]), firstTextContent(loadedMsgs[i]))
+		}
+	}
+
+	// Verify snapshot file exists.
+	if compactionEntry := findCompactionEntry(loaded); compactionEntry != nil {
+		if compactionEntry.SnapshotRef == "" {
+			t.Error("SnapshotRef is empty after reload")
+		}
+	}
+}
+
+// TestCompactionSnapshot_MultipleCompactions verifies that multiple sequential
+// compactions each create their own snapshot and GetMessages uses the latest.
+func TestCompactionSnapshot_MultipleCompactions(t *testing.T) {
+	dir := t.TempDir()
+	sess := NewSession(dir)
+
+	// First batch of messages.
+	for i := 0; i < 5; i++ {
+		sess.AppendMessage(agentctx.NewUserMessage("batch 1"))
+	}
+
+	// First compaction.
+	post1 := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("[summary 1]"),
+	}
+	sess.AppendCompaction("first summary", post1)
+
+	// More messages.
+	for i := 0; i < 3; i++ {
+		sess.AppendMessage(agentctx.NewUserMessage("batch 2"))
+	}
+
+	// Second compaction.
+	post2 := []agentctx.AgentMessage{
+		agentctx.NewUserMessage("[summary 2]"),
+		agentctx.NewUserMessage("recent after 2nd compaction"),
+	}
+	sess.AppendCompaction("second summary", post2)
+
+	// More messages after second compaction.
+	sess.AppendMessage(agentctx.NewUserMessage("final msg"))
+
+	msgs := sess.GetMessages()
+	// Should be: snapshot2 (2) + 1 post-compaction = 3
+	if got := len(msgs); got != 3 {
+		t.Fatalf("GetMessages count = %d, want 3 (2 snapshot + 1 post-compaction)", got)
+		for i, m := range msgs {
+			t.Logf("  msg[%d] = %q", i, firstTextContent(m))
+		}
+	}
+
+	if firstTextContent(msgs[0]) != "[summary 2]" {
+		t.Errorf("msgs[0] = %q, want [summary 2]", firstTextContent(msgs[0]))
+	}
+	if firstTextContent(msgs[2]) != "final msg" {
+		t.Errorf("msgs[2] = %q, want 'final msg'", firstTextContent(msgs[2]))
+	}
+
+	// Reload and verify.
+	loaded, _ := LoadSession(dir)
+	loadedMsgs := loaded.GetMessages()
+	if len(loadedMsgs) != 3 {
+		t.Fatalf("after reload: count = %d, want 3", len(loadedMsgs))
+	}
+}
+
+func firstTextContent(m agentctx.AgentMessage) string {
+	for _, c := range m.Content {
+		if tc, ok := c.(agentctx.TextContent); ok {
+			return tc.Text
+		}
+	}
+	return ""
+}
+
+func findCompactionEntry(s *Session) *SessionEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := len(s.entries) - 1; i >= 0; i-- {
+		if s.entries[i].Type == EntryTypeCompaction {
+			return s.entries[i]
+		}
+	}
+	return nil
+}

--- a/pkg/session/entries.go
+++ b/pkg/session/entries.go
@@ -2,9 +2,15 @@ package session
 
 import (
 	"encoding/json"
-	agentctx "github.com/tiancaiamao/ai/pkg/context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
+	agentctx "github.com/tiancaiamao/ai/pkg/context"
 	"github.com/tiancaiamao/ai/pkg/version"
 )
 
@@ -50,6 +56,12 @@ type SessionEntry struct {
 	Timestamp string  `json:"timestamp"`
 
 	Message *agentctx.AgentMessage `json:"message,omitempty"`
+
+	// SnapshotRef is the relative path (within session dir) to a file containing
+	// the post-compaction in-memory messages. This is the Proposal B approach:
+	// messages.jsonl is append-only; compaction records reference an external
+	// snapshot file rather than rewriting history.
+	SnapshotRef string `json:"snapshotRef,omitempty"`
 
 	Summary          string `json:"summary,omitempty"`
 	FirstKeptEntryID string `json:"firstKeptEntryId,omitempty"`
@@ -114,7 +126,7 @@ func timestampToMillis(ts string) int64 {
 	return parsed.UnixMilli()
 }
 
-func buildSessionContext(entries []*SessionEntry, leafID *string, byID map[string]*SessionEntry) []agentctx.AgentMessage {
+func buildSessionContext(entries []*SessionEntry, leafID *string, byID map[string]*SessionEntry, sessionDir string) []agentctx.AgentMessage {
 	if len(entries) == 0 {
 		return []agentctx.AgentMessage{}
 	}
@@ -173,13 +185,28 @@ func buildSessionContext(entries []*SessionEntry, leafID *string, byID map[strin
 	}
 
 	if compaction != nil {
-		msg := compactionSummaryMessage(compaction)
-		if msg.Role != "" {
-			messages = append(messages, msg)
-		}
-
-		foundFirstKept := false
-		if compaction.FirstKeptEntryID != "" {
+		// Proposal B: if SnapshotRef is set, load post-compaction messages from
+		// the external snapshot file. This avoids rewriting messages.jsonl and
+		// makes compaction entries simple pointers.
+		if compaction.SnapshotRef != "" && sessionDir != "" {
+			snapshotPath := filepath.Join(sessionDir, compaction.SnapshotRef)
+			if loaded, err := loadSnapshotMessages(snapshotPath); err == nil {
+				messages = append(messages, loaded...)
+			} else {
+				slog.Warn("[session] Failed to load compaction snapshot, falling back to summary only",
+					"path", snapshotPath, "error", err)
+				msg := compactionSummaryMessage(compaction)
+				if msg.Role != "" {
+					messages = append(messages, msg)
+				}
+			}
+		} else if compaction.FirstKeptEntryID != "" {
+			// Legacy path: reconstruct from FirstKeptEntryID (old sessions)
+			msg := compactionSummaryMessage(compaction)
+			if msg.Role != "" {
+				messages = append(messages, msg)
+			}
+			foundFirstKept := false
 			for i := 0; i < compactionIndex; i++ {
 				entry := path[i]
 				if entry.ID == compaction.FirstKeptEntryID {
@@ -188,6 +215,11 @@ func buildSessionContext(entries []*SessionEntry, leafID *string, byID map[strin
 				if foundFirstKept {
 					appendMessage(entry)
 				}
+			}
+		} else {
+			msg := compactionSummaryMessage(compaction)
+			if msg.Role != "" {
+				messages = append(messages, msg)
 			}
 		}
 
@@ -254,4 +286,40 @@ func decodeSessionHeader(line []byte) (*SessionHeader, error) {
 		return nil, nil
 	}
 	return &header, nil
+}
+
+// loadSnapshotMessages reads a compaction snapshot file (JSONL of AgentMessage).
+func loadSnapshotMessages(path string) ([]agentctx.AgentMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var messages []agentctx.AgentMessage
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	for {
+		var msg agentctx.AgentMessage
+		if err := dec.Decode(&msg); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode snapshot message: %w", err)
+		}
+		messages = append(messages, msg)
+	}
+	return messages, nil
+}
+
+// saveSnapshotMessages writes messages to a compaction snapshot file (JSONL).
+func saveSnapshotMessages(path string, messages []agentctx.AgentMessage) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	for _, msg := range messages {
+		if err := enc.Encode(msg); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, []byte(buf.String()), 0644)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -148,7 +148,7 @@ func LoadSession(sessionDir string) (*Session, error) {
 func (s *Session) GetMessages() []agentctx.AgentMessage {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return buildSessionContext(s.entries, s.leafID, s.byID)
+	return buildSessionContext(s.entries, s.leafID, s.byID, s.sessionDir)
 }
 
 // GetDir returns the session directory path.
@@ -156,6 +156,43 @@ func (s *Session) GetDir() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.sessionDir
+}
+
+// AppendCompaction records a compaction event: saves the post-compaction
+// in-memory messages to an external snapshot file, then appends a compaction
+// entry to messages.jsonl referencing that snapshot. This keeps messages.jsonl
+// append-only — history is never rewritten.
+func (s *Session) AppendCompaction(summary string, messages []agentctx.AgentMessage) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var snapshotRef string
+	if s.sessionDir != "" {
+		// Assign sequential snapshot file name based on existing compaction entries.
+		count := 0
+		for _, e := range s.entries {
+			if e.Type == EntryTypeCompaction {
+				count++
+			}
+		}
+		name := fmt.Sprintf("compaction_%05d.jsonl", count+1)
+		snapshotPath := filepath.Join(s.sessionDir, "compactions", name)
+		if err := saveSnapshotMessages(snapshotPath, messages); err != nil {
+			return "", fmt.Errorf("save compaction snapshot: %w", err)
+		}
+		snapshotRef = filepath.Join("compactions", name)
+	}
+
+	entry := &SessionEntry{
+		Type:        EntryTypeCompaction,
+		ID:          generateEntryID(s.byID),
+		ParentID:    s.leafID,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
+		Summary:     summary,
+		SnapshotRef: snapshotRef,
+	}
+	s.addEntry(entry)
+	return entry.ID, s.persistEntry(entry)
 }
 
 // GetPath returns the messages.jsonl file path of the session.


### PR DESCRIPTION
feat: append-only compaction with reasoning_content fallback

Append-only compaction persistence (Proposal B):
- messages.jsonl is never rewritten; compaction saves post-compaction
  messages to an external snapshot file (compactions/compaction_NNNNN.jsonl)
  and appends a compaction entry with SnapshotRef pointing to it.
- Session.GetMessages() resolves snapshot refs at load time, falling back
  to summary-only on missing/corrupt snapshots.
- Removed sessionWriter.Replace (no longer needed); all three compaction
  paths (loop-triggered, pre-request, manual) now use sess.AppendCompaction.
- loadSnapshotMessages returns decode errors instead of silently swallowing
  non-EOF failures.

Fix compaction summary loss when LLM puts content in reasoning_content:
- GenerateSummaryWithPrevious and askLLM now capture LLMThinkingDeltaEvent
  alongside LLMTextDeltaEvent. When text output is empty but thinking is
  not, fall back to thinking content instead of discarding the result.
- Root cause: agent system prompt canary token instruction caused GLM-5.1
  to emit [ready] as text content and the actual summary as
  reasoning_content (108 output_tokens, only 7 chars captured).

Simplify resume and checkpoint after compaction:
- LoadResumeState no longer replays journal entries from checkpoint; it
  restores AgentState only. Messages come exclusively from sess.GetMessages()
  which handles snapshot refs internally.
- saveCheckpointAfterCompaction no longer skips when LLM context is unchanged;
  always checkpoints to persist AgentState.

Unify compaction mode:
- Always use LLMDecide compaction regardless of context window size.
  ContextManager is now dead code (marked for cleanup).