### PR TITLE
perf(agent): speed up pkg/agent tests from 12s to 2.5s

### DIFF
--- a/pkg/agent/agent_integration_test.go
+++ b/pkg/agent/agent_integration_test.go
@@ -21,7 +21,7 @@ func TestExecutorPoolConcurrency(t *testing.T) {
 				name:        "slow-tool-" + string(rune('A'+i)),
 				maxFailures: 0,
 				failMessage: "success",
-				execDelayMs: 200, // 200ms each
+				execDelayMs: 50, // 50ms each
 			})
 		}
 
@@ -44,28 +44,28 @@ func TestExecutorPoolConcurrency(t *testing.T) {
 
 		elapsed := time.Since(start)
 
-		// With 3 concurrent tools and 200ms each:
-		// First 3 tools: 0-200ms
-		// Second 2 tools: 200-400ms
-		// Total: ~400ms
-		assert.True(t, elapsed >= 300*time.Millisecond)
-		assert.True(t, elapsed < 600*time.Millisecond)
+		// With 3 concurrent tools and 50ms each:
+		// First 3 tools: 0-50ms
+		// Second 2 tools: 50-100ms
+		// Total: ~100ms
+		assert.True(t, elapsed >= 80*time.Millisecond)
+		assert.True(t, elapsed < 250*time.Millisecond)
 	})
 
 	t.Run("queue_timeout", func(t *testing.T) {
-		pool := NewToolExecutor(1, 1)
+		pool := NewToolExecutorWithDuration(1, 50*time.Millisecond)
 
-		// Create a slow tool (delay must exceed queue timeout of 1s)
+		// Create a slow tool (delay must exceed queue timeout of 50ms)
 		tool := &MockTool{
 			name:        "very-slow-tool",
 			maxFailures: 0,
 			failMessage: "success",
-			execDelayMs: 1500, // was 5000ms; reduced for CI 30s timeout budget (must > 1s queue timeout)
+			execDelayMs: 200, // 200ms (must > 50ms queue timeout)
 		}
 
 		ctx := context.Background()
 
-		// Start first tool (should take 5s)
+		// Start first tool (should take 200ms)
 		resultCh1 := make(chan error, 1)
 		go func() {
 			_, err := pool.Execute(ctx, tool, map[string]any{"input": "test"})
@@ -73,7 +73,7 @@ func TestExecutorPoolConcurrency(t *testing.T) {
 		}()
 
 		// Wait for first tool to start
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
 
 		// Try to execute second tool (should timeout in queue)
 		resultCh2 := make(chan error, 1)

--- a/pkg/agent/agent_stress_test.go
+++ b/pkg/agent/agent_stress_test.go
@@ -30,7 +30,7 @@ func TestStressConcurrentRequests(t *testing.T) {
 			name:        fmt.Sprintf("tool-%d", i),
 			maxFailures: 0,
 			failMessage: "success",
-			execDelayMs: 50 + (i%5)*20, // Varying delays: 50-130ms (was 500-1300ms)
+			execDelayMs: 10 + (i%5)*5, // Varying delays: 10-30ms
 		})
 	}
 
@@ -88,14 +88,14 @@ func TestStressConcurrentRequests(t *testing.T) {
 	}
 
 	// Estimate minimum time: tools with max 10 concurrency
-	// Fastest tools (50ms) should complete quickly
-	minExpectedTime := 500 * time.Millisecond
+	// Fastest tools (10ms) should complete quickly
+	minExpectedTime := 100 * time.Millisecond
 	if elapsed < minExpectedTime {
 		t.Logf("Warning: Completed faster than expected (< %v)", minExpectedTime)
 	}
 
 	// Should not take too long
-	maxExpectedTime := 5 * time.Second
+	maxExpectedTime := 2 * time.Second
 	if elapsed > maxExpectedTime {
 		t.Errorf("Stress test took too long: %v (expected < %v)", elapsed, maxExpectedTime)
 	}
@@ -113,11 +113,11 @@ func TestStressLongRunningCommands(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Create tools with varying execution times (200-800ms)
+	// Create tools with varying execution times (50-250ms)
 	numTools := 5
 	tools := []*MockTool{}
 	for i := 0; i < numTools; i++ {
-		delay := 200 + i*150 // 200, 350, 500, 650, 800ms (was 2-8s)
+		delay := 50 + i*50 // 50, 100, 150, 200, 250ms
 		tools = append(tools, &MockTool{
 			name:        fmt.Sprintf("long-tool-%d", i),
 			maxFailures: 0,
@@ -162,11 +162,11 @@ func TestStressLongRunningCommands(t *testing.T) {
 	}
 
 	// With 3 concurrent slots and 5 tools:
-	// First 3: 0-200ms, 0-350ms, 0-500ms
-	// Second 2: 200ms-850ms, 350ms-1150ms
-	// Total: ~1.15s
-	minExpected := 800 * time.Millisecond
-	maxExpected := 2 * time.Second
+	// First 3: 0-50ms, 0-100ms, 0-150ms
+	// Second 2: 50-300ms, 100-350ms
+	// Total: ~350ms
+	minExpected := 250 * time.Millisecond
+	maxExpected := 800 * time.Millisecond
 
 	if elapsed < minExpected {
 		t.Errorf("Test completed too quickly: %v (expected >= %v)", elapsed, minExpected)
@@ -197,7 +197,7 @@ func TestStressRetryUnderLoad(t *testing.T) {
 			name:        fmt.Sprintf("stable-tool-%d", i),
 			maxFailures: 0,
 			failMessage: "success",
-			execDelayMs: 100 + i*20, // Varying delays: 100-180ms
+			execDelayMs: 20 + i*5, // Varying delays: 20-40ms
 		})
 	}
 
@@ -209,7 +209,7 @@ func TestStressRetryUnderLoad(t *testing.T) {
 			name:        fmt.Sprintf("flaky-tool-%d", i),
 			maxFailures: 2, // Will fail twice before succeeding
 			failMessage: "flaky error",
-			execDelayMs: 100 + i*20,
+			execDelayMs: 20 + i*5,
 		})
 	}
 
@@ -294,7 +294,7 @@ func TestStressQueueFull(t *testing.T) {
 
 	t.Log("Starting queue full stress test...")
 
-	pool := NewToolExecutor(2, 1)
+	pool := NewToolExecutorWithDuration(2, 100*time.Millisecond)
 
 	ctx := context.Background()
 
@@ -306,7 +306,7 @@ func TestStressQueueFull(t *testing.T) {
 			name:        fmt.Sprintf("slow-tool-%d", i),
 			maxFailures: 0,
 			failMessage: "success",
-			execDelayMs: 200, // 200ms (was 2000ms); test verifies queue timeout, not duration
+			execDelayMs: 50, // 50ms; test verifies queue timeout, not duration
 		})
 	}
 
@@ -354,10 +354,10 @@ func TestStressQueueFull(t *testing.T) {
 	}
 
 	// Should complete in reasonable time
-	// First 2 tools: 200ms each, running concurrently = ~200ms
-	// Remaining tools timeout in queue after 1s
-	// Total: ~1-2s
-	if elapsed > 3*time.Second {
-		t.Errorf("Test took too long: %v (expected <= 3s)", elapsed)
+	// First 2 tools: 50ms each, running concurrently = ~50ms
+	// Remaining tools timeout in queue after 100ms
+	// Total: ~150ms
+	if elapsed > 1*time.Second {
+		t.Errorf("Test took too long: %v (expected <= 1s)", elapsed)
 	}
 }

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -33,6 +33,15 @@ func NewToolExecutor(maxConcurrent int, queueTimeoutSec int) ToolExecutor {
 	}
 }
 
