### PR TITLE
fix: remove malformedRegex false positive in tool tag detection

### DIFF
--- a/pkg/agent/llm_stream.go
+++ b/pkg/agent/llm_stream.go
@@ -264,12 +264,14 @@ func streamAssistantResponse(
 				text := finalMessage.ExtractText()
 				if len(text) > 0 && strings.Contains(text, "<") {
 					issues := DetectIncompleteToolCalls(text)
-					traceevent.Log(ctx, traceevent.CategoryTool, "assistant_tool_tag_parse_failed",
-						traceevent.Field{Key: "stop_reason", Value: e.StopReason},
-						traceevent.Field{Key: "text_preview", Value: truncateLine(text, 500)},
-						traceevent.Field{Key: "issues", Value: issues},
-						traceevent.Field{Key: "issue_count", Value: len(issues)},
-					)
+					if len(issues) > 0 {
+						traceevent.Log(ctx, traceevent.CategoryTool, "assistant_tool_tag_parse_failed",
+							traceevent.Field{Key: "stop_reason", Value: e.StopReason},
+							traceevent.Field{Key: "text_preview", Value: truncateLine(text, 500)},
+							traceevent.Field{Key: "issues", Value: issues},
+							traceevent.Field{Key: "issue_count", Value: len(issues)},
+						)
+					}
 				}
 			}
 

--- a/pkg/agent/tool_tag_parser.go
+++ b/pkg/agent/tool_tag_parser.go
@@ -384,12 +384,6 @@ func DetectIncompleteToolCalls(text string) []string {
 		}
 	}
 
-	// Check for malformed tool call patterns (like <Read instead of <read>)
-	malformedRegex := regexp.MustCompile(`<[A-Z][a-z]+[>\s]`)
-	if malformedRegex.MatchString(text) {
-		issues = append(issues, "detected tool call with uppercase letters (should use lowercase)")
-	}
-
 	return issues
 }
 

--- a/pkg/agent/tool_tag_parser_test.go
+++ b/pkg/agent/tool_tag_parser_test.go
@@ -174,10 +174,9 @@ func TestDetectIncompleteToolCalls(t *testing.T) {
 			shouldHave: "closing </bash>",
 		},
 		{
-			name:       "uppercase tag",
-			text:       "<Bash>ls -la</Bash>",
-			wantIssues: 1,
-			shouldHave: "uppercase",
+			name:       "plain text with angle brackets (no false positive)",
+			text:       "fn foo<T>() -> Result<T, E> { ... }",
+			wantIssues: 0,
 		},
 	}
 


### PR DESCRIPTION
## Problem

`DetectIncompleteToolCalls` 中的 `malformedRegex`（匹配 `<[A-Z][a-z]+[>\s]`）会对正常文本产生大量误报。Rust 泛型如 `<Result`、`<Iterator`、Markdown 中的 `<` 符号都会误中，导致 `assistant_tool_tag_parse_failed` trace 事件在普通文本回复上频繁触发。

同时，即使 `DetectIncompleteToolCalls` 返回空 issues 列表，trace 事件也会被无条件记录，进一步增加了噪音。

## Changes

1. **删除 `malformedRegex`**（`tool_tag_parser.go`）— 该正则误报率高，且实际中 LLM 几乎不会产出 `<Bash>` 这种大写 tool tag。保留的 unclosed/closing tag 检查精确匹配 `supportedToolTags`，不受影响。

2. **llm_stream.go 加 `len(issues) > 0` 条件** — 只有真正检测到问题时才记录 trace 事件。有问题时仍保留 `stop_reason`、`text_preview`（500 字符截断）、`issues` 列表，足够定位。

3. **更新测试** — 将 "uppercase tag" 用例替换为 "plain text with angle brackets" 回归测试，确保泛型/比较符号不误报。

## Verification

```
go build ./...           # OK
go test ./pkg/agent/     # PASS
make fmt                 # OK
```