### PR TITLE
fix: smoke tests pollute ~/.ai/config.json via SaveConfig

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -180,6 +180,14 @@ func (c *Config) GetLLMModel() llm.Model {
 	}
 }
 
+// ResolveConfigPath returns the config file path, honoring AI_CONFIG_PATH if set.
+func ResolveConfigPath() (string, error) {
+	if override := strings.TrimSpace(os.Getenv("AI_CONFIG_PATH")); override != "" {
+		return override, nil
+	}
+	return GetDefaultConfigPath()
+}
+
 // GetDefaultConfigPath returns the default config file path.
 func GetDefaultConfigPath() (string, error) {
 	homeDir, err := os.UserHomeDir()

--- a/pkg/rpc/rpc_setup.go
+++ b/pkg/rpc/rpc_setup.go
@@ -164,7 +164,7 @@ func newRPCApp(sessionPath string, params rpcAppSetupParams) (*rpcApp, error) {
 
 // loadConfigWithLogger loads the config file and initializes the slog logger.
 func loadConfigWithLogger() (*config.Config, string, error) {
-	configPath, err := config.GetDefaultConfigPath()
+	configPath, err := config.ResolveConfigPath()
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get config path: %w", err)
 	}

--- a/pkg/rpc/rpcapp_smoke_test.go
+++ b/pkg/rpc/rpcapp_smoke_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -47,6 +48,10 @@ func runRPCSmoke(t *testing.T, tmpDir string, cmds []string, modelOverride strin
 
 	// Ensure API key is set so resolveModelAndKey doesn't fail in CI.
 	t.Setenv("ZAI_API_KEY", "test-key")
+
+	// Isolate config to avoid polluting ~/.ai/config.json.
+	configPath := filepath.Join(tmpDir, "config.json")
+	t.Setenv("AI_CONFIG_PATH", configPath)
 
 	reader, writer := io.Pipe()
 	outReader, outWriter := io.Pipe()


### PR DESCRIPTION
## Problem

Smoke tests (e.g. `TestRPCAppModelSwitch`) only isolated the session path via `t.TempDir()`, but the config path always resolved to the real `~/.ai/config.json` via `GetDefaultConfigPath()`.

When the test executed `/model zai/glm-4.5-air`, `handleModelSet` called `SaveConfig(app.cfg, app.configPath)`, overwriting the user's real config model to `glm-4.5-air`.

Every `go test ./pkg/rpc/...` run silently corrupted the user's config.

## Root Cause

```
runRPCSmoke(t, t.TempDir(), ...)   ← tmpDir = session path only
    → loadConfigWithLogger()
        → config.GetDefaultConfigPath()  ← hardcoded ~/.ai/config.json
    → handleModelSet / handleSetToolCallCutoff / handleSetToolSummaryAutomation
        → SaveConfig(app.cfg, app.configPath)  ← writes to real config.json
```

## Fix

1. **Implement `AI_CONFIG_PATH` env var** (`pkg/config/config.go`): Added `ResolveConfigPath()` following the exact same pattern as `ResolveModelsPath()` / `AI_MODELS_PATH`. The README already documented this env var but the code never implemented it.

2. **Use `ResolveConfigPath()` in rpc_setup** (`pkg/rpc/rpc_setup.go`): 1-line change.

3. **Isolate config in smoke tests** (`pkg/rpc/rpcapp_smoke_test.go`): Inject `AI_CONFIG_PATH=tmpDir/config.json` via `t.Setenv` so tests write to a throwaway file.

## Verification

- `go build ./...` ✅
- `go test ./pkg/config/... ./pkg/rpc/...` ✅
- Confirmed `~/.ai/config.json` unchanged after running tests ✅