### PR TITLE
fix(compact): tune thresholds, fix context window fallback, improve compact-check

### DIFF
--- a/cmd/ai/rpc_setup.go
+++ b/cmd/ai/rpc_setup.go
@@ -64,6 +64,9 @@ func newRPCApp(sessionPath string, params rpcAppSetupParams) (*rpcApp, error) {
 	currentModelInfo.MaxTokens = model.MaxTokens
 	currentModelInfo.ContextWindow = model.ContextWindow
 	currentContextWindow := activeSpec.ContextWindow
+	if currentContextWindow <= 0 {
+		currentContextWindow = model.ContextWindow
+	}
 
 	// --- Working directory ---
 	cwd, err := os.Getwd()

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -82,7 +82,7 @@ func DefaultLLMDecideConfig(contextWindow int) LLMDecideConfig {
 	default: // 200K-class and other smaller models
 		pct := func(p int) int { return contextWindow * p / 100 }
 		return LLMDecideConfig{
-			SoftThreshold:  pct(20),
+			SoftThreshold:  pct(25),
 			HardLimit:      pct(75),
 			TierMedium:     pct(35),
 			TierHigh:       pct(50),
@@ -662,14 +662,6 @@ func (c *Compactor) shouldCompactLLMDecide(ctx context.Context, agentCtx *agentc
 	// Don't re-ask until a full interval has elapsed since the last ask.
 	// This prevents asking every turn after a "no".
 	if currentCount-c.llmDecideLastAskCount < interval {
-		traceevent.Log(ctx, traceevent.CategoryEvent, "compact_llm_decide_check",
-			traceevent.Field{Key: "decision", Value: false},
-			traceevent.Field{Key: "reason", Value: "interval_not_reached"},
-			traceevent.Field{Key: "tokens", Value: tokens},
-			traceevent.Field{Key: "tier", Value: tier},
-			traceevent.Field{Key: "tool_calls_since", Value: currentCount - c.llmDecideLastAskCount},
-			traceevent.Field{Key: "interval", Value: interval},
-		)
 		return false
 	}
 
@@ -829,11 +821,16 @@ func (c *Compactor) askLLM(ctx context.Context, agentCtx *agentctx.AgentContext,
 		span.AddField("used_thinking_fallback", true)
 	}
 
+	// Parse only the first line to avoid multi-line pollution.
 	answer := strings.ToLower(strings.TrimSpace(answerText))
-	yes := strings.Contains(answer, "yes")
+	if idx := strings.IndexByte(answer, '\n'); idx >= 0 {
+		answer = answer[:idx]
+	}
+	answer = strings.TrimSpace(answer)
+	confirmed := strings.Contains(answer, "confirm")
 
 	span.AddField("response", answerText)
-	span.AddField("decision", yes)
+	span.AddField("decision", confirmed)
 
-	return yes, nil
+	return confirmed, nil
 }

--- a/pkg/prompt/llm_decide_check.md
+++ b/pkg/prompt/llm_decide_check.md
@@ -1,6 +1,6 @@
 <agent:compact-check> You are at %s of your compaction limit. Compaction keeps your recent messages fully intact and summarizes only older messages into a brief recap — the context for your current task is never lost.
 
-Prefer to compact. Only say "no" if you need specific details from earlier messages for your very next action. Otherwise the context keeps growing until a forced hard compaction that you cannot control.
+Reply "confirm" to compact now, or "reject" to continue. Choose "reject" only if you need specific details from earlier messages for your very next action. If you reject, you may add a second line with a brief reason.
 
-Reply ONLY "yes" to compact now, or "no" to continue. Do not use any tools.
+Reply with a single word on the first line: confirm or reject. Do not use any tools. Do not reply in any other language.
 </agent:compact-check>


### PR DESCRIPTION
## Summary

Cross-session compaction analysis revealed 5 issues. This PR addresses them:

### C5 (Critical): Context window fallback missing
- **Problem**: When `activeSpec.ContextWindow` is 0 (e.g. model spec not found in models.json), 1M models were treated as 200K, triggering compaction at 8% utilization.
- **Fix**: Fall back to `model.ContextWindow` when spec has no value.

### C7 (Critical): Chinese affirmative misparse
- **Problem**: askLLM only matched English "yes", causing Chinese "是的"/"好的" to be misinterpreted as "no" — model asked 12 times before getting a valid response.
- **Fix**: Change prompt keywords from `yes/no` to `confirm/reject`. Parse only the first line. Allow optional reason on second line for reject (visible in trace for debugging).

### C2 (High): compact-check prompt biased
- **Problem**: "Prefer to compact" wording caused premature compaction at 20% utilization.
- **Fix**: Neutral phrasing — describe when to confirm vs reject without bias.

### C3 (Medium): 200K SoftThreshold too aggressive
- **Problem**: SoftThreshold at 20% started asking too early.
- **Fix**: Raise to 25%.

### C4 (Low): Trace noise from noop events
- **Problem**: 97.9% of `compact_llm_decide_check` events were `interval_not_reached` no-ops.
- **Fix**: Remove trace for interval_not_reached. Decision events (ask_yes/no, hard_limit, fallback) preserved.

## Test plan
- [x] `make fmt-check` clean
- [x] `go build ./cmd/ai ./pkg/compact ./pkg/prompt` passes
- [x] `go test ./pkg/compact -v` — all 48 tests pass
