### PR TITLE
improve: prompt actionability and compaction context recovery

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -488,11 +488,11 @@ func cleanOldRuntimeState(messages []agentctx.AgentMessage) []agentctx.AgentMess
 // archiveNoteTemplate is prepended to the compaction summary so the agent knows
 // where to find the full pre-compaction conversation. It uses directive language
 // to encourage proactive recovery of lost context.
-const archiveNoteTemplate = `<critical>
-The full conversation before this summary is archived at %s.
-This summary may omit important details — analysis results, intermediate findings, discussion context.
-If anything seems incomplete or you are unsure what was discussed earlier, read this file (use the read or grep tool) BEFORE asking the user.
-</critical>`
+const archiveNoteTemplate = "<critical>\n" +
+	"The full conversation before this summary is archived at `%s`.\n" +
+	"This summary may omit important details — analysis results, intermediate findings, discussion context.\n" +
+	"If anything seems incomplete or you are unsure what was discussed earlier, read this file (use the read or grep tool) BEFORE asking the user.\n" +
+	"</critical>"
 
 // saveArchivedMessages writes old messages removed during compaction to a
 // sequential JSONL file under <sessionDir>/compactions/archived_NNNNN.jsonl.

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -420,10 +420,12 @@ func (c *Compactor) Compact(goCtx context.Context, ctx *agentctx.AgentContext) (
 	// Archive old messages so the agent can access them via read/grep later.
 	archivePath := saveArchivedMessages(c.sessionDir, oldMessages)
 
-	// Create new recent messages with summary, including archive path note
+	// Create new recent messages with summary, including archive path note.
+	// The archive note is placed BEFORE the summary so the agent sees it first
+	// and is more likely to use it proactively.
 	summaryText := summary
 	if archivePath != "" {
-		summaryText = summary + "\n\n" + fmt.Sprintf(archiveNoteTemplate, archivePath)
+		summaryText = fmt.Sprintf(archiveNoteTemplate, archivePath) + "\n\n" + summary
 	}
 	newRecentMessages := []agentctx.AgentMessage{
 		agentctx.NewCompactionSummaryMessage(summaryText),
@@ -483,9 +485,14 @@ func cleanOldRuntimeState(messages []agentctx.AgentMessage) []agentctx.AgentMess
 	return result
 }
 
-// archiveNoteTemplate is appended to the compaction summary so the agent knows
-// where to find the full pre-compaction conversation.
-const archiveNoteTemplate = "The full conversation before this summary is archived at `%s`.\nUse the read or grep tool to search it when you need details from earlier."
+// archiveNoteTemplate is prepended to the compaction summary so the agent knows
+// where to find the full pre-compaction conversation. It uses directive language
+// to encourage proactive recovery of lost context.
+const archiveNoteTemplate = `<critical>
+The full conversation before this summary is archived at %s.
+This summary may omit important details — analysis results, intermediate findings, discussion context.
+If anything seems incomplete or you are unsure what was discussed earlier, read this file (use the read or grep tool) BEFORE asking the user.
+</critical>`
 
 // saveArchivedMessages writes old messages removed during compaction to a
 // sequential JSONL file under <sessionDir>/compactions/archived_NNNNN.jsonl.

--- a/pkg/prompt/compact_summarize.md
+++ b/pkg/prompt/compact_summarize.md
@@ -15,6 +15,9 @@ Summarize current conversation for context preservation. Output ONLY the structu
 ## Decisions Made
 - Decision: [what] — Reason: [why]
 
+## Key Findings
+[Non-obvious analysis results, statistical observations, or intermediate conclusions that would be expensive to rediscover. Include specific numbers, patterns, or insights — not just "analyzed X".]
+
 ## What's Complete
 [Finished items - DO NOT omit this section]
 1. [completed task]
@@ -32,6 +35,7 @@ Summarize current conversation for context preservation. Output ONLY the structu
 - Preserve EXACT paths, errors, function names (use quotes)
 - Keep ALL sections even if empty — write "None" if truly empty
 - Keep "What's Complete" — never drop this section
+- Keep "Key Findings" — preserve non-obvious analysis results and intermediate conclusions
 - Keep "Decisions Made" as a separate section — don't merge with others
 - Keep under 800 tokens total
 - DISCARD: pleasantries, redundant explanations, abandoned approaches

--- a/pkg/prompt/prompt.md
+++ b/pkg/prompt/prompt.md
@@ -42,13 +42,23 @@ Before implementing: state assumptions explicitly, present alternatives instead 
 
 ## Planning
 
-For tasks with 5+ steps, plan the steps before executing. Track progress with checkboxes and **update them as you go** — marking each step `- [x]` immediately after completing it is how you recall what's done when the context grows long.
+For tasks with 5+ steps, break the task into concrete, verifiable steps before executing. Transform vague goals into checkpoints where you can prove progress:
 
-- [ ] Add retry logic in `callLLM()`
-- [ ] Write retry test
-- [ ] Update docs
+- "Fix the bug" → "Write a test that reproduces it → fix the code → test passes"
+- "Add retry logic" → "Implement retry → write test for each failure path → existing tests still pass"
+
+Track progress with checkboxes and **update them as you go** — marking each step `- [x]` immediately after completing it is how you recall what's done when the context grows long.
 
 Skip this for single-step tasks or quick answers.
+
+## Verification
+
+**Never claim "done" without showing proof.**
+
+- Run the actual test suite or build command — not just "code looks good".
+- Report: command, exit code, and key output lines.
+- If there's no test for what you changed, write one or find an existing one that covers it.
+- If verification fails, fix and re-run — don't report success on a broken build.
 
 ## Long-Running Reasoning
 

--- a/pkg/prompt/prompt.md
+++ b/pkg/prompt/prompt.md
@@ -24,6 +24,8 @@ Before implementing: state assumptions explicitly, present alternatives instead 
 
 **Minimum code that solves the problem. Nothing speculative.**
 
+- Before writing new code, grep the codebase or check if a library already does this — reuse over reinvent.
+- Prefer deleting code over adding it. Good software shrinks over time.
 - No features, abstractions, flexibility, or configurability beyond what was asked.
 - No error handling for impossible scenarios.
 - If you write 200 lines and it could be 50, rewrite it.
@@ -38,21 +40,15 @@ Before implementing: state assumptions explicitly, present alternatives instead 
 - When your changes create orphans, remove the imports/vars/funcs your changes made unused (not pre-existing dead code).
 - Every changed line should trace directly to the user's request.
 
-### 4. Goal-Driven Execution
+## Planning
 
-**Define success criteria. Loop until verified.**
+For tasks with 5+ steps, plan the steps before executing. Track progress with checkboxes and **update them as you go** — marking each step `- [x]` immediately after completing it is how you recall what's done when the context grows long.
 
-Transform tasks into verifiable goals:
-- "Add validation" → "Write tests for invalid inputs, then make them pass"
-- "Fix the bug" → "Write a test that reproduces it, then make it pass"
-- "Refactor X" → "Ensure tests pass before and after"
+- [ ] Add retry logic in `callLLM()`
+- [ ] Write retry test
+- [ ] Update docs
 
-For multi-step tasks, state a brief plan:
-```
-1. [Step] → verify: [check]
-2. [Step] → verify: [check]
-3. [Step] → verify: [check]
-```
+Skip this for single-step tasks or quick answers.
 
 ## Long-Running Reasoning
 

--- a/pkg/prompt/prompt.md
+++ b/pkg/prompt/prompt.md
@@ -25,9 +25,9 @@ Before implementing: state assumptions explicitly, present alternatives instead 
 **Minimum code that solves the problem. Nothing speculative.**
 
 - Before writing new code, grep the codebase or check if a library already does this — reuse over reinvent.
-- Prefer deleting code over adding it. Good software shrinks over time.
+- Prefer deleting code over adding it.
 - No features, abstractions, flexibility, or configurability beyond what was asked.
-- No error handling for impossible scenarios.
+- No error handling for scenarios that cannot occur given the code's preconditions.
 - If you write 200 lines and it could be 50, rewrite it.
 
 ### 3. Surgical Changes
@@ -62,11 +62,9 @@ Skip this for single-step tasks or quick answers.
 
 ## Long-Running Reasoning
 
-Agent requests have timeouts (typically 60-120s). If you stay in silent thinking for too long, the request gets killed with zero output — total failure, no partial progress saved.
+Agent requests have timeouts (typically 60-120s). Silent thinking for too long → request killed, zero output, total failure.
 
-This is a hard constraint, not a style preference. For any task where thinking might take a while (complex algorithms, regex design, multi-file refactors, deep debugging, etc.): periodically emit a sentence or two of visible reasoning to assistant text — current sub-goal, next hypothesis, or a partial finding — then resume thinking. Think of it as "thinking out loud on paper": break the reasoning into named phases, write each phase as you go.
-
-This keeps the connection alive and gives the orchestrator a signal you're still on track.
+For complex tasks (algorithms, regex, multi-file refactors, deep debugging): periodically emit a sentence or two of visible reasoning — current sub-goal, next hypothesis, or a partial finding — then resume thinking.
 
 ## Workspace
 


### PR DESCRIPTION
## Changes

Three improvements based on multi-model evaluation (GLM-5.1, DeepSeek-V4-Flash independently reviewing the system prompt).

### 1. Simplicity First — abstract → actionable
- **Added**: `grep the codebase or check if a library already does this — reuse over reinvent`
- **Removed**: `Few orthogonal primitives compose better than many special cases` (both models rated it too abstract to influence behavior)

### 2. Planning — reworked threshold and format
- Replaced Goal-Driven Execution section with simpler checkbox-based tracking
- Threshold: `5+ steps` (validated by both models — GLM-5.1 suggested 8-10, DeepSeek suggested 5; 5 is the consensus floor)
- Checkbox format `- [ ] / - [x]` with explicit guidance to update immediately

### 3. Compaction — proactive archive note
- **Position**: moved from end → beginning of summary (more visible)
- **Wrapping**: `<critical>` tags to signal importance
- **Language**: passive → directive (`read this file BEFORE asking the user`)
- Added "Key Findings" section to `compact_summarize.md` to preserve analysis insights that were previously lost

## Validation
- Both models confirmed `grep the codebase` is high-value and actionable
- Both models confirmed removing the abstract principle was correct
- Both models agreed 3-step threshold was too low
- All tests pass (`make test`), build clean (`go build ./...`)