+// NewToolExecutorWithDuration is like NewToolExecutor but accepts a time.Duration,
+// allowing tests to use sub-second timeouts.
+func NewToolExecutorWithDuration(maxConcurrent int, queueTimeout time.Duration) ToolExecutor {
+	return &concurrentToolExecutor{
+		semaphore:    make(chan struct{}, maxConcurrent),
+		queueTimeout: queueTimeout,
+	}
+}
+
 // Execute runs a tool with concurrency control.
 // The tool is responsible for its own timeout handling.
 func (e *concurrentToolExecutor) Execute(ctx context.Context, tool agentctx.Tool, args map[string]interface{}) ([]agentctx.ContentBlock, error) {

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -38,7 +38,7 @@ func TestToolExecutorConcurrency(t *testing.T) {
 
 	// Create a slow tool that tracks concurrent executions
 	slowTool := &slowTool{
-		delay: 200 * time.Millisecond,
+		delay: 50 * time.Millisecond,
 		executeFunc: func() {
 			mu.Lock()
 			runningCount++
@@ -48,7 +48,7 @@ func TestToolExecutorConcurrency(t *testing.T) {
 			mu.Unlock()
 
 			// Hold the slot
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 
 			mu.Lock()
 			runningCount--
@@ -79,11 +79,11 @@ func TestToolExecutorConcurrency(t *testing.T) {
 
 // TestToolExecutorQueueTimeout tests queue timeout.
 func TestToolExecutorQueueTimeout(t *testing.T) {
-	executor := NewToolExecutor(1, 1) // Max 1 concurrent, 1s queue timeout
+	executor := NewToolExecutorWithDuration(1, 50*time.Millisecond) // Max 1 concurrent, 50ms queue timeout
 
 	// Start a slow tool that will occupy the slot
-	// Delay must exceed queue timeout (1s) so the second tool times out waiting
-	slowTool := &slowTool{delay: 1500 * time.Millisecond} // was 5s; reduced for CI timeout budget
+	// Delay must exceed queue timeout so the second tool times out waiting
+	slowTool := &slowTool{delay: 200 * time.Millisecond}
 
 	ctx := context.Background()
 	resultCh := make(chan error, 1)
@@ -93,7 +93,7 @@ func TestToolExecutorQueueTimeout(t *testing.T) {
 	}()
 
 	// Wait for the slow tool to acquire the semaphore
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	// Try to execute another tool - should timeout waiting for slot
 	fastTool := &mockTool{name: "fast"}


### PR DESCRIPTION
## What

Speed up  tests by reducing mock tool delays and queue timeouts.

## Why

 was the slowest package in the test suite at **12.3s**, with most time spent on real  /  waits in stress, concurrency, and queue-timeout tests. These tests validate correctness of concurrency control and timeout behavior — the absolute delay values are irrelevant to what's being tested.

## How

1. **New ** — the existing  only accepts integer-second queue timeouts (min 1s). The new Duration variant lets tests use 50ms-level timeouts.

2. **Reduced delays and timeouts across 7 tests:**

| Test | Before | After |
|------|--------|-------|
| `TestExecutorPoolConcurrency/queue_timeout` | 1.5s | 0.2s |
| `TestToolExecutorQueueTimeout` | 1.2s | 0.07s |
| `TestStressConcurrentRequests` | 1.88s | 0.41s |
| `TestStressRetryUnderLoad` | 1.65s | 0.37s |
| `TestStressLongRunningCommands` | 1.0s | 0.30s |
| `TestToolExecutorConcurrency` | 0.60s | 0.14s |
| `TestStressQueueFull` | 0.60s | 0.10s |

## Verification

```
Before: ok  github.com/tiancaiamao/ai/pkg/agent  12.346s  coverage: 81.0%
After:  ok  github.com/tiancaiamao/ai/pkg/agent   2.520s  coverage: 80.3%
```

- `make fmt` ✅
- `go build ./...` ✅
- `go test ./pkg/agent/` ✅