### PR TITLE
fix: restore CLI usage output lost in pkg/cli refactor

### DIFF
--- a/cmd/ai/main.go
+++ b/cmd/ai/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/tiancaiamao/ai/subcommand/kill"
@@ -12,9 +13,8 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		// TODO: Add usage print from individual packages
+		rpcsubcommand.PrintUsage()
 		os.Exit(1)
-		return
 	}
 
 	binPath := os.Args[0]
@@ -22,21 +22,26 @@ func main() {
 	os.Args = os.Args[1:]
 
 	switch subcmd {
+	case "-h", "--help", "help":
+		rpcsubcommand.PrintUsage()
+		os.Exit(0)
 	case "rpc":
 		rpcsubcommand.RPCSubcommand()
 	case "run":
 		run.RunSubcommand(binPath)
 	case "serve":
 		run.ServeSubcommand(binPath)
-	case "ls":
-		ls.LsSubcommand()
 	case "watch":
 		run.WatchSubcommand()
+	case "ls":
+		ls.LsSubcommand()
 	case "send":
 		send.SendSubcommand()
 	case "kill":
 		kill.KillSubcommand()
 	default:
+		fmt.Fprintf(os.Stderr, "ai: unknown command %q\n\n", subcmd)
+		rpcsubcommand.PrintUsage()
 		os.Exit(1)
 	}
 }

--- a/subcommand/rpc/rpc.go
+++ b/subcommand/rpc/rpc.go
@@ -46,7 +46,7 @@ func RPCSubcommand() {
 
 // PrintUsage prints the CLI usage text to stderr.
 func PrintUsage() {
-	fmt.Fprintf(os.Stderr, `ai - AI coding assistant
+	fmt.Fprint(os.Stderr, `ai - AI coding assistant
 
 Usage:
   ai <subcommand> [flags]
@@ -63,6 +63,7 @@ Subcommands:
 Flags for 'run':
   --session <path>         Session file path
   --system-prompt <text>   Custom system prompt (@file to load from file)
+  --role <role>            Agent role: coder (default), orchestrator, validator
   --max-turns <n>          Maximum conversation turns (0 = unlimited)
   --timeout <duration>     Total execution timeout (0 = unlimited)
   --input <text>           Initial prompt to send after startup
@@ -71,12 +72,23 @@ Flags for 'run':
 Flags for 'serve':
   --session <path>         Session file path
   --system-prompt <text>   Custom system prompt (@file to load from file)
+  --role <role>            Agent role: coder (default), orchestrator, validator
   --max-turns <n>          Maximum conversation turns (0 = unlimited)
   --timeout <duration>     Total execution timeout (0 = unlimited)
   --http <addr>            Enable HTTP debug server (e.g., ':6060')
-  --input <text>           Initial prompt to send after startup (serve only)
-  --input-file <path>      Read initial prompt from file (serve only)
-  --name <text>            Human-readable name for the run (serve only)
+  --input <text>           Initial prompt to send after startup
+  --input-file <path>      Read initial prompt from file (avoids ARG_MAX limits)
+  --name <text>            Human-readable name for the run
+  --id-file <path>         Write run ID to this file after startup
+  --model <id>             Override LLM model ID (e.g. claude-sonnet-4-20250514)
+
+Flags for 'rpc':
+  --session <path>         Session file path
+  --system-prompt <text>   Custom system prompt (@file to load from file)
+  --agent-config <path>    Path to agent.yaml configuration file
+  --max-turns <n>          Maximum conversation turns (0 = unlimited)
+  --timeout <duration>     Total execution timeout (0 = unlimited)
+  --http <addr>            Enable HTTP debug server (e.g., ':6060')
   --model <id>             Override LLM model ID (e.g. claude-sonnet-4-20250514)
 
 Flags for 'ls':
@@ -85,7 +97,6 @@ Flags for 'ls':
 
 Flags for 'watch':
   --id <run-id>            Run ID or prefix (auto-selects by cwd if omitted)
-  --since <offset>         Start reading from byte offset (machine-readable)
   --follow                 Continuously stream events until agent exits
   --follow --pretty        Stream formatted output (readable conversation)
   --follow --summary       Stream final assistant text only (no intermediate output)
@@ -93,6 +104,9 @@ Flags for 'watch':
 
 Flags for 'send':
   --id <run-id>            Run ID or prefix (auto-selects by cwd if omitted)
+  --wait                   Wait for agent to finish and stream the response
+  --summary                With --wait: only show final assistant text
+  --timeout <duration>     With --wait: max wait time (0 = unlimited)
 
 Flags for 'kill':
   --id <run-id>            Run ID or prefix (auto-selects by cwd if omitted)
@@ -103,10 +117,14 @@ Examples:
   ai run --input "fix the bug"    Start with an initial prompt
   ai serve                        Start agent as background daemon
   ai serve --input "fix the bug"  Start daemon with an initial prompt
+  ai rpc                          Start raw JSON-RPC on stdin/stdout
   ai ls                           List running agents
+  ai ls --all                     Include finished runs
   ai send "hello"                 Send message to agent in current directory
   ai send "/session"              Send slash command
+  ai send --wait "fix the bug"    Send and wait for response
   ai watch                        Attach to agent's TUI
+  ai watch --follow --pretty      Stream formatted output
   ai kill                         Stop agent in current directory
   ai kill --id abc123             Stop specific run by ID
   ai kill --force                 Force kill (SIGKILL)


### PR DESCRIPTION
## Problem

The refactor in `a222716` ("move pkg/cli to subcommand/ directories") moved `cli.PrintUsage()` to `subcommand/rpc/rpc.go` but replaced the call in `main.go` with a `// TODO` placeholder + `os.Exit(1)`. This caused silent exits:

- `ai` (no args) → silent exit 1
- `ai -h` / `ai --help` / `ai help` → silent exit 1
- `ai <unknown command>` → silent exit 1

## Root Cause

`git blame` traced it to commit `a222716`. The diff shows:

```diff
-if len(os.Args) < 2 {
-    cli.PrintUsage()
+if len(os.Args) < 2 {
+    // TODO: Add usage print from individual packages
+    os.Exit(1)
```

`PrintUsage()` was moved to `subcommand/rpc/rpc.go` but nothing in `main.go` called it anymore.

## Fix

| File | Change |
|------|--------|
| `cmd/ai/main.go` | Call `rpcsubcommand.PrintUsage()` for help/no-args/unknown-cmd |
| `subcommand/rpc/rpc.go` | Update `PrintUsage()` content to match current flags |

### PrintUsage content updates (was stale):
- **Added**: `--role`, `--agent-config`, `--id-file`, send `--wait`/`--summary`/`--timeout`, rpc flags section
- **Removed**: obsolete `--since` (watch)

## Verification

```
ai            → prints usage, exit 1  ✓
ai -h         → prints usage, exit 0  ✓
ai help       → prints usage, exit 0  ✓
ai badcmd     → "unknown command" + usage, exit 1  ✓
make fmt      → pass  ✓
make test-ci  → all pass  ✓
```