### PR TITLE
fix(compact): sync thinking level to askLLM/GenerateSummary for prefix-cache hits

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -119,6 +119,10 @@ type Compactor struct {
 	// construction time so it survives agentCtx checkpoint/restore cycles
 	// (AgentContext.AgentContextPrefix has json:"-" and is lost on restore).
 	agentContextPrefix string
+	// thinkingLevel mirrors the agent loop's thinking level so that
+	// askLLM/GenerateSummary requests include the same thinking/reasoning
+	// parameters, keeping them in the same prefix-cache partition.
+	thinkingLevel string
 	// sessionDir is the session directory used for archiving old messages
 	// that are removed during compaction. When empty, archiving is skipped.
 	sessionDir string
@@ -250,6 +254,12 @@ func (c *Compactor) SetContextWindow(window int) {
 // cache-friendly LLM requests (askLLM, GenerateSummary).
 func (c *Compactor) SetAgentContextPrefix(prefix string) {
 	c.agentContextPrefix = prefix
+}
+
+// SetThinkingLevel sets the thinking level used in askLLM/GenerateSummary
+// requests so they match the agent loop's thinking/reasoning parameters.
+func (c *Compactor) SetThinkingLevel(level string) {
+	c.thinkingLevel = level
 }
 
 // ReserveTokens returns the effective reserve tokens setting.
@@ -651,6 +661,7 @@ func buildCacheFriendlyLLMContext(
 	contextPrefix string,
 	tools []agentctx.Tool,
 	trailingInstruction string,
+	thinkingLevel string,
 ) llm.LLMContext {
 	llmMessages := agentctx.ConvertMessagesToLLM(messages)
 
@@ -667,9 +678,10 @@ func buildCacheFriendlyLLMContext(
 	})
 
 	return llm.LLMContext{
-		SystemPrompt: systemPrompt,
-		Messages:     llmMessages,
-		Tools:        agentctx.ConvertToolsToLLM(tools),
+		SystemPrompt:  systemPrompt,
+		Messages:      llmMessages,
+		Tools:         agentctx.ConvertToolsToLLM(tools),
+		ThinkingLevel: thinkingLevel,
 	}
 }
 
@@ -696,6 +708,7 @@ func (c *Compactor) askLLM(ctx context.Context, agentCtx *agentctx.AgentContext,
 		c.agentContextPrefix,
 		agentCtx.Tools,
 		askContent,
+		c.thinkingLevel,
 	)
 
 	callCtx, cancel := context.WithTimeout(ctx, 60*time.Second)

--- a/pkg/compact/compact_summary.go
+++ b/pkg/compact/compact_summary.go
@@ -50,7 +50,7 @@ func (c *Compactor) GenerateSummary(goCtx context.Context, messages []agentctx.A
 		return "", fmt.Errorf("no agent-visible messages to summarize")
 	}
 
-	llmCtx := buildCacheFriendlyLLMContext(messages, systemPrompt, contextPrefix, tools, summarizationPrompt)
+	llmCtx := buildCacheFriendlyLLMContext(messages, systemPrompt, contextPrefix, tools, summarizationPrompt, c.thinkingLevel)
 
 	const maxRetries = 3
 	const totalTimeout = 5 * time.Minute

--- a/pkg/rpc/rpc_config_handlers.go
+++ b/pkg/rpc/rpc_config_handlers.go
@@ -121,6 +121,7 @@ func (app *rpcApp) handleModelSet(args string) (any, error) {
 	// Recreate compactor with new model
 	app.compactor = compact.NewCompactor(app.compactorConfig, app.model, app.apiKey, app.systemPrompt, spec.ContextWindow, app.sess.GetDir())
 	app.compactor.SetAgentContextPrefix(app.agentContextPrefix)
+	app.compactor.SetThinkingLevel(app.currentThinkingLevel)
 	app.sessionComp.Update(app.compactor)
 	app.ag.SetCompactor(app.sessionComp)
 	app.ag.SetContextWindow(spec.ContextWindow)
@@ -192,6 +193,9 @@ func (app *rpcApp) handleSetThinkingLevel(value string, validLevels map[string]b
 	app.currentThinkingLevel = level
 	app.stateMu.Unlock()
 	app.ag.SetThinkingLevel(level)
+	if app.compactor != nil {
+		app.compactor.SetThinkingLevel(level)
+	}
 	return map[string]any{"setting": "thinking-level", "value": level}, nil
 }
 

--- a/pkg/rpc/rpc_helpers.go
+++ b/pkg/rpc/rpc_helpers.go
@@ -71,6 +71,7 @@ func (app *rpcApp) createBaseContext() *agentctx.AgentContext {
 	// and is lost on checkpoint/restore, so the compactor stores its own copy.
 	if app.compactor != nil {
 		app.compactor.SetAgentContextPrefix(app.agentContextPrefix)
+		app.compactor.SetThinkingLevel(app.currentThinkingLevel)
 	}
 	ctx := agentctx.NewAgentContext(app.systemPrompt)
 	ctx.AgentContextPrefix = app.agentContextPrefix

--- a/pkg/rpc/rpc_session_handlers.go
+++ b/pkg/rpc/rpc_session_handlers.go
@@ -23,6 +23,7 @@ func (app *rpcApp) setSession(newSess *session.Session, newID, newName string) {
 	// archive files are written to the correct session dir.
 	app.compactor = compact.NewCompactor(app.compactorConfig, app.model, app.apiKey, app.systemPrompt, app.model.ContextWindow, newSess.GetDir())
 	app.compactor.SetAgentContextPrefix(app.agentContextPrefix)
+	app.compactor.SetThinkingLevel(app.currentThinkingLevel)
 	app.sessionComp.Update(app.compactor)
 
 	app.setAgentContext(app.createBaseContext())


### PR DESCRIPTION
## Problem

`askLLM` and `GenerateSummary` build LLM requests without `thinking`/`reasoning_effort` parameters, causing them to land in a different prefix-cache partition than the main agent loop.

Evidence from trace analysis (session `2cb47c8e`):

| Ask # | Prev call gap | cache_read | input | hit % | Explanation |
|-------|--------------|------------|-------|-------|-------------|
| #1 | MAIN 2s ago | **3712** | 44167 | 8% | thinking param mismatch → cache miss |
| #2 | MAIN 1s ago | **3712** | 44941 | 8% | same |
| #3 | Ask#2 80s ago | **44736** | 54233 | 82% | same thinking=False → cache hit! |
| #4 | Ask#3 594s ago | **3712** | 34115 | 10% | cache expired |

`MAIN` requests include `{"thinking":{"type":"enabled"},"reasoning_effort":"medium"}`, `ASK` requests omit them. ZAI prefix cache partitions by request parameters, so ASK calls only hit the system-prompt-level cache (~3712 tokens).

## Fix

Add `thinkingLevel` to `Compactor`, synced via `SetThinkingLevel` in all RPC sites that already call `SetAgentContextPrefix`, and pass it through `buildCacheFriendlyLLMContext` so askLLM/GenerateSummary requests include the same thinking parameters as normal agent turns.

## Changes

- `pkg/compact/compact.go`: Add `thinkingLevel` field, `SetThinkingLevel` setter, pass through to `buildCacheFriendlyLLMContext`
- `pkg/compact/compact_summary.go`: Pass `c.thinkingLevel` to `buildCacheFriendlyLLMContext`
- `pkg/rpc/` (3 files): Call `SetThinkingLevel` alongside `SetAgentContextPrefix`, sync on runtime thinking-level change